### PR TITLE
dispatch finishability for Trigger and Free Trigger abilities

### DIFF
--- a/DMHub Game Rules/TriggeredAbility.lua
+++ b/DMHub Game Rules/TriggeredAbility.lua
@@ -1060,6 +1060,9 @@ function TriggeredAbility:Trigger(characterModifier, creature, symbols, auraCont
 			argOptions.alreadyPaid = true
 		end
 		executeTrigger()
+		if self:ActionResource() == CharacterResource.triggerResourceId then
+			casterToken.properties:DispatchEvent("finishability", {usedability = self})
+		end
 	else
 		dmhub.Coroutine(function()
 			local guid = dmhub.GenerateGuid()
@@ -1240,6 +1243,7 @@ function TriggeredAbility:Trigger(characterModifier, creature, symbols, auraCont
 
 				dmhub.Schedule(0.01, function() --make execute in the main thread with a schedule.
 					executeTrigger()
+					casterToken.properties:DispatchEvent("finishability", {usedability = self})
 				end)
 			end
 		end)


### PR DESCRIPTION
## Summary

- The \"Finish Using an Ability\" triggered ability event (`finishability`) previously only fired for regular `ActivatedAbility` casts, never for `TriggeredAbility` modifiers
- Mandatory `TriggeredAbility` instances that cost the trigger resource (Trigger type) now dispatch `finishability` after auto-firing
- Non-mandatory `TriggeredAbility` instances (player-activated via the trigger button) dispatch `finishability` after the player confirms, covering both Trigger and Free Trigger types
- Passive auto-firing abilities with no trigger resource cost remain excluded