### PR TITLE
Rename initiative slider options to use Turn Order language

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,3 +190,7 @@ Key stubs:
 - `game.lua` — the `game` global
 - `GameRules.lua` — `GameRules` global
 - `module.lua` — `module` global for mod management
+
+## Editing Files
+
+Always edit files in the **main copy** of the repository (`C:\draw-steel-codex\`), not in any git worktree under `.claude\worktrees\`. Worktrees are used for isolated agent work only; the user works directly from the main copy.

--- a/Draw Steel UI/DSInitiativeRoll.lua
+++ b/Draw Steel UI/DSInitiativeRoll.lua
@@ -1843,9 +1843,9 @@ local function ShowCombatSetupDialog(selectedTokens)
             gui.EnumeratedSliderControl{
                 width = 600,
                 options = {
-                    { id = "heroes", text = "Heroes Win Initiative"},
-                    { id = "roll", text = "Roll for Initiative"},
-                    { id = "monsters", text = "Monsters Win Initiative"},
+                    { id = "heroes", text = "Heroes Win Turn Order"},
+                    { id = "roll", text = "Roll for Turn Order"},
+                    { id = "monsters", text = "Monsters Win Turn Order"},
                 },
 
                 refreshSurprise = function(element)


### PR DESCRIPTION
## Summary
- Changed "Heroes Win Initiative" → "Heroes Win Turn Order"
- Changed "Roll for Initiative" → "Roll for Turn Order"
- Changed "Monsters Win Initiative" → "Monsters Win Turn Order"

## Test plan
- [ ] Open the initiative panel in DMHub and verify the slider shows the updated labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)