### PR TITLE
Fix StealAbility abilityFilter not resolving Used Ability symbol

### DIFF
--- a/Draw Steel Ability Behaviors/AbilityStealAbility.lua
+++ b/Draw Steel Ability Behaviors/AbilityStealAbility.lua
@@ -55,7 +55,15 @@ function ActivatedAbilityStealAbilityBehavior:EditorItems(parentPanel)
                             "Caster.Name = 'Bob'",
                             "Caster.Level > 5",
                         },
-                    }
+                    },
+                    usedability = {
+                        name = "Used Ability",
+                        type = "ability",
+                        desc = "The ability that triggered this steal, if fired from a triggered ability.",
+                        examples = {
+                            "Ability.Name = Used Ability.Name",
+                        },
+                    },
                 }
             }
         }
@@ -209,6 +217,7 @@ function ActivatedAbilityStealAbilityBehavior:Cast(ability, casterToken, targets
                 local symbols = {
                     ability = a,
                     caster = casterToken.properties,
+                    usedability = options ~= nil and options.symbols ~= nil and options.symbols.usedability or nil,
                 }
                 passesFilter = GoblinScriptTrue(ExecuteGoblinScript(filter, targetCreature:LookupSymbol(symbols), 0, "Steal Ability Filter"))
             end


### PR DESCRIPTION
## Summary

- `ActivatedAbilityStealAbilityBehavior:Cast` built its filter symbol table with only `ability` and `caster`, so any `abilityFilter` expression referencing `Used Ability` (e.g. when the behavior is used inside a `targetwithability` triggered ability) resolved to nil and produced a blank list
- The trigger event context already carries `usedability` through the full call chain into `options.symbols` by the time behavior Cast methods run — this change threads it into the filter symbol table
- Also adds `Used Ability` to the `EditorItems` documentation so it appears as a known symbol in the GoblinScript editor tooltip

The intended filter expression for triggered abilities like Absorption is now:
```
Ability.Name = Used Ability.Name
```

## Test plan

- [ ] Equip the Absorption armor on a hero token
- [ ] Have an enemy cast a single-target magic or psionic ability targeting the hero
- [ ] The triggered Absorption action fires; when used, the Steal Ability dialog should show exactly one ability (the one just cast)
- [ ] Confirm the stolen ability can be used and fires correctly
- [ ] Confirm that a StealAbility behavior with no `abilityFilter` still shows all abilities as before (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)