### PR TITLE
Intercept Hook RollDialog_BeforeRoll within DSRollDialog.lua

### DIFF
--- a/Draw Steel UI/DSRollDialog.lua
+++ b/Draw Steel UI/DSRollDialog.lua
@@ -3203,6 +3203,32 @@ function GameHud.CreateRollDialog(self)
                 }
 
                 g_activeRollArgs = rollArgs
+
+                -- Hook for external mods to intercept rolls
+                local hookResult = nil
+                if RollDialog_BeforeRoll then
+                    hookResult = RollDialog_BeforeRoll({
+                        rollArgs = rollArgs,
+                        roll = rollArgs.roll,
+                        description = rollArgs.description,
+                        creature = rollArgs.creature,
+                        tokenid = rollArgs.tokenid,
+                        properties = rollArgs.properties,
+                        dmonly = rollArgs.dmonly,
+                        instant = rollArgs.instant,
+                        silent = rollArgs.silent,
+                        delay = rollArgs.delay,
+                        guid = rollArgs.guid,
+                        modifiers = modifiersUsed,
+                        multitargets = multitargetsUsed,
+                        boons = m_boons,
+                    })
+                end
+
+                if hookResult == "intercept" then
+                    return
+                end                
+
                 activeRoll = dmhub.Roll(rollArgs)
                 print("ROLL:: ACTIVE ROLL FROM", rollArgs, "HAVE", activeRoll)
 

--- a/Timeline/EmbeddedRollDialog.lua
+++ b/Timeline/EmbeddedRollDialog.lua
@@ -3634,6 +3634,32 @@ function GameHud.CreateEmbeddedRollDialog()
                 }
 
                 g_activeRollArgs = rollArgs
+
+                -- Hook for external mods to intercept rolls
+                local hookResult = nil
+                if RollDialog_BeforeRoll then
+                    hookResult = RollDialog_BeforeRoll({
+                        rollArgs = rollArgs,
+                        roll = rollArgs.roll,
+                        description = rollArgs.description,
+                        creature = rollArgs.creature,
+                        tokenid = rollArgs.tokenid,
+                        properties = rollArgs.properties,
+                        dmonly = rollArgs.dmonly,
+                        instant = rollArgs.instant,
+                        silent = rollArgs.silent,
+                        delay = rollArgs.delay,
+                        guid = rollArgs.guid,
+                        modifiers = modifiersUsed,
+                        multitargets = multitargetsUsed,
+                        boons = m_boons,
+                    })
+                end
+
+                if hookResult == "intercept" then
+                    return
+                end
+
                 activeRoll = dmhub.Roll(rollArgs)
                 print("ROLL:: ACTIVE ROLL FROM", rollArgs, "HAVE", activeRoll)
 


### PR DESCRIPTION
Introducing a new intercept hook, `RollDialog_BeforeRoll`, to both `DSRollDialog.lua` and the newer `EmbeddedRollDialog.lua` (Timeline). This allows external mods to intercept or modify the rolling logic immediately before `dmhub.Roll()` is executed, facilitating custom dice behavior or secondary effects without hard-patching the core codex.

**Changes**

-  DSRollDialog.lua: Added RollDialog_BeforeRoll hook after rollArgs is fully constructed, before dmhub.Roll(rollArgs).    
- EmbeddedRollDialog.lua: Added the same hook at the equivalent location in the embedded dialog's submit flow.
- Context Passing: The hook receives a context table containing the complete `rollArgs`, as well as individual fields (roll, description, creature, modifiers, multitargets, boons, etc.).
- Execution Flow: If the hook returns the string `"intercept"`, the script exits early, preventing the default `dmhub.Roll(rollArgs)` call.
- If the hook returns anything else, or if the function is undefined, execution continues normally.