### PR TITLE
Add Artifact equipment category type

### DIFF
--- a/DMHub Compendium/Compendium.lua
+++ b/DMHub Compendium/Compendium.lua
@@ -3197,6 +3197,18 @@ local ShowEquipmentCategoriesPanel = function(parentPanel)
 			end,
 		}
 
+		--whether items in this category are artifacts (equip in leveled treasure slots, no project fields).
+		children[#children+1] = gui.Check{
+			text = "Is Artifact",
+			halign = "left",
+			fontSize = 22,
+			value = data:try_get("isArtifact", false),
+			change = function(element)
+				data.isArtifact = element.value
+				UploadData()
+			end,
+		}
+
 		--whether items in this category are packs of items.
 		children[#children+1] = gui.Check{
 			text = "Equipment Packs",

--- a/DMHub Game Rules/EquipmentCategory.lua
+++ b/DMHub Game Rules/EquipmentCategory.lua
@@ -47,6 +47,7 @@ EquipmentCategory.isQuantity = false
 EquipmentCategory.isTreasure = false
 EquipmentCategory.isPacks = false
 EquipmentCategory.isLightSource = false
+EquipmentCategory.isArtifact = false
 
 EquipmentCategory.martialWeaponCategories = {}
 EquipmentCategory.meleeWeaponCategories = {}
@@ -279,7 +280,9 @@ end
 
 function EquipmentCategory.IsEquippable(item)
     local cat = item:try_get("equipmentCategory", "")
-    return cat == EquipmentCategory.LeveledTreasureId or cat == EquipmentCategory.TrinketId
+    return cat == EquipmentCategory.LeveledTreasureId
+        or cat == EquipmentCategory.TrinketId
+        or EquipmentCategory.IsArtifact(item)
 end
 
 function EquipmentCategory.IsLeveledTreasure(item)
@@ -290,6 +293,14 @@ end
 function EquipmentCategory.IsTrinket(item)
     local cat = item:try_get("equipmentCategory", "")
     return cat == EquipmentCategory.TrinketId
+end
+
+function EquipmentCategory.IsArtifact(item)
+    local catId = item:try_get("equipmentCategory", "")
+    if catId == "" then return false end
+    local cats = dmhub.GetTable("equipmentCategories") or {}
+    local cat = cats[catId]
+    return cat ~= nil and cat:try_get("isArtifact", false)
 end
 
 function EquipmentCategory.IsTreasure(item)

--- a/Draw Steel Inventory/DrawSteelInventory.lua
+++ b/Draw Steel Inventory/DrawSteelInventory.lua
@@ -376,7 +376,7 @@ local CreateInventorySlot = function(dmhud, options)
 
                 if slotInfo.type == "trinket" and EquipmentCategory.IsTrinket(item) then
                     return true
-                elseif slotInfo.type == "leveled" and EquipmentCategory.IsLeveledTreasure(item) then
+                elseif slotInfo.type == "leveled" and (EquipmentCategory.IsLeveledTreasure(item) or EquipmentCategory.IsArtifact(item)) then
                     return true
                 end
 


### PR DESCRIPTION
## Summary

- Adds a new `isArtifact` boolean flag to `EquipmentCategory`, exposed as an **Is Artifact** checkbox in the Equipment Categories editor
- Artifact items equip into **Leveled Treasure** slots (not Trinket slots)
- Artifact items show the standard Gear editor fields (Name, Description, Cost, Keywords, Custom Feature) but omit the five project/treasure-specific fields: Echelon, Item Prerequisite, Project Source, Project Roll Characteristic, and Project Goal
- `IsArtifact` uses a live table lookup rather than a cached set, so newly created Artifact categories work without requiring a game reload

## Files changed

- `DMHub Game Rules/EquipmentCategory.lua` — `isArtifact` default field, `IsArtifact()` predicate, updated `IsEquippable()`
- `DMHub Compendium/Compendium.lua` — "Is Artifact" checkbox in the Equipment Categories editor
- `Draw Steel Inventory/DrawSteelInventory.lua` — Artifact items accepted by leveled treasure slots

## Setup

After deploying, create a new entry under **Compendium → Rules → Equipment Categories**, set Editor Type to **Gear**, and check **Is Artifact**. The category will then appear in the item Type dropdown.

## Test plan

- [ ] Create an Artifact category in Equipment Categories with Is Artifact checked
- [ ] Create a new item with Type set to Artifact — confirm Echelon, Item Prerequisite, Project Source, Project Roll Characteristic, and Project Goal do not appear
- [ ] Confirm Add Custom Feature / Add Magical Property is available
- [ ] Drag an Artifact item onto a Leveled Treasure slot — confirm it equips
- [ ] Confirm Artifact items cannot be dragged into Trinket slots

🤖 Generated with [Claude Code](https://claude.com/claude-code)