### PR TITLE
Fix crash in CustomAttribute:CalculateBaseValue when typeInfo is nil

### DIFF
--- a/DMHub Game Rules/CustomAttribute.lua
+++ b/DMHub Game Rules/CustomAttribute.lua
@@ -313,6 +313,9 @@ end
 
 function CustomAttribute:CalculateBaseValue(creature)
 	local typeInfo = self.GetAttributeType(self.id)
+	if typeInfo == nil then
+		return nil
+	end
 	if type(self.baseValue) == "string" and trim(self.baseValue) == "" then
 		return typeInfo:DefaultValue()
 	end


### PR DESCRIPTION
## Summary

- `CustomAttribute.GetAttributeType` returns `nil` when no attribute type is registered for a given ID (and already prints a warning to the log)
- `CalculateBaseValue` was not guarding against this, crashing with `attempt to index a nil value (local 'typeInfo')` on every call
- Added an early `return nil` when `typeInfo` is nil, stopping the crash and the cascade of unattached panel errors that followed