### PR TITLE
Fall Damage Reduction attribute + action bar rename

### DIFF
--- a/Draw Steel Ability Behaviors/AbilityDamage.lua
+++ b/Draw Steel Ability Behaviors/AbilityDamage.lua
@@ -416,7 +416,16 @@ function ActivatedAbilityDamageChatMessage:Render(message)
         damageTypeText = " " .. damageTypeText
     end
 
-    local messageText = string.format("%d%s damage", self.amount, damageTypeText)
+    local displayAmount = self.amount
+    if self.chatMessage == "Falling Damage" then
+        local targetTokens = self:GetTargetTokens()
+        if #targetTokens > 0 and targetTokens[1].valid then
+            local reduction = targetTokens[1].properties:CalculateNamedCustomAttribute("Fall Damage Reduction", 0)
+            displayAmount = math.max(0, displayAmount - reduction)
+        end
+    end
+
+    local messageText = string.format("%d%s damage", displayAmount, damageTypeText)
 
     local detailLabel = gui.Label{
         classes = {"action-log-detail"},

--- a/Draw Steel Core Rules/MCDMCreature.lua
+++ b/Draw Steel Core Rules/MCDMCreature.lua
@@ -3614,6 +3614,10 @@ function creature.TakeDamage(self, amount, note, info)
         return
     end
 
+    if info.ability ~= nil and info.ability.name == "Fall Damage" then
+        amount = math.max(0, amount - self:CalculateNamedCustomAttribute("Fall Damage Reduction", 0))
+    end
+
     if amount <= 0 and note == nil then
         return
     end

--- a/DrawSteelActionBar/DrawSteelActionBar.lua
+++ b/DrawSteelActionBar/DrawSteelActionBar.lua
@@ -1670,7 +1670,7 @@ local function ActionSubMenu(args)
             classes = { "submenuHeading" },
             abilities = function(element, abilities, grouping)
                 if g_token.properties.typeName == "monster" and grouping == "Heroic Abilities" then
-                    grouping = "Villain Actions"
+                    grouping = "Malice Abilities"
                 elseif grouping == "Triggers" then
                     grouping = "Manual Use Triggers"
                 end


### PR DESCRIPTION
## Summary

- **Fall Damage Reduction attribute**: New named custom attribute that reduces the stamina lost when a creature falls. Distinct from the existing `Fall Reduction` attribute (which raises the height threshold before fall damage triggers). Negative values act as vulnerability, increasing damage taken.
- **Action log fix**: The engine sends the \"Falling Damage\" chat message with the pre-reduction amount. `ActivatedAbilityDamageChatMessage:Render` now reads the target's `Fall Damage Reduction` at render time and displays the correct post-reduction value.
- **Action bar rename**: \"Villain Actions\" submenu heading renamed to \"Malice Abilities\" for monster tokens.

## Test plan

- [ ] Give a creature a `Fall Damage Reduction` modifier and drop them off a ledge — stamina loss should be reduced
- [ ] Confirm the action log \"Falling Damage\" entry shows the reduced amount, not the full amount
- [ ] Confirm a creature with no `Fall Damage Reduction` takes normal fall damage
- [ ] Confirm negative `Fall Damage Reduction` increases fall damage taken
- [ ] Open a monster token's action submenu and confirm the heading reads \"Malice Abilities\"