### PR TITLE
Fix saveendseffects GoblinScript symbol always returning false

### DIFF
--- a/Draw Steel Core Rules/MCDMCreature.lua
+++ b/Draw Steel Core Rules/MCDMCreature.lua
@@ -1351,10 +1351,16 @@ creature.RegisterSymbol {
     lookup = function(c)
         if c:has_key("inflictedConditions") then
             local conditions = c.inflictedConditions
-            for _, cond in ipairs(conditions) do
+            for _, cond in pairs(conditions) do
                 if cond.duration == "save" then
                     return true
                 end
+            end
+        end
+
+        for _, effectInstance in ipairs(c:ActiveOngoingEffects()) do
+            if effectInstance.removeOnSave then
+                return true
             end
         end
 


### PR DESCRIPTION
## Summary

- `inflictedConditions` is a dictionary keyed by condition ID, but the symbol was iterating it with `ipairs` (which only works on numeric arrays), so it always iterated nothing and returned false
- Added a check for active ongoing effects with `removeOnSave`, which are the other class of save ends effects (matching how `MCDMAbilitySaveBehavior` detects them)

## Test plan

- Apply a save ends condition (e.g. bleeding) to a token and verify the `saveendseffects` GoblinScript symbol returns true
- Apply a save ends ongoing effect to a token and verify the same
- Verify a token with no save ends effects returns false