### PR TITLE
Add numberofplayers GoblinScript symbol

### DIFF
--- a/Draw Steel Core Rules/MCDMCreature.lua
+++ b/Draw Steel Core Rules/MCDMCreature.lua
@@ -4159,6 +4159,28 @@ creature.RegisterSymbol {
     }
 }
 
+creature.RegisterSymbol {
+    symbol = "numberofplayers",
+    lookup = function(c)
+        local partyid = GetDefaultPartyID()
+        local charids = dmhub.GetCharacterIdsInParty(partyid) or {}
+        local count = 0
+        for _, charid in ipairs(charids) do
+            local ch = dmhub.GetCharacterById(charid)
+            if ch ~= nil and ch.followerType == nil then
+                count = count + 1
+            end
+        end
+        return count
+    end,
+    help = {
+        name = "NumberOfPlayers",
+        type = "number",
+        desc = "The number of players in the game, not counting followers.",
+        seealso = {},
+    }
+}
+
 function creature:StartOnDying()
     self:RemoveMatchingOngoingEffects(function(ongoingEffect)
         return ongoingEffect.removeOnEoEOrDying


### PR DESCRIPTION
## Summary
- Adds a new `numberofplayers` GoblinScript symbol to `MCDMCreature.lua`
- Returns the count of player characters in the default party, excluding followers (artisans, sages, retainers)
- Followers are identified by the presence of the `followerType` field

## Test plan
- Use `numberofplayers` in any GoblinScript formula field in DMHub
- Verify followers are not counted when the party includes retainers/artisans/sages
- Verify the count updates correctly when heroes are added or removed from the party

🤖 Generated with [Claude Code](https://claude.com/claude-code)