### PR TITLE
Fix Suppress Effects discarding Half Damage multiplier annotation

### DIFF
--- a/Draw Steel Core Rules/MCDModifyPowerRolls.lua
+++ b/Draw Steel Core Rules/MCDModifyPowerRolls.lua
@@ -764,10 +764,16 @@ CharacterModifier.TypeInfo.power = {
         end
 
         if self.modtype == "suppresseffects" then
+            local damageMultiplier = self:try_get("damageMultiplier", "full")
             for i,tier in ipairs(rollProperties.tiers) do
                 local m = regex.MatchGroups(tier, "^(?<prefix>.*?)(?<damage>\\d+\\s+[^0-9]*damage)(?<suffix>.*)$")
                 if m ~= nil then
                     tier = m.damage
+                    if damageMultiplier == "half" then
+                        tier = tier .. " (half)"
+                    elseif damageMultiplier ~= "full" then
+                        tier = tier .. " (no damage)"
+                    end
                 else
                     tier = "No effect"
                 end


### PR DESCRIPTION
## Summary

- When a Power Roll Trigger behavior has both **Suppress Effects** (Roll Mod) and **Half Damage** (Damage Multiplier) active, the suppress effects block was silently discarding the `(half)` annotation.
- Root cause: the suppresseffects regex extracts only the raw damage text and throws away the suffix, which already contained `(half)` from the earlier damageMultiplier pass.
- Fix: re-read `damageMultiplier` inside the suppresseffects block and re-append the annotation after stripping tier effects, so both modifications compose correctly.

## Test plan

- [x] Ability with Suppress Effects only: tiers show plain damage or "No effect" (no regression)
- [x] Ability with Half Damage only: tiers show damage with `(half)`, effects retained (no regression)
- [x] Ability with both Suppress Effects + Half Damage: tiers show `"X damage (half)"` with all other effects stripped
- [x] Ability with Suppress Effects + No Damage multiplier: tiers show `"X damage (no damage)"` or "No effect"

Tested via the **Inertial Absorption** (Psionic, 11 Discipline) ability which requires both simultaneously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)