### PR TITLE
PowerRollTrigger: Fix Roll Mod (e.g. Tier Up) not applying on trigger

### DIFF
--- a/Draw Steel Core Rules/MCDMAbilityRollBehavior.lua
+++ b/Draw Steel Core Rules/MCDMAbilityRollBehavior.lua
@@ -250,6 +250,10 @@ local function CalculateMultitargetsFromRollProperties(rollMessage, rollResult)
                 rollInfo.total = rollInfo.total + (targetBonusFromBoonsAndBanes - baseBonusFromBoonsAndBanes)
             end
 
+            if (target.tiersDelta or 0) ~= 0 then
+                rollInfo.tiers = (rollInfo.tiers or 0) + target.tiersDelta
+            end
+
             local tier = rollMessage.properties:try_get("overrideTier") or DiceResultToTier(rollInfo)
 
             multitargets[#multitargets+1] = {

--- a/Timeline/EmbeddedRollDialog.lua
+++ b/Timeline/EmbeddedRollDialog.lua
@@ -2953,6 +2953,7 @@ function GameHud.CreateEmbeddedRollDialog()
             m_multitargets[index].rollProperties.multitargets = nil
             m_multitargets[index].boons = (rollInfo.boons or 0)
             m_multitargets[index].banes = (rollInfo.banes or 0)
+            m_multitargets[index].tiersDelta = (rollInfo.tiers or 0)
 
             -- Check roll requirements for triggers so they hide/show dynamically.
             -- If a trigger is already activated, skip the check -- its own effect
@@ -2987,16 +2988,20 @@ function GameHud.CreateEmbeddedRollDialog()
         --a multitarget's "boons" is relative to the boons for the roll.
         local normalizedBoons = m_multitargets[index].boons
         local normalizedBanes = m_multitargets[index].banes
+        local normalizedTiers = m_multitargets[index].tiersDelta or 0
         if m_rollInfo ~= nil then
             --if the roll has already started then the roll defines the normalized boons.
             normalizedBoons = (m_rollInfo.boons or 0)
             normalizedBanes = (m_rollInfo.banes or 0)
+            normalizedTiers = (m_rollInfo.tiers or 0)
         end
         for i = 1, #m_multitargets do
             m_multitargets[i].boons = m_multitargets[i].boons - normalizedBoons
             m_multitargets[i].banes = m_multitargets[i].banes - normalizedBanes
+            m_multitargets[i].tiersDelta = (m_multitargets[i].tiersDelta or 0) - normalizedTiers
             rollProperties.multitargets[i].boons = m_multitargets[i].boons
             rollProperties.multitargets[i].banes = m_multitargets[i].banes
+            rollProperties.multitargets[i].tiersDelta = m_multitargets[i].tiersDelta
         end
 
         resultPanel:FireEventTree("recalculatedMultiTargets", m_multitargets, rollProperties)


### PR DESCRIPTION
## Summary

- Fixes a bug where Roll Mod settings on a Power Roll Trigger modifier (Tier Up, Tier Down, etc.) had no effect when the trigger was activated
- The Roll Mod worked correctly on a standard Modify Power Roll behaviour but was silently ignored in the triggered context

## Root cause

`RecalculateMultiTargets` builds per-target roll strings incorporating the active trigger's Roll Mod (e.g. appending `tierup` to the formula) and calls `ParseRoll` to compute per-target roll info. The resulting `tiers` delta was discarded — only `boons` and `banes` were saved back to the multitargets data. `CalculateMultitargetsFromRollProperties` therefore computed the final tier for each target without knowledge of the tier modification.

## Fix

- `Timeline/EmbeddedRollDialog.lua` (`RecalculateMultiTargets`): Store a `tiersDelta` per target from `ParseRoll`, normalised against the actual roll's base tiers — the same pattern used for `boons`/`banes`. Write the delta back into `rollProperties.multitargets`.
- `Draw Steel Core Rules/MCDMAbilityRollBehavior.lua` (`CalculateMultitargetsFromRollProperties`): Apply `target.tiersDelta` to `rollInfo.tiers` before calling `DiceResultToTier`, so Tier Up and Tier Down Roll Mods on triggered modifiers are correctly reflected in the outcome.

## Test plan

- [ ] Create a Power Roll Trigger with Roll Mod = Tier Up; confirm the triggered result is one tier higher than the base roll
- [ ] Confirm Tier Down similarly reduces the result by one tier
- [ ] Confirm triggers with no Roll Mod (Roll Mod = None) are unaffected
- [ ] Confirm multi-target scenarios work correctly (each target's tier modified independently)

🤖 Generated with [Claude Code](https://claude.com/claude-code)