### PR TITLE
Implement Arrestor Cycle (Skip Turn) initiative behavior

### DIFF
--- a/DMHub Game Rules/AbilityInitiative.lua
+++ b/DMHub Game Rules/AbilityInitiative.lua
@@ -82,6 +82,48 @@ function ActivatedAbilityInitiativeBehavior:Cast(ability, casterToken, targets, 
         if changes then
             dmhub:UploadInitiativeQueue()
         end
+
+    elseif mode == "skip_turn" then
+        if #targets > 0 then
+            local token = targets[1].token
+            if token ~= nil then
+                local q = dmhub.initiativeQueue
+                if q == nil or q.hidden then return end
+                local initiativeid = InitiativeQueue.GetInitiativeId(token)
+                local allTokens = InitiativeQueue.GetTokensForInitiativeId(initiativeid)
+
+                if token.valid and token.properties ~= nil then
+                    token:ModifyProperties{
+                        description = "Skip Turn",
+                        execute = function()
+                            token.properties:MarkTurnSkipped(initiativeid)
+                            token.properties:ConsumeResource(
+                                CharacterResource.actionResourceId, "turn", 1)
+                            token.properties:ConsumeResource(
+                                CharacterResource.maneuverResourceId, "turn", 1)
+                            local speed = token.properties:CurrentMovementSpeed()
+                            if speed > 0 then
+                                token.properties.moveDistance = speed
+                                token.properties.moveDistanceRoundId = q:GetRoundId()
+                            end
+                        end,
+                    }
+                end
+
+                -- Only auto-advance when this creature is the sole entry in initiative.
+                -- If others share the entry, they still need to act.
+                if #allTokens <= 1 then
+                    dmhub.Schedule(0.1, function()
+                        if mod.unloaded then return end
+                        GameHud.instance:NextInitiative(function()
+                            dmhub:UploadInitiativeQueue()
+                        end)
+                    end)
+                end
+
+                ability:CommitToPaying(casterToken, options)
+            end
+        end
     end
 end
 
@@ -110,7 +152,11 @@ function ActivatedAbilityInitiativeBehavior:EditorItems(parentPanel)
                 {
                     id = "add_to_initiative",
                     text = "Add to Combat as Caster Ally",
-                }
+                },
+                {
+                    id = "skip_turn",
+                    text = "Skip Turn",
+                },
             },
             idChosen = self:try_get("mode", "begin_turn"),
             change = function(element)

--- a/DMHub Game Rules/AbilityInvokeAbility.lua
+++ b/DMHub Game Rules/AbilityInvokeAbility.lua
@@ -513,6 +513,7 @@ function ActivatedAbilityInvokeAbilityBehavior:EditorItems(parentPanel)
                 end
             }
         }
