### PR TITLE
Compendium inventory filter: fix blank items and add category search

### DIFF
--- a/DMHub Compendium/ItemCompendium.lua
+++ b/DMHub Compendium/ItemCompendium.lua
@@ -173,16 +173,21 @@ mod.shared.InventoryCompendiumEditor = function(categories)
 							end
 
 							local match = true
+							local cat = catsTable[item:try_get("equipmentCategory", "")]
+							local catName = cat ~= nil and string.lower(cat.name) or ""
 							for _,term in ipairs(searchTerms) do
 								if match then
 									match = false
-									if TextSearch(item.name, term) then
+									if TextSearch(item.name, term) or TextSearch(catName, term) then
 										match = true
 									end
 								end
 							end
-						
+
 							element:SetClass("collapsed", not match)
+							if match and element.data.init == false then
+								element:FireEvent("expose")
+							end
 						end,
 
 						expose = function(element)


### PR DESCRIPTION
## Summary

- **Fix blank/black items after filtering**: Items lazily initialised via `expose` were never getting their children built (name label, category label, settings button) when they came into view after a search collapsed the items above them. The fix fires `expose` explicitly on any matching-but-uninitialised item panel after the collapsed state is resolved.
- **Category name search**: Extends the filter to also match against the item's equipment category name, so typing e.g. `weapon` or `armor` in the filter bar shows all items of that type.

## Test plan

- [ ] Open Compendium > Inventory and type a search term that matches items near the bottom of the alphabetical list (off-screen at load time) — confirm they render correctly (name, category, settings button visible, not black/blank)
- [ ] Type a category name (e.g. `weapon`, `armor`) — confirm only items of that type are shown
- [ ] Type an item name — confirm name-based search still works
- [ ] Clear the search — confirm the full list restores correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)