### PR TITLE
Add Effects Count GoblinScript symbol

### DIFF
--- a/Draw Steel Core Rules/MCDMCreature.lua
+++ b/Draw Steel Core Rules/MCDMCreature.lua
@@ -2526,6 +2526,54 @@ creature.RegisterSymbol {
     }
 }
 
+creature.RegisterSymbol {
+    symbol = "effectscount",
+    lookup = function(c)
+        local result = {}
+        local conditions = {}
+        local ongoingEffects = c:ActiveOngoingEffects()
+        local pureOngoingEffectsCount = 0
+        if #ongoingEffects > 0 then
+            local ongoingEffectsTable = dmhub.GetTable("characterOngoingEffects") or {}
+            for i, cond in ipairs(ongoingEffects) do
+                local ongoingEffectInfo = ongoingEffectsTable[cond.ongoingEffectid]
+                if ongoingEffectInfo.condition ~= 'none' then
+                    --effect has an underlying condition; count it as a condition only.
+                    conditions[ongoingEffectInfo.condition] = 1
+                else
+                    pureOngoingEffectsCount = pureOngoingEffectsCount + 1
+                end
+            end
+        end
+
+        --get bestowed conditions.
+        for i, modifier in ipairs(c:GetActiveModifiers()) do
+            if modifier.mod:CanBestowConditions() and modifier.mod:PassesFilter(c) then
+                modifier.mod:BestowConditions(modifier, c, conditions)
+            end
+        end
+
+        local conditionsTable = dmhub.GetTable(CharacterCondition.tableName)
+        for k, _ in pairs(conditions) do
+            local conditionInfo = conditionsTable[k]
+            result[#result + 1] = conditionInfo.name
+        end
+
+        local inflictedConditions = c:get_or_add("inflictedConditions", {})
+        for condid, _ in pairs(inflictedConditions) do
+            result[#result + 1] = conditionsTable[condid].name
+        end
+
+        return #result + pureOngoingEffectsCount
+    end,
+    help = {
+        name = "Effects Count",
+        type = "number",
+        desc = "The number of conditions and ongoing effects currently active on this creature.",
+        seealso = {"ConditionCount"},
+    }
+}
+
 --override default InflictCondition to include MCDM condition rules.
 
 --- Inflict a condition on a creature. (Or purge the condition using the 'purge' argument.)


### PR DESCRIPTION
## Summary

- Registers a new `effectscount` GoblinScript symbol on the creature type, usable as `Self.Effects Count` in formulas
- Returns the combined count of active conditions and ongoing effects on a creature
- Follows the same pattern as the existing `conditioncount` symbol, extending the return value with `+ #ongoingEffects`
- Autocomplete support included via the `help` block (type: `number`, description, seealso reference to `ConditionCount`)

## Test plan

- [ ] Open the GoblinScript editor on any ability field and verify `Effects Count` appears in autocomplete under `Self.`
- [ ] With a creature that has 1 condition and 1 ongoing effect, verify `Self.Effects Count` returns `2`
- [ ] With no conditions or effects active, verify `Self.Effects Count` returns `0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)