### PR TITLE
DispatchEventAndWait: fix trigger name mismatch causing dismiss to hang

### DIFF
--- a/Draw Steel Core Rules/MCDMCreature.lua
+++ b/Draw Steel Core Rules/MCDMCreature.lua
@@ -4137,7 +4137,7 @@ function creature:DispatchEventAndWait(eventName, info)
     local modName
     for i, mod in ipairs(mods) do
         if mod.mod:HasTriggeredEvent(self, eventName) then
-            modName = mod.mod.name
+            modName = mod.mod.triggeredAbility.name
             hasTrigger = true
             break
         end


### PR DESCRIPTION
## Summary

- `DispatchEventAndWait` was capturing `modName` from the **CharacterModifier name** (`mod.mod.name`), but `triggerInfo.text` is always set from the **TriggeredAbility name** (`self.name` in TriggeredAbility.lua:1079)
- When modifier name != ability name (e.g. modifier `"Self-Taught Benefit and Drawback"` wrapping ability `"Self-Taught"`), `triggerId` is never found
- The fallback path `if not triggerId then triggerStillExists = true end` then loops forever — dismissing the trigger popup gets stuck and blocks subsequent start-of-turn events (heroic resource roll, etc.)
- The Feat version of the same trigger happened to work because its modifier and ability names are both `"Self-Taught"`

**Fix:** Use `mod.mod.triggeredAbility.name` instead of `mod.mod.name` so the lookup matches what `ActiveTrigger.text` is actually set to.