### PR TITLE
feat: add movementrestriction modifier for willing movement filtering

### DIFF
--- a/DMHub Game Rules/ModifierMovementText.lua
+++ b/DMHub Game Rules/ModifierMovementText.lua
@@ -177,6 +177,98 @@ CharacterModifier.TypeInfo.movementtext = {
     end,
 }
 
+CharacterModifier.RegisterType('movementrestriction', "Movement Restriction")
+
+CharacterModifier.TypeInfo.movementrestriction = {
+    init = function(modifier)
+        modifier.targetFormula = ""
+    end,
+
+    GetMovementRestrictionFilter = function(modifier, cre, token)
+        local formula = modifier:try_get("targetFormula", "")
+        if formula == "" then return nil end
+
+        local targetCreature = ExecuteGoblinScript(
+            formula,
+            cre:LookupSymbol(modifier:try_get("_tmp_symbols", {})),
+            nil,
+            "movement restriction target")
+        if targetCreature == nil then return nil end
+
+        local targetToken = dmhub.LookupToken(targetCreature)
+        if targetToken == nil or not targetToken.valid then return nil end
+
+        local distanceNow = targetToken:Distance(token.loc)
+
+        return function(loc)
+            return targetToken:Distance(loc) >= distanceNow
+        end
+    end,
+
+    createEditor = function(modifier, element)
+        local Refresh
+        local firstRefresh = true
+
+        Refresh = function()
+            if firstRefresh then
+                firstRefresh = false
+            else
+                element:FireEvent("refreshModifier")
+            end
+
+            local children = {}
+            children[#children+1] = modifier:FilterConditionEditor()
+
+            children[#children+1] = gui.Panel{
+                classes = {'formPanel'},
+                children = {
+                    gui.Label{
+                        text = 'Cannot Move Toward:',
+                        classes = {'formLabel'},
+                    },
+                    gui.GoblinScriptInput{
+                        classes = {'formInput'},
+                        value = modifier:try_get("targetFormula", ""),
+                        change = function(self)
+                            modifier.targetFormula = self.value
+                            Refresh()
+                        end,
+                        documentation = {
+                            output = "creature",
+                            help = "The creature that the affected creature cannot willingly move closer to.",
+                        },
+                    },
+                },
+            }
+
+            element.children = children
+        end
+
+        Refresh()
+    end,
+}
+
+function creature:GetMovementRestrictionFilter(token)
+    local mods = self:GetActiveModifiers()
+    local filters = {}
+    for _, mod in ipairs(mods) do
+        local typeInfo = CharacterModifier.TypeInfo[mod.mod.behavior]
+        if typeInfo ~= nil and typeInfo.GetMovementRestrictionFilter ~= nil then
+            local f = typeInfo.GetMovementRestrictionFilter(mod.mod, self, token)
+            if f ~= nil then
+                filters[#filters+1] = f
+            end
+        end
+    end
+    if #filters == 0 then return nil end
+    return function(loc)
+        for _, f in ipairs(filters) do
+            if not f(loc) then return false end
+        end
+        return true
+    end
+end
+
 function CharacterModifier:MovementAdvisoryText(creature, path, text)
 	local typeInfo = CharacterModifier.TypeInfo[self.behavior] or {}
 	if typeInfo.MovementAdvisoryText ~= nil then

--- a/DrawSteelActionBar/DrawSteelActionBar.lua
+++ b/DrawSteelActionBar/DrawSteelActionBar.lua
@@ -4823,6 +4823,13 @@ CreateAbilityController = function()
                         end
 
                         local filterTargetPredicate = g_currentAbility:TargetLocPassesFilterPredicate(g_token, g_currentSymbols)
+                        if not forcedMovement then
+                            local restrictionFilter = g_token.properties:GetMovementRestrictionFilter(g_token)
+                            if restrictionFilter ~= nil then
+                                local baseFilter = filterTargetPredicate
+                                filterTargetPredicate = function(loc) return baseFilter(loc) and restrictionFilter(loc) end
+                            end
+                        end
                         local radiusMarker = g_token:MarkMovementRadius(g_range,
                             { moveFlags = moveFlags, waypoints = waypoints, mask = mask, filter = filterTargetPredicate})
 
@@ -5262,6 +5269,13 @@ CalculateSpellTargeting = function(forceCast, initialSetup)
 
 
                 local filterTargetPredicate = g_currentAbility:TargetLocPassesFilterPredicate(g_token, g_currentSymbols)
+                if g_currentAbility:try_get("targeting", "direct") ~= "straightline" then
+                    local restrictionFilter = g_token.properties:GetMovementRestrictionFilter(g_token)
+                    if restrictionFilter ~= nil then
+                        local baseFilter = filterTargetPredicate
+                        filterTargetPredicate = function(loc) return baseFilter(loc) and restrictionFilter(loc) end
+                    end
+                end
 
                 print("MARK:: MovementRadius:: MARK", range)
                 g_radiusMarkers[#g_radiusMarkers + 1] = g_token:MarkMovementRadius(range,


### PR DESCRIPTION
## Summary

- Adds a new `movementrestriction` CharacterModifier behavior type that prevents a creature from willingly moving closer to a specified target creature
- The target is specified via a GoblinScript formula (output: creature), making it attachable to any condition, ongoing effect, or feature
- Wires the restriction filter into both `MarkMovementRadius` call sites in the action bar so the movement overlay respects the restriction during invoke movement
- Forced/compelled movement (straightline targeting) bypasses the restriction -- only willing movement is affected
- Multiple active restrictions are ANDed together