### PR TITLE
ModifyPowerRoll: Add vertical movement support to adjustments

### DIFF
--- a/Draw Steel Core Rules/MCDModifyPowerRolls.lua
+++ b/Draw Steel Core Rules/MCDModifyPowerRolls.lua
@@ -779,7 +779,13 @@ CharacterModifier.TypeInfo.power = {
                     local adj = ExecuteGoblinScript(adjustment.value, lookupFunction, 1, "Determine adjustment")
                     local value = safe_toint(match.value)
                     local newValue = math.max(0, value + (adj or 0))
-                    rollProperties.tiers[j] = string.format("%s%s %d%s", match.prefix, match.type, newValue, match.postfix)
+                    local prefix = match.prefix
+                    local typeOutput = match.type
+                    if self:try_get("vertical", false) and adjustment.type ~= "jump" then
+                        prefix = regex.ReplaceAll(prefix, "vertical\\s+$", "")
+                        typeOutput = "vertical " .. adjustment.type
+                    end
+                    rollProperties.tiers[j] = string.format("%s%s %d%s", prefix, typeOutput, newValue, match.postfix)
                 end
             end
         end
@@ -2060,6 +2066,35 @@ CharacterModifier.TypeInfo.power = {
                 },
             }
 
+            local hasVerticalAdjustment = false
+            for _,adj in ipairs(modifier:try_get("adjustments", {})) do
+                if adj.type == "push" or adj.type == "pull" or adj.type == "slide" then
+                    hasVerticalAdjustment = true
+                    break
+                end
+            end
+
+            children[#children+1] = gui.Panel{
+                classes = {"formPanel", cond(not hasVerticalAdjustment, "collapsed-anim")},
+                gui.Label{
+                    classes = {"formLabel"},
+                    text = "",
+                },
+                gui.Check{
+                    style = {
+                        height = 30,
+                        width = 160,
+                        fontSize = 18,
+                        halign = "left",
+                    },
+                    text = "Add Vertical",
+                    value = modifier:try_get("vertical", false),
+                    change = function(element)
+                        modifier.vertical = element.value
+                        Refresh()
+                    end,
+                },
+            }
 
             children[#children+1] = gui.Panel{
                 classes = {"formPanel", cond(modifier.rollType == "project_roll", "collapsed-anim")},


### PR DESCRIPTION
## Summary

- Adds an **Add Vertical** checkbox to the Modify Power Roll modifier's adjustments section
- When enabled, push/pull/slide adjustments prepend `vertical` to the movement type in power roll tier text (e.g. `push 3` becomes `vertical push 6`)
- Handles tier text that already contains `vertical` without duplicating it
- The checkbox only appears when at least one push, pull, or slide adjustment is present — hidden when only jump adjustments exist
- Jump adjustments are unaffected by the vertical flag

Implemented to support the **Forceful III** imbuement: *whenever you use a magic or psionic ability to push or pull a creature, you can move that creature an additional 3 squares and that movement can be vertical.*

## Test plan

- [ ] Open a Modify Power Roll modifier and add a push adjustment — confirm **Add Vertical** checkbox appears
- [ ] Add only a jump adjustment — confirm checkbox is hidden
- [ ] Enable Add Vertical with a push +3 adjustment and use an ability with `push 3` in a tier — confirm output is `vertical push 6`
- [ ] Confirm an ability already containing `vertical push 3` becomes `vertical push 6` (no duplication)
- [ ] Confirm existing adjustments without vertical enabled are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)