### PR TITLE
Fix GoblinScript autocomplete for trigger symbols (Used Ability)

### DIFF
--- a/DMHub Compendium/TriggeredAbilityEditor.lua
+++ b/DMHub Compendium/TriggeredAbilityEditor.lua
@@ -344,6 +344,9 @@ function TriggeredAbility:GenerateEditor(options)
         local triggerInfo = TriggeredAbility.GetTriggerById(self.trigger)
         if triggerInfo ~= nil then
             for k,v in pairs(triggerInfo.symbols or {}) do
+                if type(v) == "table" and v.name then
+                    k = string.lower(string.gsub(v.name, "%s+", ""))
+                end
                 helpSymbols[k] = v
             end
 

--- a/Draw Steel Core Rules/MCDMRules.lua
+++ b/Draw Steel Core Rules/MCDMRules.lua
@@ -1099,7 +1099,7 @@ GameSystem.OnEndCastActivatedAbility = function(casterToken, ability, options)
     ability:FireUseAbility(casterToken, options)
 
 	if ability.categorization == "Signature Ability" and (ability:HasKeyword("Area") or ability:HasKeyword("Strike")) then
-		casterToken.properties:DispatchEvent("castsignature", {usedability = ability, cast = options.symbols.cast})
+		casterToken.properties:DispatchEvent("castsignature", {ability = ability, cast = options.symbols.cast})
 	end
 end
 
@@ -2553,7 +2553,7 @@ GameSystem.OnEndCastActivatedAbility = function(casterToken, ability, options)
     ability:FireUseAbility(casterToken, options)
 
 	if ability.categorization == "Signature Ability" and (ability:HasKeyword("Area") or ability:HasKeyword("Strike")) then
-		casterToken.properties:DispatchEvent("castsignature", {usedability = ability, cast = options.symbols.cast})
+		casterToken.properties:DispatchEvent("castsignature", {ability = ability, cast = options.symbols.cast})
 	end
 end
 

--- a/Draw Steel Core Rules/MCDMRules.lua
+++ b/Draw Steel Core Rules/MCDMRules.lua
@@ -1099,7 +1099,7 @@ GameSystem.OnEndCastActivatedAbility = function(casterToken, ability, options)
     ability:FireUseAbility(casterToken, options)
 
 	if ability.categorization == "Signature Ability" and (ability:HasKeyword("Area") or ability:HasKeyword("Strike")) then
-		casterToken.properties:DispatchEvent("castsignature", {ability = ability, cast = options.symbols.cast})
+		casterToken.properties:DispatchEvent("castsignature", {usedability = ability, cast = options.symbols.cast})
 	end
 end
 
@@ -2553,7 +2553,7 @@ GameSystem.OnEndCastActivatedAbility = function(casterToken, ability, options)
     ability:FireUseAbility(casterToken, options)
 
 	if ability.categorization == "Signature Ability" and (ability:HasKeyword("Area") or ability:HasKeyword("Strike")) then
-		casterToken.properties:DispatchEvent("castsignature", {ability = ability, cast = options.symbols.cast})
+		casterToken.properties:DispatchEvent("castsignature", {usedability = ability, cast = options.symbols.cast})
 	end
 end
 


### PR DESCRIPTION
## Summary

- In `TriggeredAbilityEditor.lua`, trigger symbols were being merged into the autocomplete table using raw Lua table keys. Array-format symbols (e.g. `g_abilitySymbols`) received numeric keys (`1`, `2`, ...) which `dmhub.AutoCompleteGoblinScript` cannot match. Dict-format symbols like `ability = {name="Used Ability"}` had a key that didn't match the engine's normalized identifier (`usedability`), causing the lookup to fail and fall back to creature (self) subfields.
- Fixed the merge loop to always derive the key from the normalized `name` field (lowercase, spaces removed), consistent with how `creature.helpSymbols` is structured.
- Fixed the `castsignature` `DispatchEvent` calls to pass the ability under key `usedability` (matching the normalized "Used Ability" GoblinScript identifier), aligning with the existing `useability` and `targetwithability` dispatches.

## Test plan

- [ ] Open a triggered ability that uses the "Use Signature Attack or Area", "Use an Ability", or "Target With Ability" trigger
- [ ] Focus the Condition formula field and type `Used Ability.` -- autocomplete should now show ability subfields (name, keywords, spell, etc.) instead of creature fields
- [ ] Verify `Cast.` shows spellcast subfields
- [ ] Confirm a formula like `Used Ability.spell` evaluates correctly at runtime when the trigger fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)