### PR TITLE
Add Common Ability category with dedicated action menu section

### DIFF
--- a/Draw Steel Core Rules/MCDMRules.lua
+++ b/Draw Steel Core Rules/MCDMRules.lua
@@ -860,19 +860,21 @@ GameSystem.RegisterAbilityCategorization{category = "Heroic Ability", grouping =
 GameSystem.RegisterAbilityCategorization{category = "Villain Action", grouping = "Villain Actions"}
 GameSystem.RegisterAbilityCategorization{category = "Malice", grouping = "Malice Abilities"}
 GameSystem.RegisterAbilityCategorization{category = "Signature Ability", grouping = "Signature Abilities"}
-GameSystem.RegisterAbilityCategorization{category = "Ability", grouping = "Common Abilities"}
+GameSystem.RegisterAbilityCategorization{category = "Common Ability", grouping = "Common Abilities"}
+GameSystem.RegisterAbilityCategorization{category = "Ability", grouping = "Abilities"}
 GameSystem.RegisterAbilityCategorization{category = "Trigger", grouping = "Triggers"}
-GameSystem.RegisterAbilityCategorization{category = "Skill", grouping = "Common Abilities"}
+GameSystem.RegisterAbilityCategorization{category = "Skill", grouping = "Abilities"}
 GameSystem.RegisterAbilityCategorization{category = "Basic Attack", grouping = "Common Abilities"}
 GameSystem.RegisterAbilityCategorization{category = "Move", grouping = "Move"}
-GameSystem.RegisterAbilityCategorization{category = "Hidden", grouping = "Common Abilities"}
+GameSystem.RegisterAbilityCategorization{category = "Hidden", grouping = "Abilities"}
 
 GameSystem.ActionBarGroupings = {
     ["Heroic Abilities"] = 1,
     ["Malice Abilities"] = 2,
     ["Signature Abilities"] = 3,
-    ["Common Abilities"] = 4,
-    ["Triggers"] = 5,
+    ["Abilities"] = 4,
+    ["Common Abilities"] = 5,
+    ["Triggers"] = 6,
 }
 
 function GameSystem.GetAbilityCategoryInfo(category)
@@ -2331,19 +2333,21 @@ GameSystem.RegisterAbilityCategorization{category = "Heroic Ability", grouping =
 GameSystem.RegisterAbilityCategorization{category = "Villain Action", grouping = "Villain Actions"}
 GameSystem.RegisterAbilityCategorization{category = "Malice", grouping = "Malice Abilities"}
 GameSystem.RegisterAbilityCategorization{category = "Signature Ability", grouping = "Signature Abilities"}
-GameSystem.RegisterAbilityCategorization{category = "Ability", grouping = "Common Abilities"}
+GameSystem.RegisterAbilityCategorization{category = "Common Ability", grouping = "Common Abilities"}
+GameSystem.RegisterAbilityCategorization{category = "Ability", grouping = "Abilities"}
 GameSystem.RegisterAbilityCategorization{category = "Trigger", grouping = "Triggers"}
-GameSystem.RegisterAbilityCategorization{category = "Skill", grouping = "Common Abilities"}
+GameSystem.RegisterAbilityCategorization{category = "Skill", grouping = "Abilities"}
 GameSystem.RegisterAbilityCategorization{category = "Basic Attack", grouping = "Common Abilities"}
 GameSystem.RegisterAbilityCategorization{category = "Move", grouping = "Move"}
-GameSystem.RegisterAbilityCategorization{category = "Hidden", grouping = "Common Abilities"}
+GameSystem.RegisterAbilityCategorization{category = "Hidden", grouping = "Abilities"}
 
 GameSystem.ActionBarGroupings = {
     ["Heroic Abilities"] = 1,
     ["Malice Abilities"] = 2,
     ["Signature Abilities"] = 3,
-    ["Common Abilities"] = 4,
-    ["Triggers"] = 5,
+    ["Abilities"] = 4,
+    ["Common Abilities"] = 5,
+    ["Triggers"] = 6,
 }
 
 function GameSystem.GetAbilityCategoryInfo(category)

--- a/DrawSteelActionBar/DrawSteelActionBar.lua
+++ b/DrawSteelActionBar/DrawSteelActionBar.lua
@@ -1924,7 +1924,7 @@ ActionMenu = function()
             local abilitiesByGrouping = {}
 
             for _, ability in ipairs(abilities) do
-                local grouping = GameSystem.GetAbilityCategoryInfo(ability.categorization).grouping or "Common Abilities"
+                local grouping = GameSystem.GetAbilityCategoryInfo(ability.categorization).grouping or "Abilities"
                 if grouping == "Common Abilities" and ability.actionResourceId == CharacterResource.freeManeuverResourceId then
                     grouping = "Free Maneuvers"
                 end


### PR DESCRIPTION
## Summary

- Adds a new **Common Ability** category option in the ability editor dropdown
- Abilities assigned **Common Ability** appear under a new **Common Abilities** section in the action menu
- Renames the old **Common Abilities** section to **Abilities** (covers Skill, Ability, Hidden categories)
- **Basic Attack** is grouped into **Common Abilities** alongside the new category
- Section order in the action menu: Heroic Abilities → Malice Abilities → Signature Abilities → Abilities → Common Abilities → Triggers

## Test plan

- [ ] Open the ability editor — verify "Common Ability" appears in the Category dropdown
- [ ] Assign an ability to "Common Ability" — verify it appears under "Common Abilities" in the action menu
- [ ] Verify existing Skill/Ability/Hidden abilities now appear under "Abilities" section
- [ ] Verify Basic Attack abilities appear under "Common Abilities"
- [ ] Verify section ordering matches the intended order above