### PR TITLE
Respect Maximum Surges custom attribute in roll dialogs

### DIFF
--- a/Draw Steel UI/DSRollDialog.lua
+++ b/Draw Steel UI/DSRollDialog.lua
@@ -1539,7 +1539,7 @@ function GameHud.CreateRollDialog(self)
                 }
 
                 local surges = {}
-                for surgeNum = 3, 1, -1 do
+                for surgeNum = ((creature ~= nil) and creature:GetMaxSurgeCount() or 3), 1, -1 do
                     surges[#surges + 1] = gui.Panel {
                         classes = { "icon", "hideWhenMinimized" },
                         textCalculated = function(element, calculationOptions)
@@ -1786,8 +1786,9 @@ function GameHud.CreateRollDialog(self)
                     surgesOverride = surgesOverride - 1
                 end
 
-                if surgesOverride > 3 then
-                    surgesOverride = 3
+                local maxSurges = (creature ~= nil) and creature:GetMaxSurgeCount() or 3
+                if surgesOverride > maxSurges then
+                    surgesOverride = maxSurges
                 end
 
                 local options = m_lastCalculationOptions or {}

--- a/Timeline/EmbeddedRollDialog.lua
+++ b/Timeline/EmbeddedRollDialog.lua
@@ -2167,7 +2167,7 @@ function GameHud.CreateEmbeddedRollDialog()
                 }
 
                 local surges = {}
-                for surgeNum = 3, 1, -1 do
+                for surgeNum = ((creature ~= nil) and creature:GetMaxSurgeCount() or 3), 1, -1 do
                     surges[#surges + 1] = gui.Panel {
                         classes = { "icon", "hideWhenMinimized" },
                         textCalculated = function(element, calculationOptions)
@@ -2446,8 +2446,9 @@ function GameHud.CreateEmbeddedRollDialog()
                     surgesOverride = surgesOverride - 1
                 end
 
-                if surgesOverride > 3 then
-                    surgesOverride = 3
+                local maxSurges = (creature ~= nil) and creature:GetMaxSurgeCount() or 3
+                if surgesOverride > maxSurges then
+                    surgesOverride = maxSurges
                 end
 
                 local options = m_lastCalculationOptions or {}


### PR DESCRIPTION
## Summary

- Roll dialogs were hardcoding `3` as the max surges cap in two places each: the surge icon press handler and the multi-target surge icon loop
- These bypassed the existing `GetMaxSurgeCount()` function which already reads the **Maximum Surges** custom attribute
- Fixed both `DSRollDialog.lua` and `EmbeddedRollDialog.lua` to call `creature:GetMaxSurgeCount()` instead