### PR TITLE
Add Conditional After Power Roll activation type

### DIFF
--- a/Draw Steel Core Rules/MCDMCreature.lua
+++ b/Draw Steel Core Rules/MCDMCreature.lua
@@ -3121,6 +3121,22 @@ function creature:GetModifiersForPowerRoll(roll, rollType, options)
     return result
 end
 
+function creature:GetAfterRollModifiersForPowerRoll(rollType, options)
+    options = options or {}
+    local result = {}
+    local modifiers = self:GetActiveModifiers()
+    for _, mod in ipairs(modifiers) do
+        local m = mod.mod:DescribeModifyPowerRollAfter(mod, self, rollType, options)
+        if m ~= nil then
+            m.hint = m.modifier:HintModifyPowerRollsAfter(mod, self, rollType, options)
+            if m.hint ~= nil then
+                result[#result + 1] = m
+            end
+        end
+    end
+    return result
+end
+
 function creature:RollCustomPowerTableTest(title, characteristics, skills, tiers)
     local attrid = nil
     local bestModifier = nil

--- a/Draw Steel Core Rules/MCDModifyPowerRolls.lua
+++ b/Draw Steel Core Rules/MCDModifyPowerRolls.lua
@@ -218,6 +218,13 @@ CharacterModifier.TypeInfo.power = {
     hintPowerRoll = function(self, creature, rollType, options)
         options = options or {}
 
+        if type(self:try_get("activationAfterRoll", false)) == "string" then
+            return {
+                result = false,
+                justification = {}
+            }
+        end
+
         if self:has_key("baseModifier") and (not self:try_get("overrideBase", false)) then
             local baseResult = CharacterModifier.TypeInfo.power.hintPowerRoll(self.baseModifier, creature, rollType, options)
             if baseResult.result == false then
@@ -293,6 +300,10 @@ CharacterModifier.TypeInfo.power = {
 
     shouldShowInPowerRollDialog = function(self, creature, rollType, roll, options)
 
+        if type(self:try_get("activationAfterRoll", false)) == "string" then
+            return false
+        end
+
         if self:has_key("baseModifier") and (not CharacterModifier.TypeInfo.power.shouldShowInPowerRollDialog(self.baseModifier, creature, rollType, roll, options)) then
             return false
         end
@@ -367,6 +378,57 @@ CharacterModifier.TypeInfo.power = {
         end
 
         return true
+    end,
+
+    shouldShowInPowerRollDialogAfterRoll = function(self, creature, rollType, roll, options)
+        if type(self:try_get("activationAfterRoll", false)) ~= "string" then
+            return false
+        end
+        if not RollTypeMatches(self, rollType) then
+            return false
+        end
+        if not self:PassesFilter(creature) then
+            return false
+        end
+        return true
+    end,
+
+    hintPowerRollAfter = function(self, creature, rollType, options)
+        options = options or {}
+
+        if not RollTypeMatches(self, rollType) then
+            return { result = false, justification = {} }
+        end
+
+        if self:HasResourcesAvailable(creature) == false then
+            return {
+                result = false,
+                justification = {"You have expended all uses of this ability."},
+            }
+        end
+
+        local lookupFunction = creature:LookupSymbol(self:AppendSymbols{
+            ability = GenerateSymbols(options.ability),
+            target  = GenerateSymbols(options.target),
+            caster  = GenerateSymbols(options.caster),
+            cast    = options.symbols and GenerateSymbols(options.symbols.cast),
+            title   = options.title or "",
+        })
+
+        if self:try_get("displayAfterRoll", "") ~= "" then
+            if not GoblinScriptTrue(ExecuteGoblinScript(self.displayAfterRoll, lookupFunction, 0, "Power Roll After Display Condition")) then
+                return nil
+            end
+        end
+
+        if self.activationAfterRoll == "" then
+            return { result = false, justification = {} }
+        end
+
+        return {
+            result = GoblinScriptTrue(ExecuteGoblinScript(self.activationAfterRoll, lookupFunction, 0, "Power Roll After Activation Condition")),
+            justification = {},
+        }
     end,
 
     modifyPowerRoll = function(self, creature, rollType, roll, options)
@@ -834,7 +896,11 @@ CharacterModifier.TypeInfo.power = {
 
             local conditionType = "condition"
             if modifier.activationCondition == false then
-                conditionType = "never"
+                if type(modifier:try_get("activationAfterRoll", false)) == "string" then
+                    conditionType = "condition_after_roll"
+                else
+                    conditionType = "never"
+                end
             elseif modifier.activationCondition == true then
                 conditionType = "always"
             end
@@ -1179,15 +1245,26 @@ CharacterModifier.TypeInfo.power = {
 							id = "condition",
 							text = "Condition",
 						},
+						{
+							id = "condition_after_roll",
+							text = "Conditional After Power Roll",
+						},
 					},
 					change = function(element)
 						if element.idChosen ~= conditionType then
 							if element.idChosen == "never" then
 								modifier.activationCondition = false
+								modifier.activationAfterRoll = false
 							elseif element.idChosen == "always" then
 								modifier.activationCondition = true
-							else
+								modifier.activationAfterRoll = false
+							elseif element.idChosen == "condition" then
 								modifier.activationCondition = ""
+								modifier.activationAfterRoll = false
+							else -- condition_after_roll
+								modifier.activationCondition = false
+								modifier.activationAfterRoll = ""
+								modifier.displayAfterRoll = ""
 							end
 							Refresh()
 						end
@@ -1255,6 +1332,64 @@ CharacterModifier.TypeInfo.power = {
 						symbols = modifier:HelpAdditionalSymbols(helpSymbols),
 					},
 				}
+            elseif conditionType == "condition_after_roll" then
+                local helpSymbols = CharacterModifier.defaultHelpSymbols
+                if modifier.rollType == "ability_power_roll" or modifier.rollType == "enemy_ability_power_roll" then
+                    helpSymbols = g_powerRollSymbols
+                end
+
+                helpSymbols = DeepCopy(helpSymbols)
+                helpSymbols.cast = {
+                    name = "Cast",
+                    type = "spellcast",
+                    desc = "The cast info for this ability. After the roll, cast.roll contains the dice total and cast.tier contains the tier result (1, 2, or 3).",
+                }
+                helpSymbols.title = {
+                    name = "Title",
+                    type = "text",
+                    desc = "The title of the roll",
+                    examples = "Recall Lore Test to Recall Location of Amulet",
+                }
+
+                children[#children+1] = gui.GoblinScriptInput{
+                    placeholderText = "Enter display criteria...",
+                    value = modifier:try_get("displayAfterRoll", ""),
+                    change = function(element)
+                        modifier.displayAfterRoll = element.value
+                        Refresh()
+                    end,
+
+                    documentation = {
+                        domains = modifier:Domains(),
+                        help = "This GoblinScript is evaluated after the dice are rolled to determine whether this modifier is shown as an option. Use cast.roll for the dice total and cast.tier for the tier (1, 2, or 3).",
+                        output = "boolean",
+                        examples = {
+                        },
+                        subject = creature.helpSymbols,
+                        subjectDescription = "The creature affected by this modifier",
+                        symbols = modifier:HelpAdditionalSymbols(helpSymbols),
+                    },
+                }
+
+                children[#children+1] = gui.GoblinScriptInput{
+                    placeholderText = "Enter after-roll activation criteria...",
+                    value = modifier:try_get("activationAfterRoll", ""),
+                    change = function(element)
+                        modifier.activationAfterRoll = element.value
+                        Refresh()
+                    end,
+
+                    documentation = {
+                        domains = modifier:Domains(),
+                        help = "This GoblinScript is evaluated after the dice are rolled to determine whether this modifier is applied. It sets the default checked state of the checkbox that appears in the post-roll window. Use cast.roll for the dice total and cast.tier for the tier (1, 2, or 3). The player can always override the value manually.",
+                        output = "boolean",
+                        examples = {
+                        },
+                        subject = creature.helpSymbols,
+                        subjectDescription = "The creature affected by this modifier",
+                        symbols = modifier:HelpAdditionalSymbols(helpSymbols),
+                    },
+                }
             end
 
 
@@ -2145,6 +2280,38 @@ function CharacterModifier:HintModifyPowerRolls(modContext, creature, rollType, 
         return result
     end
 
+    return nil
+end
+
+function CharacterModifier:ShouldShowInPowerRollDialogAfter(modContext, creature, rollType, options)
+    local typeInfo = CharacterModifier.TypeInfo[self.behavior] or {}
+    local shouldShow = typeInfo.shouldShowInPowerRollDialogAfterRoll
+    if shouldShow ~= nil then
+        self:InstallSymbolsFromContext(modContext)
+        self:InstallSymbolsFromContext(options)
+        return shouldShow(self, creature, rollType, nil, options)
+    end
+    return false
+end
+
+function CharacterModifier:DescribeModifyPowerRollAfter(modContext, creature, rollType, options)
+    if self:ShouldShowInPowerRollDialogAfter(modContext, creature, rollType, options) then
+        return {
+            modifier = self,
+            context = modContext,
+        }
+    end
+    return nil
+end
+
+function CharacterModifier:HintModifyPowerRollsAfter(modContext, creature, rollType, options)
+    local typeInfo = CharacterModifier.TypeInfo[self.behavior] or {}
+    local hint = typeInfo.hintPowerRollAfter
+    if hint ~= nil then
+        self:InstallSymbolsFromContext(modContext)
+        self:InstallSymbolsFromContext(options)
+        return hint(self, creature, rollType, options)
+    end
     return nil
 end
 

--- a/Timeline/EmbeddedRollDialog.lua
+++ b/Timeline/EmbeddedRollDialog.lua
@@ -285,6 +285,11 @@ function GameHud.CreateEmbeddedRollDialog()
     --- @type nil|({token: CharacterToken, boons: number, banes: number, text: string, modifiers: CharacterModifier[], triggers: list}[])
     local m_multitargets = nil
     local m_CalculateMultiTargets = nil
+    local m_afterRollModifierEntries = nil
+    -- Non-dice modifier portion of the roll (total - naturalRoll), computed on first
+    -- pending call.  On re-rolls the engine provides a fresh naturalRoll but a stale
+    -- total, so we recompute: correctedTotal = naturalRoll + m_rollNonDiceModifier.
+    local m_rollNonDiceModifier = nil
 
     local GetCurrentMultiTarget = function()
         if m_multitargets == nil or targetCreature == nil then
@@ -1745,6 +1750,11 @@ function GameHud.CreateEmbeddedRollDialog()
                     events:Listen(element)
                 end
             end
+            -- On re-rolls rollInfo.total is stale; use the stored modifier
+            -- so diceface events compute the correct running total.
+            if m_rollNonDiceModifier ~= nil and #rollInfo.rolls > 0 then
+                element.data.mod = m_rollNonDiceModifier
+            end
             if #rollInfo.rolls == 0 then
                 element.text = tostring(rollInfo.total)
             end
@@ -2950,6 +2960,14 @@ function GameHud.CreateEmbeddedRollDialog()
                 end
             end
 
+            -- Re-inject after-roll modifier entries so they survive this recalculation.
+            -- The same entry objects are reused, preserving any mod.override values set by the user.
+            if m_afterRollModifierEntries ~= nil then
+                for _, entry in ipairs(m_afterRollModifierEntries) do
+                    m_options.modifiers[#m_options.modifiers + 1] = entry
+                end
+            end
+
             resultPanel:FireEventTree('prepare', m_options)
             local roll = CalculateRollText {
                 surges = m_multitargets[index].surges or 0,
@@ -2980,6 +2998,135 @@ function GameHud.CreateEmbeddedRollDialog()
                     end
                 else
                     trigger.failsRequirement = nil
+                end
+            end
+
+            -- Re-evaluate after-roll conditions using the effective (post-modifier) roll.
+            -- Modifier toggles may change the effective tier, which affects conditions like Cast.Tier = 3.
+            -- Only runs after pending has fired (m_afterRollModifierEntries ~= nil).
+            if m_afterRollModifierEntries ~= nil
+                    and m_symbols ~= nil and m_symbols.cast ~= nil then
+                -- rollInfo here is from ParseRoll which does not carry a 'total' field.
+                -- Build a combined rollInfo using the corrected dice total and the
+                -- per-target boons/banes/tiers from ParseRoll so DiceResultToTier works correctly.
+                -- On re-rolls the engine's m_rollInfo.total is stale; recompute
+                -- from naturalRoll + stored modifier (same logic as pending callback).
+                local correctedTotal = 0
+                if m_rollInfo ~= nil then
+                    local natRoll = m_rollInfo.naturalRoll or 0
+                    if natRoll > 0 and m_rollNonDiceModifier ~= nil then
+                        correctedTotal = natRoll + m_rollNonDiceModifier
+                    else
+                        correctedTotal = m_rollInfo.total or 0
+                    end
+                end
+                local effectiveRollInfo = {
+                    total        = correctedTotal,
+                    boons        = rollInfo.boons,
+                    banes        = rollInfo.banes,
+                    tiers        = rollInfo.tiers,
+                    autosuccess  = rollInfo.autosuccess,
+                    autofailure  = rollInfo.autofailure,
+                    nottierone   = rollInfo.nottierone,
+                    nottierthree = rollInfo.nottierthree,
+                }
+                -- Keep all three cast symbols in sync so condition scripts see consistent
+                -- values regardless of when RecalculateMultiTargets fires relative to pending.
+                if m_rollInfo ~= nil then
+                    local natRoll = m_rollInfo.naturalRoll or 0
+                    m_symbols.cast.roll = correctedTotal
+                    m_symbols.cast.naturalRoll = natRoll > 0 and natRoll or correctedTotal
+                end
+                m_symbols.cast.tier = (rollProperties and rollProperties:try_get("overrideTier"))
+                                       or RollUtils.DiceResultToTier(effectiveRollInfo)
+
+                -- Re-run full collection (Pass 1 + Pass 2) with updated symbols.
+                local recollected = {}
+                if creature ~= nil then
+                    local creatureMods = creature:GetAfterRollModifiersForPowerRoll(rollType, {
+                        ability  = m_options.ability,
+                        target   = m_options.targetCreature,
+                        caster   = m_options.creature,
+                        title    = m_options.title or "",
+                        symbols  = m_symbols,
+                    })
+                    for _, mod in ipairs(creatureMods) do
+                        recollected[#recollected + 1] = mod
+                    end
+                end
+                if m_options.ability ~= nil then
+                    for _, behavior in ipairs(m_options.ability.behaviors or {}) do
+                        if behavior.typeName == "ActivatedAbilityModifyPowerRollBehavior" then
+                            local modifier = behavior.modifier
+                            if type(modifier:try_get("activationAfterRoll", false)) == "string" then
+                                local modContext = { mod = modifier }
+                                local hint = modifier:HintModifyPowerRollsAfter(modContext, creature, rollType, {
+                                    ability  = m_options.ability,
+                                    target   = m_options.targetCreature,
+                                    caster   = m_options.creature,
+                                    title    = m_options.title or "",
+                                    symbols  = m_symbols,
+                                })
+                                if hint ~= nil then
+                                    recollected[#recollected + 1] = {
+                                        modifier = modifier,
+                                        context  = modContext,
+                                        hint     = hint,
+                                    }
+                                end
+                            end
+                        end
+                    end
+                end
+
+                -- Merge with existing entries to preserve any user override values.
+                local existingByModifier = {}
+                for _, e in ipairs(m_afterRollModifierEntries) do
+                    existingByModifier[e.modifier] = e
+                end
+                local newEntries = {}
+                local changed = (#recollected ~= #m_afterRollModifierEntries)
+                for _, rec in ipairs(recollected) do
+                    local existing = existingByModifier[rec.modifier]
+                    if existing then
+                        if existing.hint == nil
+                                or existing.hint.result ~= rec.hint.result then
+                            existing.hint = rec.hint
+                            changed = true
+                        end
+                        newEntries[#newEntries + 1] = existing
+                    else
+                        newEntries[#newEntries + 1] = rec
+                        changed = true
+                    end
+                end
+
+                if changed then
+                    -- Rebuild m_options.modifiers: strip old entries, append new entries.
+                    local oldEntrySet = {}
+                    for _, e in ipairs(m_afterRollModifierEntries) do
+                        oldEntrySet[e] = true
+                    end
+                    local filtered = {}
+                    for _, mod in ipairs(m_options.modifiers) do
+                        if not oldEntrySet[mod] then
+                            filtered[#filtered + 1] = mod
+                        end
+                    end
+                    m_afterRollModifierEntries = newEntries
+                    for _, entry in ipairs(m_afterRollModifierEntries) do
+                        filtered[#filtered + 1] = entry
+                    end
+                    m_options.modifiers = filtered
+                    -- CalculateRollText fires 'prepare' internally (at the start of its
+                    -- rollProperties block), so a separate prepare call here is redundant.
+                    -- Re-running CalculateRollText ensures m_activeModifiers, surge counts,
+                    -- and rollProperties reflect the updated modifier state. Without this,
+                    -- modifiersUsed is captured before the modifier becomes active, so its
+                    -- effects (surges etc.) are never applied on roll acceptance.
+                    CalculateRollText{surges = m_multitargets[index].surges or 0}
+                    m_multitargets[index].modifiersUsed = DeepCopy(m_activeModifiers)
+                    m_multitargets[index].rollProperties = DeepCopy(rollProperties)
                 end
             end
         end
@@ -3234,6 +3381,7 @@ function GameHud.CreateEmbeddedRollDialog()
                 rollDiceButton.hasFocus = true
 
                 m_symbols = options.symbols
+                m_rollNonDiceModifier = nil
 
                 resultPanel.data.rollid = options.rollid or dmhub.GenerateGuid()
                 rollIsSilent = false
@@ -3712,7 +3860,41 @@ function GameHud.CreateEmbeddedRollDialog()
                     end,
                     pending = function(rollInfo)
                         m_rollInfo = rollInfo
-                        m_rollTotalLabel.text = tostring(rollInfo.total or 0)
+
+                        -- On re-rolls the engine provides a fresh naturalRoll but a
+                        -- stale total.  Compute the non-dice modifier once (first
+                        -- pending, where total IS accurate) then reuse it.
+                        local natRoll = rollInfo.naturalRoll or 0
+                        local correctedTotal
+                        if natRoll > 0 then
+                            if m_rollNonDiceModifier == nil then
+                                m_rollNonDiceModifier = (rollInfo.total or 0) - natRoll
+                            end
+                            correctedTotal = natRoll + m_rollNonDiceModifier
+                        else
+                            correctedTotal = rollInfo.total or 0
+                        end
+
+                        m_rollTotalLabel.text = tostring(correctedTotal)
+
+                        if m_symbols ~= nil and m_symbols.cast ~= nil then
+                            m_symbols.cast.roll = correctedTotal
+                            m_symbols.cast.naturalRoll = natRoll > 0 and natRoll or correctedTotal
+                            local tierRollInfo = {
+                                total        = correctedTotal,
+                                boons        = rollInfo.boons,
+                                banes        = rollInfo.banes,
+                                tiers        = rollInfo.tiers,
+                                autosuccess  = rollInfo.autosuccess,
+                                autofailure  = rollInfo.autofailure,
+                                nottierone   = rollInfo.nottierone,
+                                nottierthree = rollInfo.nottierthree,
+                            }
+                            local tier = (rollProperties and rollProperties:try_get("overrideTier"))
+                                         or RollUtils.DiceResultToTier(tierRollInfo)
+                            m_symbols.cast.tier = tier
+                        end
+
                         if showingDialog then
                             resultPanel:SetClassTree("rolling", false)
                             resultPanel:SetClassTree("finishedRolling", true)
@@ -3723,6 +3905,76 @@ function GameHud.CreateEmbeddedRollDialog()
                             else
                                 rollAgainButton:SetClass("collapsed", false)
                                 proceedAfterRollButton:SetClass("collapsed", false)
+                            end
+
+                            -- On re-roll, strip any stale after-roll entries that were
+                            -- re-injected by RecalculateMultiTargets before the new dice were thrown.
+                            if m_afterRollModifierEntries ~= nil and m_options.modifiers ~= nil then
+                                local oldEntries = {}
+                                for _, entry in ipairs(m_afterRollModifierEntries) do
+                                    oldEntries[entry] = true
+                                end
+                                local filtered = {}
+                                for _, mod in ipairs(m_options.modifiers) do
+                                    if not oldEntries[mod] then
+                                        filtered[#filtered + 1] = mod
+                                    end
+                                end
+                                m_options.modifiers = filtered
+                            end
+
+                            -- Collect after-roll modifier entries into a persistent table so
+                            -- they survive RecalculateMultiTargets calls (which rebuild m_options.modifiers).
+                            m_afterRollModifierEntries = {}
+
+                            -- Pass 1: creature-level modifiers (conditions, features) via GetActiveModifiers()
+                            if creature ~= nil then
+                                local creatureMods = creature:GetAfterRollModifiersForPowerRoll(rollType, {
+                                    ability  = m_options.ability,
+                                    target   = m_options.targetCreature,
+                                    caster   = m_options.creature,
+                                    title    = m_options.title or "",
+                                    symbols  = m_symbols,
+                                })
+                                for _, mod in ipairs(creatureMods) do
+                                    m_afterRollModifierEntries[#m_afterRollModifierEntries + 1] = mod
+                                end
+                            end
+
+                            -- Pass 2: ActivatedAbilityModifyPowerRollBehavior modifiers on the active ability.
+                            -- These are NOT in GetActiveModifiers() so must be iterated directly.
+                            if m_options.ability ~= nil then
+                                for _, behavior in ipairs(m_options.ability.behaviors or {}) do
+                                    if behavior.typeName == "ActivatedAbilityModifyPowerRollBehavior" then
+                                        local modifier = behavior.modifier
+                                        if type(modifier:try_get("activationAfterRoll", false)) == "string" then
+                                            local modContext = { mod = modifier }
+                                            local hint = modifier:HintModifyPowerRollsAfter(modContext, creature, rollType, {
+                                                ability  = m_options.ability,
+                                                target   = m_options.targetCreature,
+                                                caster   = m_options.creature,
+                                                title    = m_options.title or "",
+                                                symbols  = m_symbols,
+                                            })
+                                            if hint ~= nil then
+                                                m_afterRollModifierEntries[#m_afterRollModifierEntries + 1] = {
+                                                    modifier = modifier,
+                                                    context  = modContext,
+                                                    hint     = hint,
+                                                }
+                                            end
+                                        end
+                                    end
+                                end
+                            end
+
+                            if #m_afterRollModifierEntries > 0 then
+                                m_options.modifiers = m_options.modifiers or {}
+                                for _, entry in ipairs(m_afterRollModifierEntries) do
+                                    m_options.modifiers[#m_options.modifiers + 1] = entry
+                                end
+                                resultPanel:FireEventTree('prepare', m_options)
+                                CalculateRollText{}
                             end
                         end
                     end,

--- a/Timeline/EmbeddedRollDialog.lua
+++ b/Timeline/EmbeddedRollDialog.lua
@@ -2397,6 +2397,9 @@ function GameHud.CreateEmbeddedRollDialog()
                 local children = {}
 
                 for modifierIndex, mod in ipairs(options.modifiers) do
+                    if mod.isAfterRoll then
+                        goto continue
+                    end
                     if mod.modifier then
                         -- Skip modifiers that fail requirements
                         if mod.failsRequirement then
@@ -2582,6 +2585,117 @@ function GameHud.CreateEmbeddedRollDialog()
                     ::continue::
                 end
 
+                element.children = children
+            end,
+        },
+    }
+
+    local afterRollModifiersPanel = gui.Panel {
+        classes = { "hideWhenMinimized", "modifiers-panel" },
+        width = "100%",
+        height = "auto",
+        flow = "horizontal",
+        wrap = true,
+        bmargin = 6,
+        events = {
+            prepare = function(element, options)
+                if creature == nil or options.modifiers == nil then
+                    element.children = {}
+                    element:SetClass('collapsed-anim', true)
+                    return
+                end
+
+                local children = {}
+
+                for modifierIndex, mod in ipairs(options.modifiers) do
+                    if not mod.isAfterRoll then
+                        goto continue
+                    end
+                    if mod.modifier then
+                        if mod.failsRequirement then
+                            goto continue
+                        end
+
+                        mod.context = mod.context or {}
+                        local ischecked = false
+                        local force = mod.modifier:try_get("force", false)
+                        if mod.override ~= nil then
+                            ischecked = mod.override
+                        elseif force then
+                            ischecked = true
+                        elseif mod.hint ~= nil then
+                            ischecked = mod.hint.result
+                        end
+
+                        local tooltip = mod.modifier:GetSummaryText()
+                        if creature ~= nil then
+                            tooltip = StringInterpolateGoblinScript(tooltip, creature)
+                        end
+                        for i, justification in ipairs(mod.hint.justification) do
+                            tooltip = string.format("%s\n<color=%s>%s", tooltip, cond(ischecked, '#aaffaa', '#ffaaaa'),
+                                justification)
+                        end
+
+                        local text = mod.modifier.name
+                        if mod.modFromTarget then
+                            text = string.format("Target is %s", text)
+                        end
+
+                        local triggeredModifier = mod.modifier:try_get("_tmp_trigger")
+
+                        if triggeredModifier then
+                            local token = dmhub.GetTokenById(mod.modifier._tmp_triggerCharid)
+                            if token ~= nil then
+                                text = string.format("%s (%s)", text, token.name)
+                            end
+                        else
+                            local availability = mod.modifier:DescribeResourceAvailability(creature,
+                                mod.context.charges or 1, options.expectedCostOfCurrentCast)
+                            if availability then
+                                text = string.format("%s (%s)", text, availability)
+                            end
+                        end
+
+                        local classes = nil
+
+                        if force then
+                            classes = { "collapsed-anim" }
+                        end
+
+                        local check = ModifierPanel{
+                            classes = classes,
+                            text = text,
+                            value = ischecked,
+                            hmargin = 2,
+                            mod = mod,
+                            data = {
+                                mod = mod,
+                                modifierIndex = modifierIndex,
+                            },
+                            change = function(element)
+                                mod.override = element.value
+
+                                resultPanel:FireEventTree('prepare', m_options)
+                                CalculateRollText()
+                                RecalculateMultiTargets()
+                            end,
+                            linger = gui.Tooltip {
+                                text = tooltip,
+                                maxWidth = 600,
+                            },
+                        }
+
+                        children[#children + 1] = check
+                    end
+
+                    ::continue::
+                end
+
+                if #children > 0 then
+                    element:SetClass('collapsed-anim', false)
+                else
+                    element:SetClass('collapsed-anim', true)
+                end
                 element.children = children
             end,
         },
@@ -2856,6 +2970,7 @@ function GameHud.CreateEmbeddedRollDialog()
             m_tableContainer,
             rollInputContainer,
             m_rollTotalLabel,
+            afterRollModifiersPanel,
             m_rollResults,
             triggersWithTabContainer,
             rollDisabledLabel,
@@ -3051,6 +3166,7 @@ function GameHud.CreateEmbeddedRollDialog()
                         symbols  = m_symbols,
                     })
                     for _, mod in ipairs(creatureMods) do
+                        mod.isAfterRoll = true
                         recollected[#recollected + 1] = mod
                     end
                 end
@@ -3072,6 +3188,7 @@ function GameHud.CreateEmbeddedRollDialog()
                                         modifier = modifier,
                                         context  = modContext,
                                         hint     = hint,
+                                        isAfterRoll = true,
                                     }
                                 end
                             end
@@ -3937,6 +4054,7 @@ function GameHud.CreateEmbeddedRollDialog()
                                     symbols  = m_symbols,
                                 })
                                 for _, mod in ipairs(creatureMods) do
+                                    mod.isAfterRoll = true
                                     m_afterRollModifierEntries[#m_afterRollModifierEntries + 1] = mod
                                 end
                             end
@@ -3961,6 +4079,7 @@ function GameHud.CreateEmbeddedRollDialog()
                                                     modifier = modifier,
                                                     context  = modContext,
                                                     hint     = hint,
+                                                    isAfterRoll = true,
                                                 }
                                             end
                                         end


### PR DESCRIPTION
## Summary
- Adds a new **Conditional After Power Roll** activation type for Modify Power Roll behaviors, enabling modifiers that evaluate GoblinScript conditions after dice land (e.g., Expert Fencer granting 3 surges when natural roll >= 17 and tier = 3)
- New creature method `GetAfterRollModifiersForPowerRoll` collects after-roll modifiers from active creature modifiers
- Post-roll modifier injection in the roll dialog's pending callback and RecalculateMultiTargets, with live re-evaluation when boons/banes are toggled
- Fixes Lua 0-truthiness bug where `naturalRoll = 0` for manual/forced rolls caused condition checks to always fail
- Fixes stale `rollInfo.total` on re-rolls by storing the non-dice modifier offset and recomputing the corrected total

## Test plan
- [ ] Open Expert Fencer (duelist 9th-level) in Compendium -- confirm Conditional After Power Roll fields are populated
- [ ] Type "19" manually in roll box -- modifier checkbox should appear (naturalRoll fix)
- [ ] Type "19" with double bane, roll -- modifier hidden (tier 2). Remove banes -- modifier appears (tier 3)
- [ ] Roll naturally, get 17+ -- modifier appears (no regression)
- [ ] Click re-roll -- dice display updates correctly (stale total fix)
- [ ] Roll < 17 naturally -- modifier does not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)