### PR TITLE
Increase power roll tier character limit to 350

### DIFF
--- a/Draw Steel Core Rules/MCDMAbilityRollBehavior.lua
+++ b/Draw Steel Core Rules/MCDMAbilityRollBehavior.lua
@@ -1888,7 +1888,7 @@ function ActivatedAbilityPowerRollBehavior:EditorItems(parentPanel)
             gui.Label{ fontSize = 24, text = tier, fontFace = "DrawSteelGlyphs" },
             gui.Input{
                 text = self.tiers[i],
-                characterLimit = 256,
+                characterLimit = 350,
                 halign = "right",
                 change = function(element)
                     self.tiers[i] = element.text


### PR DESCRIPTION
Increases character limit for Ability Power Roll tier text inputs from 256 to 350 characters