### PR TITLE
Condition Details: increase character limit to 600

### DIFF
--- a/DMHub Game Rules/Condition.lua
+++ b/DMHub Game Rules/Condition.lua
@@ -283,6 +283,7 @@ local SetData = function(tableName, conditionPanel, condid)
 		gui.Input{
 			text = condition.description,
 			multiline = true,
+			characterLimit = 600,
 			minHeight = 50,
 			height = 'auto',
 			width = 400,


### PR DESCRIPTION
## Summary
- The Details field on the Compendium Conditions editor was silently truncating text at the DMHub engine's default character limit (~256 chars)
- Long condition descriptions like Unconscious were cut off mid-sentence
- Added `characterLimit = 600` to the `gui.Input` in `DMHub Game Rules/Condition.lua`

## Test plan
- [ ] Open DMHub and navigate to Compendium > Conditions > Unconscious
- [ ] Confirm the full description is displayed without truncation
- [ ] Confirm text input beyond 256 characters is accepted up to 600

🤖 Generated with [Claude Code](https://claude.com/claude-code)