### PR TITLE
Add EoT Effects symbol, Subject to mode conditions, and prone to purge chosen

### DIFF
--- a/DMHub Compendium/ActivatedAbilityEditor.lua
+++ b/DMHub Compendium/ActivatedAbilityEditor.lua
@@ -1683,6 +1683,13 @@ function ActivatedAbility:TargetTypeEditor()
 									},
 									subject = creature.helpSymbols,
 									subjectDescription = "The creature using the ability.",
+									symbols = {
+										subject = {
+											name = "Subject",
+											type = "creature",
+											desc = "The creature that the event occurred on. For triggered abilities this is the creature that triggered the event; for self-only triggers this is the same as Self.",
+										},
+									},
 								},
 							},
 

--- a/DMHub Game Rules/AbilityPurgeEffects.lua
+++ b/DMHub Game Rules/AbilityPurgeEffects.lua
@@ -701,6 +701,12 @@ function ActivatedAbilityPurgeEffectsBehavior:CollectPurgeItems(targetToken, lim
                         break
                     end
                 end
+                if not passFilter and self:try_get("includeProne") then
+                    local condDef = conditionsTable[key]
+                    if condDef ~= nil and string.lower(condDef.name) == "prone" then
+                        passFilter = true
+                    end
+                end
                 local casterOk = limitToCasterid == nil
                 if not casterOk and conditionInfo.casterInfo ~= nil then
                     casterOk = conditionInfo.casterInfo.tokenid == limitToCasterid
@@ -805,6 +811,12 @@ function ActivatedAbilityPurgeEffectsBehavior:CollectPurgeItems(targetToken, lim
                             if durationEntry == "all" or string.lower(durationEntry) == string.lower(conditionInfo.duration or "") then
                                 passFilter = true
                                 break
+                            end
+                        end
+                        if not passFilter and self:try_get("includeProne") then
+                            local condDef = conditionsTable[key]
+                            if condDef ~= nil and string.lower(condDef.name) == "prone" then
+                                passFilter = true
                             end
                         end
                         local casterOk = limitToCasterid == nil
@@ -2357,6 +2369,18 @@ function ActivatedAbilityPurgeEffectsBehavior:EditorItems(parentPanel)
         },
     }
 
+
+    result[#result+1] = gui.Check{
+        classes = {cond(self.purgeType ~= "chosen", "collapsed")},
+        text = "Include Prone",
+        value = self:try_get("includeProne", false),
+        change = function(element)
+            self.includeProne = element.value
+        end,
+        refreshPurge = function(element)
+            element:SetClass("collapsed", self.purgeType ~= "chosen")
+        end,
+    }
 
     --Future support Shwayguy
     result[#result+1] = gui.Panel{

--- a/Draw Steel Core Rules/MCDMCreature.lua
+++ b/Draw Steel Core Rules/MCDMCreature.lua
@@ -1399,6 +1399,33 @@ creature.RegisterSymbol {
 }
 
 creature.RegisterSymbol {
+    symbol = "eoteffects",
+    lookup = function(c)
+        if c:has_key("inflictedConditions") then
+            local conditions = c.inflictedConditions
+            for _, cond in pairs(conditions) do
+                if cond.duration == "eot" then
+                    return true
+                end
+            end
+        end
+
+        for _, effectInstance in ipairs(c:ActiveOngoingEffects()) do
+            if effectInstance.removeAtNextTurnEnd then
+                return true
+            end
+        end
+
+        return false
+    end,
+    help = {
+        name = "EoT Effects",
+        type = "boolean",
+        desc = "Does this creature have any end of turn effects?",
+    }
+}
+
+creature.RegisterSymbol {
     symbol = "leader",
     lookup = function(c)
         return string.find(string.lower(c:try_get("role", "")), "leader") ~= nil


### PR DESCRIPTION
## Summary
Fix for My Life For Yours:
- **EoT Effects GoblinScript symbol** (`eoteffects`) — mirrors the existing `saveendseffects` symbol; returns `true` when the creature has any end-of-turn inflicted conditions (`duration == "eot"`) or ongoing effects with `removeAtNextTurnEnd` set.
- **Subject in mode condition docs** — exposes `Subject` in the GoblinScript documentation for triggered ability mode conditions so designers can reference the event subject creature in condition formulas.
- **Include Prone for Purge Chosen Effects** — adds an "Include Prone" checkbox to the Purge Ongoing Effects behavior (visible only when purgeType is "Chosen Effects") that allows prone to appear in the choosable conditions list regardless of its duration, matching the existing behaviour in the Draw Steel Save behavior.

## Test plan

- [ ] Verify `EoT Effects` appears as a symbol in GoblinScript inputs on creature context and returns correctly for creatures with/without EoT effects
- [ ] Open a triggered ability mode condition editor and confirm `Subject` is listed in the GoblinScript symbol help
- [ ] Add a Purge Ongoing Effects behavior set to "Chosen Effects" and confirm "Include Prone" checkbox appears; tick it and verify a prone creature shows Prone in the selection dialog