### PR TITLE
Fix jump distance not counting towards movement this turn

### DIFF
--- a/DMHub Game Rules/AbilityRelocateCreature.lua
+++ b/DMHub Game Rules/AbilityRelocateCreature.lua
@@ -147,6 +147,9 @@ function ActivatedAbilityRelocateCreatureBehavior:Cast(ability, casterToken, tar
         elseif movementType == "jump" then
             print("JUMP:: TARGET =", targets[1].loc.floor)
 		    local path = casterToken:Move(targets[#targets].loc, { ignoreFalling = true, straightline = true, moveThroughFriends = true, ignorecreatures = true, maxCost = 30000, movementType = "jump" })
+            if path ~= nil then
+                options.symbols.cast.spacesMoved = options.symbols.cast.spacesMoved + path.numSteps
+            end
 		else
 
             if options.symbols.invoker ~= nil then


### PR DESCRIPTION
## Summary
- Jump movement was calling `casterToken:Move()` but never updating `options.symbols.cast.spacesMoved` with the resulting path distance
- This meant `jumpDistance` was always 0 in the `^jump` behavior, so `moveDistance` (and thus `DistanceMovedThisTurn()` / the `movedthisturn` GoblinScript symbol) was never incremented
- Added the same `path.numSteps` update that teleport and forced movement already use

## Test plan
- [ ] Use a Jump ability mid-turn and verify the movement tracker shows the jump distance consumed
- [ ] Verify the `movedthisturn` GoblinScript symbol reflects jumps
- [ ] Verify you can't jump further than your remaining movement speed allows