### PR TITLE
Fix No Damage From Forced Movement not dealing damage to collided creature

### DIFF
--- a/DMHub Game Rules/AbilityRelocateCreature.lua
+++ b/DMHub Game Rules/AbilityRelocateCreature.lua
@@ -174,7 +174,7 @@ function ActivatedAbilityRelocateCreatureBehavior:Cast(ability, casterToken, tar
 			local throughCreatures = ability:try_get("forcedMovementThroughCreatures", false)
 			local forcedPushOptions = casterToken.properties:GetForcedPushOptions()
 			local abilityDist = ability:GetRange(casterToken.properties)/dmhub.unitsPerSquare
-			if (ability.targeting == "straightline" or ability.targetType == "line") and casterToken.properties:CalculateNamedCustomAttribute("No Damage From Forced Movement") == 0 then
+			if ability.targeting == "straightline" or ability.targetType == "line" then
 				local abilityDistForArrow = abilityDist
 				local movementInfo = casterToken:MarkMovementArrow(targets[1].loc, {waypoints = options.symbols.waypoints, straightline = true, ignorecreatures = (ability.targetType == "line" or throughCreatures), forcedMovementDistance = abilityDistForArrow, rebound = forcedPushOptions.rebound, maxBounces = forcedPushOptions.maxBounces})
 				if movementInfo ~= nil then
@@ -333,15 +333,17 @@ function ActivatedAbilityRelocateCreatureBehavior:Cast(ability, casterToken, tar
                     end
                 end
                 print("TRIGGERCOLLIDE:: objects =", #objectsCollidedWith, collisionInfo.speed, withobject, collisionInfo.collideWith)
-                casterToken.properties._tmp_forcedMovementCast = options.symbols.cast
-				casterToken.properties:TriggerEvent("collide", {
-					speed = collisionInfo.speed,
-                    withobject = withobject,
-                    withcreature = not withobject,
-                    pusher = options.symbols.invoker,
-                    haspusher = options.symbols.invoker ~= nil,
-                    movementtype = forcedMovementType,
-				})
+                if casterToken.properties:CalculateNamedCustomAttribute("No Damage From Forced Movement") == 0 then
+                    casterToken.properties._tmp_forcedMovementCast = options.symbols.cast
+                    casterToken.properties:TriggerEvent("collide", {
+                        speed = collisionInfo.speed,
+                        withobject = withobject,
+                        withcreature = not withobject,
+                        pusher = options.symbols.invoker,
+                        haspusher = options.symbols.invoker ~= nil,
+                        movementtype = forcedMovementType,
+                    })
+                end
 
                 if casterToken.isObject then
                     --hard code damage equal to speed.


### PR DESCRIPTION
## Summary

- The `No Damage From Forced Movement` custom attribute was gating the entire collision detection block, so when a token with this attribute was force-moved into a creature, `collisionInfo` was never built and neither token received the `collide` event — meaning the collided-into creature also took no damage.
- Collision path calculation now always runs for straight-line forced moves.
- Only the moved token's own `TriggerEvent("collide")` call is gated on the attribute, so the token with the attribute remains immune but the creature it hits still takes collision damage correctly.

## Test plan

- [ ] Give a token the `No Damage From Forced Movement` attribute and force-move it into another creature — immune token should take no collision damage, collided creature should take collision damage.
- [ ] Test without the attribute on either token — both parties should take collision damage as before.
- [ ] Test with the attribute on the collided-into creature (not the mover) — no change expected; that creature should still take damage (the attribute only protects the token being moved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)