### PR TITLE
Fix cast.tier always nil in useability trigger condition

### DIFF
--- a/DMHub Game Rules/ActivatedAbility.lua
+++ b/DMHub Game Rules/ActivatedAbility.lua
@@ -1550,11 +1550,11 @@ function ActivatedAbility:FireUseAbility(casterToken, options)
 			}
 		end
 
-        casterToken.properties:DispatchEvent("useability", {usedability = self, cast = options.cast})
+        casterToken.properties:DispatchEvent("useability", {usedability = self, cast = options.symbols and options.symbols.cast})
 
         for _,target in ipairs(options.targets or {}) do
             if target.token ~= nil then
-                casterToken.properties:DispatchEvent("targetwithability", {usedability = self, cast = options.cast, target = target.token.properties})
+                casterToken.properties:DispatchEvent("targetwithability", {usedability = self, cast = options.symbols and options.symbols.cast, target = target.token.properties})
             end
         end
 	end


### PR DESCRIPTION
## Summary

- `options.cast` does not exist anywhere in the codebase; the cast object with tier data lives at `options.symbols.cast`
- This caused GoblinScript conditions like `cast.tier = 3` on the **Use an Ability** trigger to always evaluate to `0` (false), so the trigger debugger would report \"Trigger condition failed\" even when the correct tier was rolled
- Fixed both the `useability` and `targetwithability` event dispatches in `FireUseAbility` to pass `options.symbols.cast`, matching the pattern already used in the `castsignature` dispatch in `MCDMRules.lua`

## Test plan

- [ ] Add a triggered ability to a hero or monster with trigger **Use an Ability**, subject **Self**, and condition formula `cast.tier = 3`
- [ ] Use an ability and force the power roll result to tier 3 via the override button
- [ ] Verify the trigger fires (previously it would fail the condition check)
- [ ] Verify tiers 1 and 2 do not fire the trigger when condition is `cast.tier = 3`
- [ ] Verify the trigger debugger no longer shows \"Trigger condition failed\" for a matching tier

🤖 Generated with [Claude Code](https://claude.com/claude-code)