### PR TITLE
Add rival ancestries reference document

### DIFF
--- a/rival-ancestries-reference.md
+++ b/rival-ancestries-reference.md
@@ -1,0 +1,44 @@
+# Rival Ancestries Reference
+
+Rivals can be adjusted to more closely model a player character of a specific ancestry. Choose an ancestry from the table below, then modify the rival stat block by:
+
+1. Adding the ancestry **keyword**
+2. Adjusting the **size** as noted
+3. Adding the **stability adjustment** value to the rival's base stability
+4. Giving the rival the **ancestral trait**
+
+## Rival Abilities
+
+Any rival can replace their signature ability with a signature ability a hero has access to. The fury, shadow, and tactician can select a signature ability from any kit (see Chapter 6: Kits in Draw Steel: Heroes), and other rivals can select a signature ability from their respective class. If you replace a rival's signature ability, the replacement ability deals extra damage equal to the rival's level and targets two creatures or objects if the original ability targets only one.
+
+## Rival Languages
+
+Most rivals speak Caelian and two other languages.
+
+---
+
+## Ancestry Table
+
+| Ancestry | Size | Stability Adjustment | Ancestral Trait |
+|---|---|---|---|
+| Devil | 1M | +0 | **Prehensile Tail:** The rival can't be flanked. |
+| Draconian *(for the dragon knight)* | 1M | +1 | **Wings:** The rival can fly. While flying, their stability is 0. |
+| Dwarf | 1M | +2 | **Great Fortitude:** The rival can't be made weakened. |
+| High Elf / Wode Elf | 1M | +0 | **Otherworldly Grace:** At the start of each of their turns, the rival can choose one effect on them that can be ended by a saving throw. That effect instead ends at the end of their turn. |
+| Hakaan | 1L | +2 | **Forceful:** When the rival force moves a creature or object, they can force move them an additional 2 squares. |
+| Human | 1M | +1 | **Determination:** As a maneuver, the rival can end the frightened, slowed, or weakened condition on themself. |
+| Memonek | 1M | -1 *(minimum 0)* | **Nonstop:** The rival can't be made slowed. |
+| Orc | 1M | +2 | **Glowing Recovery:** Once per round, the rival can use a maneuver to regain Stamina equal to 5 times their level. |
+| Polder | 1S | +0 | **Nimblestep:** The rival ignores difficult terrain and can move at full speed while sneaking. |
+| Revenant | 1M | +1 | **Vengeance Mark:** The rival places a magic sigil on an enemy within 10 squares of them. The rival always knows the direction to that enemy while the sigil is active on them. As a main action, the rival can detonate the sigil, dealing damage to the target equal to the rival's free strike and sliding the target up to 2 squares. |
+| Time Raider | 1M | +0 | **Four-Armed Martial Arts:** Whenever the rival uses the Grab or Knockback maneuver, they can target one additional creature. |
+
+---
+
+## Example: The Black Iron Pact *(5th-level rival party, all Human ancestry)*
+
+- **Lord Erasmus Deseo** -- Rival Tactician
+- **Canon Athenodorus** -- Rival Conduit
+- **Cloak** -- Rival Shadow
+- **Lady Avalla Deseo** -- Rival Elementalist
+- **Qar, Master of Jackals** -- Rival Null


### PR DESCRIPTION
## Summary

- Extracts rival ancestry rules from Draw Steel Monsters into `rival-ancestries-reference.md`
- Covers all 11 ancestries: Devil, Draconian, Dwarf, High Elf, Wode Elf, Hakaan, Human, Memonek, Orc, Polder, Revenant, Time Raider
- Documents keyword, size adjustment, stability adjustment, and ancestral trait for each
- Includes the Black Iron Pact example party

## Test plan

- [ ] Review `rival-ancestries-reference.md` for accuracy against the Draw Steel Monsters PDF
- [ ] Confirm all 11 ancestries are present with correct trait descriptions