### PR TITLE
Fix character_create analytics firing before ancestry selection

### DIFF
--- a/Codex Titlescreen/CodexTitlescreen.lua
+++ b/Codex Titlescreen/CodexTitlescreen.lua
@@ -171,6 +171,22 @@ local function EditHero(element, character)
         dmhub.DeregisterEventHandler(handler)
         print("TITLESCREEN:: SHOW")
         handler = nil
+
+        -- Track character_create after the builder closes so ancestry/class/kit
+        -- reflect the player's actual choices, not the defaults.
+        local c = character
+        if c ~= nil and c.valid then
+            local classInfo = c.properties:GetClass()
+            local kitTable = dmhub.GetTable("kits")
+            local kitId = c.properties:try_get("kitid")
+            track("character_create", {
+                ancestry = c.properties:RaceOrMonsterType() or "",
+                class = classInfo and classInfo.name or "",
+                kit = (kitId and kitTable[kitId]) and kitTable[kitId].name or "",
+                method = "titlescreen",
+                dailyLimit = 5,
+            })
+        end
     end)
 end
 
@@ -212,16 +228,6 @@ local function CreateHero(element)
                                 c.properties.creatorid = dmhub.userid
                             end,
                         }
-                        local classInfo = c.properties:GetClass()
-                        local kitTable = dmhub.GetTable("kits")
-                        local kitId = c.properties:try_get("kitid")
-                        track("character_create", {
-                            ancestry = c.properties:RaceOrMonsterType() or "",
-                            class = classInfo and classInfo.name or "",
-                            kit = (kitId and kitTable[kitId]) and kitTable[kitId].name or "",
-                            method = "titlescreen",
-                            dailyLimit = 5,
-                        })
                         EditHero(element, c)
                     end
                     return

--- a/DMHub Core Panels/CharacterPanel.lua
+++ b/DMHub Core Panels/CharacterPanel.lua
@@ -3145,13 +3145,6 @@ local CreateBestiaryAndPartyPanel = function(noBestiary)
                             element.data.newcharTime = dmhub.Time()
                             element.monitorGame = string.format("/characters/%s", charid)
                             mod.shared.CompleteTutorial("Create a Character")
-                            track("character_create", {
-                                ancestry = "",
-                                class = "",
-                                kit = "",
-                                method = "panel",
-                                dailyLimit = 5,
-                            })
                         end
 
                         local menuItems = {}
@@ -3185,6 +3178,28 @@ local CreateBestiaryAndPartyPanel = function(noBestiary)
                             local tok = dmhub.GetCharacterById(element.data.newchar)
                             if tok ~= nil then
                                 tok:ShowSheet("Appearance")
+
+                                -- Track character_create after the sheet closes so
+                                -- ancestry/class/kit reflect actual player choices.
+                                local trackToken = tok
+                                local handler
+                                handler = dmhub.RegisterEventHandler("characterSheetClosed", function()
+                                    dmhub.DeregisterEventHandler(handler)
+                                    handler = nil
+                                    local c = trackToken
+                                    if c ~= nil and c.valid then
+                                        local classInfo = c.properties:GetClass()
+                                        local kitTable = dmhub.GetTable("kits")
+                                        local kitId = c.properties:try_get("kitid")
+                                        track("character_create", {
+                                            ancestry = c.properties:RaceOrMonsterType() or "",
+                                            class = classInfo and classInfo.name or "",
+                                            kit = (kitId and kitTable[kitId]) and kitTable[kitId].name or "",
+                                            method = "panel",
+                                            dailyLimit = 5,
+                                        })
+                                    end
+                                end)
                             end
                         end
 


### PR DESCRIPTION
## Summary
- `character_create` was firing immediately after `game.CreateCharacter()`, capturing default ancestry (Human) or empty strings rather than the player's actual selections — making the event misleading compared to `builder_selection` data.
- Moved tracking into the `characterSheetClosed` handler in both creation flows (titlescreen and character panel) so ancestry/class/kit reflect final choices.
- Follower creation path (`DSFollower.lua`) left unchanged — it sets ancestry programmatically before tracking.

## Test plan
- [ ] Create a hero from the titlescreen, pick a non-Human ancestry, close builder → verify `character_create` event shows chosen ancestry
- [ ] Create a character from the character panel, pick class/kit, close sheet → verify event captures real values
- [ ] Verify `builder_selection` and `character_create` ancestry distributions now align
- [ ] Confirm follower creation still tracks correctly