### PR TITLE
Fix nil crash when shape has no locations in maphover

### DIFF
--- a/Draw Steel Core Rules/MCDMAbilityRollBehavior.lua
+++ b/Draw Steel Core Rules/MCDMAbilityRollBehavior.lua
@@ -1888,7 +1888,7 @@ function ActivatedAbilityPowerRollBehavior:EditorItems(parentPanel)
             gui.Label{ fontSize = 24, text = tier, fontFace = "DrawSteelGlyphs" },
             gui.Input{
                 text = self.tiers[i],
-                characterLimit = 256,
+                characterLimit = 350,
                 halign = "right",
                 change = function(element)
                     self.tiers[i] = element.text

--- a/DrawSteelActionBar/DrawSteelActionBar.lua
+++ b/DrawSteelActionBar/DrawSteelActionBar.lua
@@ -4503,6 +4503,7 @@ CreateAbilityController = function()
                     end
 
                     local locs = g_pointTargeting.shape.locations
+                    if #locs == 0 then return end
                     local point = locs[1].withGroundAltitude.point3
                     local minx = point.x
                     local miny = point.y

--- a/Timeline/AbilitySidebar.lua
+++ b/Timeline/AbilitySidebar.lua
@@ -1155,7 +1155,9 @@ function GameHud:InitAbilityDisplayPanel(abilityDisplayPanel)
                     { token = token, symbols = symbols, width = 346, bgcolor = "#222222e9", })
                 --Shwayguy: Entire panel cannot be made non-interactive
                 --Implementation chip hover requires it
-                panel:MakeNonInteractiveRecursive()
+                if panel ~= nil then
+                    panel:MakeNonInteractiveRecursive()
+                end
             end
 
             if panel == nil then


### PR DESCRIPTION
## Summary
- Fixes a crash in `DrawSteelActionBar.lua` when `g_pointTargeting.shape.locations` is empty — added early return guard before indexing `locs[1]`
- Fixes a crash in `AbilitySidebar.lua` when `CreateAbilityTooltip` returns nil during an invoked ability — guard `MakeNonInteractiveRecursive()` call

## Errors fixed

**DrawSteelActionBar:**
```
attempt to index a nil value (field 'integer index')
DrawSteelActionBar.lua:4506
```

**AbilitySidebar:**
```
attempt to index a nil value (local 'panel')
AbilitySidebar.lua:1158
```