### PR TITLE
Respect Initiative Threshold custom attribute in Draw Steel roll

### DIFF
--- a/Draw Steel UI/DSInitiativeRoll.lua
+++ b/Draw Steel UI/DSInitiativeRoll.lua
@@ -1,5 +1,8 @@
 local mod = dmhub.GetModLoading()
 
+local g_selectedTokensOpenInitiative = nil
+local g_playerTokensOpenInitiative = nil
+local g_monsterTokensOpenInitiative = nil
 
 local function createDrawSteelBanner(options)
     print("BANNER:: CREATE")
@@ -23,6 +26,17 @@ local function createDrawSteelBanner(options)
 
     if options.immediateResult then
         m_heroesWin = cond(options.immediateResult == "heroes", true, false)
+    end
+
+    local m_initiativeThreshold = 6
+    for charid,_ in pairs(g_playerTokensOpenInitiative or {}) do
+        local tok = dmhub.GetCharacterById(charid)
+        if tok ~= nil and tok.valid then
+            local t = tok.properties:CalculateNamedCustomAttribute("Initiative Threshold")
+            if type(t) == "number" and t > 0 and t < m_initiativeThreshold then
+                m_initiativeThreshold = t
+            end
+        end
     end
 
     local m_rollInfo = nil
@@ -223,7 +237,7 @@ local function createDrawSteelBanner(options)
         end,
 
         diceface = function(self, diceguid, num)
-            local heroesWin = (num >= 6)
+            local heroesWin = (num >= m_initiativeThreshold)
             m_heroesWin = heroesWin
             BannerPanel:SetClassTree("rolling", true)
             BannerPanel:SetClassTree("heroes", heroesWin)
@@ -812,10 +826,6 @@ local function SetTokenSurprised(tok, surprised)
         }
     end
 end
-
-local g_selectedTokensOpenInitiative = nil
-local g_playerTokensOpenInitiative = nil
-local g_monsterTokensOpenInitiative = nil
 
 local function ShowCombatSetupDialog(selectedTokens)
     local m_encounterStrength = 0

--- a/Draw Steel UI/DSInitiativeRoll.lua
+++ b/Draw Steel UI/DSInitiativeRoll.lua
@@ -29,12 +29,16 @@ local function createDrawSteelBanner(options)
     end
 
     local m_initiativeThreshold = 6
+    local surprisedConditionForThreshold = CharacterCondition.conditionsByName["surprised"]
     for charid,_ in pairs(g_playerTokensOpenInitiative or {}) do
         local tok = dmhub.GetCharacterById(charid)
         if tok ~= nil and tok.valid then
-            local t = tok.properties:CalculateNamedCustomAttribute("Initiative Threshold")
-            if type(t) == "number" and t > 0 and t < m_initiativeThreshold then
-                m_initiativeThreshold = t
+            local isSurprised = surprisedConditionForThreshold ~= nil and tok.properties:HasCondition(surprisedConditionForThreshold.id)
+            if not isSurprised then
+                local t = tok.properties:CalculateNamedCustomAttribute("Initiative Threshold")
+                if type(t) == "number" and t > 0 and t < m_initiativeThreshold then
+                    m_initiativeThreshold = t
+                end
             end
         end
     end


### PR DESCRIPTION
## Summary

- The Draw Steel initiative roll previously used a hardcoded threshold of 6 (heroes win on 6+)
- Added logic to read the `Initiative Threshold` custom attribute from all hero combatants at the start of the roll
- The lowest threshold found across the party is used, so a Tactician with a modifier reducing it to 4 means the whole party wins on 4+
- Falls back to 6 if no heroes are present or no modifier has been applied

## Changes

`Draw Steel UI/DSInitiativeRoll.lua`
- Hoisted the three `g_*` initiative token locals to the top of the file so they are in scope as upvalues inside `createDrawSteelBanner`
- Added threshold computation loop in `createDrawSteelBanner` (runs once on banner creation, not on every dice animation frame)
- Replaced `num >= 6` with `num >= m_initiativeThreshold` in the `diceface` handler

## Test plan

- [ ] Start combat with no Tactician modifier applied -- confirm heroes still win on 6+
- [ ] Apply an Initiative Threshold modifier (e.g. Tactician reducing to 4) to one hero and start combat -- confirm heroes win on 4 and 5 as well as 6+
- [ ] Confirm monsters still win on rolls below the threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)