### PR TITLE
Increased lore description character limit to 8192 characters

### DIFF
--- a/DMHub Compendium/RaceEditor.lua
+++ b/DMHub Compendium/RaceEditor.lua
@@ -145,6 +145,7 @@ local SetRace = function(tableName, racePanel, raceid)
 			height = 'auto',
 			width = 700,
 			textAlignment = "topleft",
+			characterLimit = 8192,
 			change = function(element)
 				race.lore = element.text
 				UploadRace()


### PR DESCRIPTION
Increased the character limit for the lore description panel in the Ancestries section of the Compendium.