### PR TITLE
PowerRollTrigger: Add Epic Resource as a resource cost option

### DIFF
--- a/DMHub Game Rules/CharacterModifier.lua
+++ b/DMHub Game Rules/CharacterModifier.lua
@@ -3193,6 +3193,10 @@ function CharacterModifier:ConsumeResourceInternal(creature, modContext)
             note = modContext.modifier.name
         end
         creature:ConsumeSurges(cost, note)
+    elseif costType == "epicresource" and not self:try_get("overrideCost", false) then
+        local charges = self:try_get("_tmp_symbols", {}).charges or 1
+        local cost = ExecuteGoblinScript(self:try_get("resourceCostAmount", "1"), creature:LookupSymbol(self:try_get("_tmp_symbols", {})), 0)*charges
+        creature:ConsumeResource(CharacterResource.epicResourceId, "unbounded", cost, string.format("%s", self.name))
     elseif costType ~= "none" and not self:try_get("overrideCost", false) then
         local charges = self:try_get("_tmp_symbols", {}).charges or 1
         local cost = ExecuteGoblinScript(self:try_get("resourceCostAmount", "1"), creature:LookupSymbol(self:try_get("_tmp_symbols", {})), 0)*charges
@@ -3233,6 +3237,10 @@ function CharacterModifier:HasResourcesAvailable(creature)
     local costType = self:try_get("resourceCostType", "none")
     if costType == "surges" then
         local resourcesAvailable = creature:GetAvailableSurges()
+        local cost = ExecuteGoblinScript(self:try_get("resourceCostAmount", "1"), creature:LookupSymbol(self:try_get("_tmp_symbols", {})), 0)
+        return cost <= resourcesAvailable
+    elseif costType == "epicresource" then
+        local resourcesAvailable = creature:GetEpicResources()
         local cost = ExecuteGoblinScript(self:try_get("resourceCostAmount", "1"), creature:LookupSymbol(self:try_get("_tmp_symbols", {})), 0)
         return cost <= resourcesAvailable
     elseif costType ~= "none" then
@@ -3276,6 +3284,9 @@ function CharacterModifier:DescribeResourceAvailability(creature, charges, expec
         if costType == "surges" then
             resourcesAvailable = creature:GetAvailableSurges()
             resourceName = tr("Surges")
+        elseif costType == "epicresource" then
+            resourcesAvailable = creature:GetEpicResources()
+            resourceName = creature:GetEpicResourceName()
         else
             resourcesAvailable = creature:GetHeroicOrMaliceResources()
             resourceName = creature:GetHeroicResourceName()

--- a/Draw Steel Core Rules/MCDModifyPowerRolls.lua
+++ b/Draw Steel Core Rules/MCDModifyPowerRolls.lua
@@ -1001,6 +1001,10 @@ CharacterModifier.TypeInfo.power = {
                             id = "surges",
                             text = "Surges",
                         },
+                        {
+                            id = "epicresource",
+                            text = "Epic Resource",
+                        },
 					},
 					change = function(element)
                         modifier.resourceCostType = element.idChosen


### PR DESCRIPTION
## Summary

- Adds **Epic Resource** to the Resource Cost dropdown in the Power Roll Trigger modifier behaviour, alongside None, Malice/Heroic Resources, Malice/Heroic Resources+, and Surges
- When selected, the trigger checks the creature's Epic Resource balance before firing, and deducts from it on activation — mirroring the checks and balances on the other resource options
- The cost value box (GoblinScript formula) appears automatically, as it does for all non-None resource types
- Uses existing infrastructure: `GetEpicResources()`, `GetEpicResourceName()` (returns the class-specific name e.g. Virtue, Command, Vision), and `ConsumeResource()` with the Epic Resource UUID

Three functions updated in `CharacterModifier.lua`: `HasResourcesAvailable`, `ConsumeResourceInternal`, `DescribeResourceAvailability`. One dropdown entry added in `MCDModifyPowerRolls.lua`.

## Test plan

- [ ] Open a Power Roll Trigger modifier editor — confirm "Epic Resource" appears in the Resource Cost dropdown
- [ ] Select Epic Resource — confirm the Cost field appears
- [ ] Assign the feature to a Level 10 hero with Epic Resource; confirm the trigger fires when they have sufficient resource and is blocked when they have 0
- [ ] Confirm the Epic Resource balance decreases by the correct amount after the trigger activates
- [ ] Confirm the cost description in the UI shows the class-specific resource name (e.g. "1/3 Virtue")

🤖 Generated with [Claude Code](https://claude.com/claude-code)