+
     end
 
 	result[#result+1] = gui.Panel{

--- a/DMHub Game Rules/TriggeredAbility.lua
+++ b/DMHub Game Rules/TriggeredAbility.lua
@@ -635,7 +635,6 @@ function TriggeredAbility:Trigger(characterModifier, creature, symbols, auraCont
 
     argOptions = argOptions or {}
 
-
 	local casterToken = dmhub.LookupToken(creature)
 	if casterToken == nil then
         if argOptions.debugLog then

--- a/Draw Steel Core Rules/MCDMAbilityRollBehavior.lua
+++ b/Draw Steel Core Rules/MCDMAbilityRollBehavior.lua
@@ -1063,11 +1063,17 @@ function ActivatedAbilityPowerRollBehavior:Cast(ability, casterToken, targets, o
             end
         end
 
-        dialog = CharacterPanel.EmbedDialogInAbility()
+        -- EmbedDialogInAbility returns nil when the sidebar is not available
+        -- (e.g. triggered ability context). Only overwrite dialog if successful
+        -- so the fallback GameHud.instance.rollDialog is preserved.
+        local embeddedDialog = CharacterPanel.EmbedDialogInAbility()
+        if embeddedDialog ~= nil then
+            dialog = embeddedDialog
 
-        --give a few cycles for the dialog to init.
-        for i=1,4 do
-            coroutine.yield(0.01)
+            --give a few cycles for the dialog to init.
+            for i=1,4 do
+                coroutine.yield(0.01)
+            end
         end
     end
 
@@ -1083,7 +1089,7 @@ function ActivatedAbilityPowerRollBehavior:Cast(ability, casterToken, targets, o
         amendable = true,
         modifiers = modifiersApplied,
         multitargets = multitargets,
-        RecalculateMultitargets = CalculateMultitargets,
+        CalculateMultiTargets = CalculateMultitargets,
         creature = caster,
         targetCreature = appliedTargetCreature,
         symbols = options.symbols,

--- a/Draw Steel Core Rules/MCDMActivatedAbility.lua
+++ b/Draw Steel Core Rules/MCDMActivatedAbility.lua
@@ -2276,8 +2276,9 @@ function ActivatedAbility:GetNumTargets(casterToken, symbols)
     local result = g_numTargetsFunction(self, casterToken, symbols)
 
     if (not mod.unloaded) and casterToken ~= nil and casterToken.properties.minion and self.categorization == "Signature Ability" and result == 1 and casterToken.properties:has_key("_tmp_minionSquad") then
-        --minion signature abilities can target one target for each member of the squad.
-        return casterToken.properties._tmp_minionSquad.liveMinions
+        --minion signature abilities can target one target for each active (non-skipped) member.
+        return casterToken.properties._tmp_minionSquad.activeMinions
+            or casterToken.properties._tmp_minionSquad.liveMinions
     end
 
     return result

--- a/Draw Steel Core Rules/MCDMCreature.lua
+++ b/Draw Steel Core Rules/MCDMCreature.lua
@@ -9,6 +9,15 @@ creature.minionDead = false
 --- @field creature.initiativeGrouping false|string
 creature.initiativeGrouping = false
 
+--- @field creature.skipTurnInitiativeId string The initiative id for which this creature's turn was skipped.
+creature.skipTurnInitiativeId = ""
+
+--- @field creature.skipTurnRoundId string The round ID in which this creature's turn was skipped.
+creature.skipTurnRoundId = ""
+
+--- @field creature.skipTurnTurnsTaken number The turnsTaken value for the entry at the time of the skip.
+creature.skipTurnTurnsTaken = 0
+
 --- @alias SquadInfo table
 
 
@@ -453,11 +462,41 @@ function creature:RefreshToken(token)
     end
 end
 
+function creature:MarkTurnSkipped(initiativeid)
+    if dmhub.initiativeQueue == nil then return end
+    local q = dmhub.initiativeQueue
+    self.skipTurnInitiativeId = initiativeid or ""
+    self.skipTurnRoundId = q:GetRoundId() or ""
+    local entry = q.entries[initiativeid]
+    self.skipTurnTurnsTaken = (entry ~= nil) and (entry.turnsTaken or 0) or 0
+end
+
+function creature:IsTurnSkipped(token)
+    if dmhub.initiativeQueue == nil then return false end
+    local q = dmhub.initiativeQueue
+    if self:try_get("skipTurnRoundId", "") ~= (q:GetRoundId() or "") then return false end
+    local myInitiativeId = InitiativeQueue.GetInitiativeId(token)
+    if self:try_get("skipTurnInitiativeId", "") ~= myInitiativeId then return false end
+    local entry = q.entries[myInitiativeId]
+    if entry ~= nil then
+        if (entry.turnsTaken or 0) > self:try_get("skipTurnTurnsTaken", 0) then
+            return false  -- multi-turn boss used another turn; skip has expired
+        end
+    end
+    return true
+end
+
 function creature:RefreshInitiativeInfo(token)
     local q = dmhub.initiativeQueue
     if q == nil or q.hidden then
         self._tmp_initiativeStatus = nil
     else
+        -- Check if this creature's turn was skipped. Show as "Done" even during
+        -- a grouped turn where other creatures still have their turns available.
+        if self:IsTurnSkipped(token) then
+            self._tmp_initiativeStatus = "Done"
+            return
+        end
         local initiativeid = InitiativeQueue.GetInitiativeId(token)
         local initiativeEntry = q:GetFirstInitiativeEntry()
         if initiativeEntry ~= nil and initiativeEntry.initiativeid == initiativeid then
@@ -640,6 +679,7 @@ function creature:RefreshSquadInfo(token)
         }
 
         local liveMinions = 0
+        local activeMinions = 0
         local damage_taken_charid = self._tmp_minionSquad.damage_taken_charid or nil
         local damage_taken = self._tmp_minionSquad.damage_taken or 0
         local damage_taken_seq = self._tmp_minionSquad.damage_taken_seq or 0
@@ -654,6 +694,9 @@ function creature:RefreshSquadInfo(token)
                     self._tmp_minionSquad.tokens[#self._tmp_minionSquad.tokens + 1] = tok
                     if (not tok.properties.minionDead) and tok.properties.minion then
                         liveMinions = liveMinions + 1
+                        if not tok.properties:IsTurnSkipped(tok) then
+                            activeMinions = activeMinions + 1
+                        end
                     end
 
                     if tok.properties:has_key("squadpos") then
@@ -710,6 +753,7 @@ function creature:RefreshSquadInfo(token)
 
         self._tmp_minionSquad.hasCaptain = newHasCaptain
         self._tmp_minionSquad.liveMinions = liveMinions
+        self._tmp_minionSquad.activeMinions = activeMinions
         self._tmp_minionSquad.health_single = health_single
         self._tmp_minionSquad.maximum_health = health_single * liveMinions
         self._tmp_minionSquad.damage_taken = damage_taken

--- a/Draw Steel Core Rules/MCDMInitiativeBar.lua
+++ b/Draw Steel Core Rules/MCDMInitiativeBar.lua
@@ -1840,7 +1840,11 @@ function GameHud:NextInitiative(oncomplete)
         --damage is done in the end turn event it still shouldn't take damage.
 		for i,tok in ipairs(tokens) do
 			if tok.properties ~= nil then
-				tok.properties:EndTurn(tok)
+                if tok.properties:IsTurnSkipped(tok) then
+                    -- Suppress EndTurn: save-ends and end-of-turn effects do not trigger.
+                else
+				    tok.properties:EndTurn(tok)
+                end
 			end
 		end
 


### PR DESCRIPTION
## Summary

- Adds a new `skip_turn` mode to `ActivatedAbilityInitiativeBehavior` for the Arrestor Cycle ability, marking a target's turn as skipped, consuming their action/maneuver, exhausting their movement, and auto-advancing initiative if the creature is alone in their entry.
- Fixes turn skip state persisting across combat sessions by using `GetRoundId()` (a GUID-prefixed round ID) instead of the plain round number.
- Suppresses `EndTurn` for skipped creatures so save-ends and end-of-turn effects do not trigger.
- Tracks `activeMinions` (alive and not turn-skipped) separately from `liveMinions` so minion squad target counts exclude skipped members.
- Guards `EmbedDialogInAbility` nil return in triggered-ability context; fixes `CalculateMultiTargets` field name mismatch.

## Test plan

- [ ] Use an Arrestor Cycle ability to skip a target creature's turn; confirm the creature shows as "Done" in the initiative bar and their turn is skipped.
- [ ] Confirm action, maneuver, and movement are consumed on the skipped creature.
- [ ] Confirm the skip does not persist into the next combat session.
- [ ] Confirm save-ends conditions on the skipped creature do not expire at end of their skipped turn.
- [ ] For a minion squad with one member skipped, confirm the squad attack targets the remaining active members only (target count is correct).
- [ ] If the skipped creature is alone in their initiative entry, confirm initiative auto-advances past them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)