### PR TITLE
Fix crash when imbuement item in inventory with Character Inspector open and add support for imbuements to replace their pre-req

### DIFF
--- a/Draw Steel Core Rules/DSImbuement.lua
+++ b/Draw Steel Core Rules/DSImbuement.lua
@@ -6,9 +6,12 @@
 --- @field imbueTargetType string The equipment type this imbuement applies to: "armor", "implement", or "weapon".
 --- @field imbueLevel number Imbuement tier level (1, 5, or 9 correspond to kit tiers).
 --- @field imbuePrereq nil|string Id of a prerequisite imbuement that must already be applied.
+--- @field imbueReplacesPrereq boolean If true, applying this imbuement removes the prerequisite's features from the target item.
 --- @field features table[] Features/modifiers applied to the target item when imbued.
 --- Represents an imbuement: a magical enhancement that can be applied to a mundane item.
 DSImbuement = RegisterGameType("DSImbuement")
+
+DSImbuement.imbueReplacesPrereq = false
 
 --- Create a unique mundane item to be imbued
 --- @param itemType "armor"|"implement"|"weapon"
@@ -40,6 +43,33 @@ function DSImbuement.CreateMundaneItem(itemType)
     dmhub.SetAndUploadTableItem(equipment.tableName, item)
 
     return item
+end
+
+--- Remove features contributed by a specific imbuement from targetItem,
+--- and clean up the imbuements tracking table entry.
+--- @param targetItem equipment
+--- @param imbueId string
+--- @param imbuements table
+local function _removeImbuementFromItem(targetItem, imbueId, imbuements)
+    local imbueObj = dmhub.GetTable(equipment.tableName)[imbueId]
+    if imbueObj then
+        for _,oldFeature in ipairs(imbueObj:try_get("features", {})) do
+            for i,itemFeature in ipairs(targetItem:try_get("features", {})) do
+                if itemFeature.guid == oldFeature.guid then
+                    table.remove(targetItem.features, i)
+                    break
+                end
+            end
+        end
+    end
+    imbuements[imbueId] = nil
+    local byLevel = imbuements.byLevel or {}
+    for level, id in pairs(byLevel) do
+        if id == imbueId then
+            byLevel[level] = nil
+            break
+        end
+    end
 end
 
 --- Determine whether the imbuement can be applied to the target
@@ -104,6 +134,21 @@ function DSImbuement.ImbueItem(imbueItem, targetItem)
                 end
             end
         end
+    end
+
+    -- If this imbuement replaces its prereq, recursively remove
+    -- the prereq and any imbuements it also replaced.
+    if imbueItem:try_get("imbueReplacesPrereq", false) and prereq and prereq ~= "none" then
+        local function removeChain(chainId)
+            if chainId == nil or chainId == "none" then return end
+            if imbuements[chainId] ~= true then return end
+            local chainObj = dmhub.GetTable(equipment.tableName)[chainId]
+            if chainObj and chainObj:try_get("imbueReplacesPrereq", false) then
+                removeChain(chainObj:try_get("imbuePrereq"))
+            end
+            _removeImbuementFromItem(targetItem, chainId, imbuements)
+        end
+        removeChain(prereq)
     end
 
     -- Apply the imbuement's features

--- a/Draw Steel Core Rules/MCDMCreature.lua
+++ b/Draw Steel Core Rules/MCDMCreature.lua
@@ -1097,7 +1097,7 @@ creature.RegisterSymbol{
         -- Count equipped magic items
         for _, itemid in ipairs(self:EquipmentInUse()) do
             local item = gearTable[itemid]
-            if item ~= nil and item.keywords["Magic"] then
+            if item ~= nil and item:try_get("keywords", {})["Magic"] then
                 count = count + 1
             end
         end
@@ -1105,7 +1105,7 @@ creature.RegisterSymbol{
         -- Count carried (inventory) magic items
         for itemid, info in pairs(self:try_get("inventory", {})) do
             local item = gearTable[itemid]
-            if item ~= nil and item.keywords["Magic"] then
+            if item ~= nil and item:try_get("keywords", {})["Magic"] then
                 count = count + (info.quantity or 1)
             end
         end

--- a/Draw Steel UI/DSInventoryEditor.lua
+++ b/Draw Steel UI/DSInventoryEditor.lua
@@ -849,6 +849,26 @@ function DataTables.tbl_Gear.GenerateEditor(document, options)
             },
 
             FormPanel {
+                text = "Replaces Prerequisite:",
+                collapse = function()
+                    return not EquipmentCategory.IsImbuement(document)
+                        or document:try_get("imbuePrereq", "none") == "none"
+                end,
+
+                child = gui.Check {
+                    text = "Replaces benefit of prerequisite",
+                    value = document:try_get("imbueReplacesPrereq", false),
+                    refresh = function(element)
+                        element.value = document:try_get("imbueReplacesPrereq", false)
+                    end,
+                    change = function(element)
+                        document.imbueReplacesPrereq = element.value
+                        Refresh()
+                    end,
+                },
+            },
+
+            FormPanel {
                 text = '',
                 dmOnly = true,
                 child = gui.Check {


### PR DESCRIPTION
## Summary

- Accessing `item.keywords` directly in the `magictreasurecount` GoblinScript symbol raised `Attempt to read unknown field keywords in type equipment` when iterating over `DSImbuement` items, which don't declare a `keywords` field
- Replaced both direct accesses with `item:try_get("keywords", {})["Magic"]`, matching the safe pattern already used in `Equipment.lua`
- Affects both the equipped items loop and the inventory loop in the symbol's `lookup` function

## Repro

1. Add an imbuement item to a token's inventory or equipment slot
2. Open the Character Inspector dev panel
3. Click the token -- error is logged repeatedly

## Test plan

- [ ] Add an imbuement item to a token's inventory/equipment
- [ ] Open Character Inspector and click the token -- no error
- [ ] Confirm tokens with actual magic treasure (keywords containing "Magic") still report correct `magictreasurecount`

🤖 Generated with [Claude Code](https://claude.com/claude-code)