### PR TITLE
Movement Restriction modifier via GoblinScript + MoveToLocPermitted

### DIFF
--- a/DMHub Game Rules/ModifierMovementText.lua
+++ b/DMHub Game Rules/ModifierMovementText.lua
@@ -177,6 +177,98 @@ CharacterModifier.TypeInfo.movementtext = {
     end,
 }
 
+CharacterModifier.RegisterType('movementrestriction', "Movement Restriction")
+
+CharacterModifier.TypeInfo.movementrestriction = {
+    init = function(modifier)
+        modifier.targetFormula = ""
+    end,
+
+    GetMovementRestrictionFilter = function(modifier, cre, token)
+        local formula = modifier:try_get("targetFormula", "")
+        if formula == "" then return nil end
+
+        local targetCreature = ExecuteGoblinScript(
+            formula,
+            cre:LookupSymbol(modifier:try_get("_tmp_symbols", {})),
+            nil,
+            "movement restriction target")
+        if targetCreature == nil then return nil end
+
+        local targetToken = dmhub.LookupToken(targetCreature)
+        if targetToken == nil or not targetToken.valid then return nil end
+
+        local distanceNow = targetToken:Distance(token.loc)
+
+        return function(loc)
+            return targetToken:Distance(loc) >= distanceNow
+        end
+    end,
+
+    createEditor = function(modifier, element)
+        local Refresh
+        local firstRefresh = true
+
+        Refresh = function()
+            if firstRefresh then
+                firstRefresh = false
+            else
+                element:FireEvent("refreshModifier")
+            end
+
+            local children = {}
+            children[#children+1] = modifier:FilterConditionEditor()
+
+            children[#children+1] = gui.Panel{
+                classes = {'formPanel'},
+                children = {
+                    gui.Label{
+                        text = 'Cannot Move Toward:',
+                        classes = {'formLabel'},
+                    },
+                    gui.GoblinScriptInput{
+                        classes = {'formInput'},
+                        value = modifier:try_get("targetFormula", ""),
+                        change = function(self)
+                            modifier.targetFormula = self.value
+                            Refresh()
+                        end,
+                        documentation = {
+                            output = "creature",
+                            help = "The creature that the affected creature cannot willingly move closer to.",
+                        },
+                    },
+                },
+            }
+
+            element.children = children
+        end
+
+        Refresh()
+    end,
+}
+
+function creature:GetMovementRestrictionFilter(token)
+    local mods = self:GetActiveModifiers()
+    local filters = {}
+    for _, mod in ipairs(mods) do
+        local typeInfo = CharacterModifier.TypeInfo[mod.mod.behavior]
+        if typeInfo ~= nil and typeInfo.GetMovementRestrictionFilter ~= nil then
+            local f = typeInfo.GetMovementRestrictionFilter(mod.mod, self, token)
+            if f ~= nil then
+                filters[#filters+1] = f
+            end
+        end
+    end
+    if #filters == 0 then return nil end
+    return function(loc)
+        for _, f in ipairs(filters) do
+            if not f(loc) then return false end
+        end
+        return true
+    end
+end
+
 function CharacterModifier:MovementAdvisoryText(creature, path, text)
 	local typeInfo = CharacterModifier.TypeInfo[self.behavior] or {}
 	if typeInfo.MovementAdvisoryText ~= nil then

--- a/DMHub Game Rules/ModifierMovementText.lua
+++ b/DMHub Game Rules/ModifierMovementText.lua
@@ -184,25 +184,54 @@ CharacterModifier.TypeInfo.movementrestriction = {
         modifier.targetFormula = ""
     end,
 
-    GetMovementRestrictionFilter = function(modifier, cre, token)
+    -- Returns false if stepping onto loc would bring the creature closer to the
+    -- target than its starting position.
+    MoveToLocPermitted = function(modifier, modContext, creature, startLoc, loc)
         local formula = modifier:try_get("targetFormula", "")
-        if formula == "" then return nil end
+        if formula == "" then return true end
 
-        local targetCreature = ExecuteGoblinScript(
-            formula,
-            cre:LookupSymbol(modifier:try_get("_tmp_symbols", {})),
-            nil,
-            "movement restriction target")
-        if targetCreature == nil then return nil end
-
-        local targetToken = dmhub.LookupToken(targetCreature)
-        if targetToken == nil or not targetToken.valid then return nil end
-
-        local distanceNow = targetToken:Distance(token.loc)
-
-        return function(loc)
-            return targetToken:Distance(loc) >= distanceNow
+        -- Cache the resolved charid per frame so EvalGoblinScriptToObject only runs
+        -- once across all tile checks in a single movement overlay calculation.
+        local currentFrame = dmhub.FrameCount()
+        local targetCharid = modifier:try_get("_tmp_targetCharid")
+        if modifier:try_get("_tmp_targetFrame") ~= currentFrame then
+            targetCharid = nil
+            local result = dmhub.EvalGoblinScriptToObject(formula, creature:LookupSymbol(), "Movement restriction target")
+            if type(result) == "string" and result ~= "" then
+                targetCharid = result
+            elseif type(result) == "number" then
+                targetCharid = tostring(math.floor(result))
+            elseif result ~= nil and type(result) == "table" then
+                local tid = dmhub.LookupTokenId(result)
+                if tid ~= nil and tid ~= "" then
+                    targetCharid = tid
+                end
+            end
+            modifier._tmp_targetFrame = currentFrame
+            modifier._tmp_targetCharid = targetCharid
         end
+
+        if targetCharid == nil or targetCharid == "" then return true end
+
+        local targetToken = dmhub.GetTokenById(targetCharid)
+        if targetToken == nil or (not targetToken.valid) then return true end
+
+        local targetLocs = targetToken.locsOccupying
+        if targetLocs == nil or #targetLocs == 0 then return true end
+
+        local startDist = math.huge
+        for _, tl in ipairs(targetLocs) do
+            local d = startLoc:DistanceInTiles(tl)
+            if d < startDist then startDist = d end
+        end
+
+        local locDist = math.huge
+        for _, tl in ipairs(targetLocs) do
+            local d = loc:DistanceInTiles(tl)
+            if d < locDist then locDist = d end
+        end
+
+        return locDist >= startDist
     end,
 
     createEditor = function(modifier, element)
@@ -220,22 +249,30 @@ CharacterModifier.TypeInfo.movementrestriction = {
             children[#children+1] = modifier:FilterConditionEditor()
 
             children[#children+1] = gui.Panel{
-                classes = {'formPanel'},
-                children = {
-                    gui.Label{
-                        text = 'Cannot Move Toward:',
-                        classes = {'formLabel'},
-                    },
-                    gui.GoblinScriptInput{
-                        classes = {'formInput'},
-                        value = modifier:try_get("targetFormula", ""),
-                        change = function(self)
-                            modifier.targetFormula = self.value
-                            Refresh()
-                        end,
-                        documentation = {
-                            output = "creature",
-                            help = "The creature that the affected creature cannot willingly move closer to.",
+                classes = {"formPanel"},
+                gui.Label{
+                    classes = {"formLabel"},
+                    text = "Target:",
+                },
+                gui.GoblinScriptInput{
+                    value = modifier:try_get("targetFormula", ""),
+                    change = function(self)
+                        local v = trim(self.value)
+                        if v == "" then
+                            modifier.targetFormula = nil
+                        else
+                            modifier.targetFormula = v
+                        end
+                        Refresh()
+                    end,
+                    documentation = {
+                        help = "A GoblinScript expression that evaluates to the creature the restricted creature cannot approach. Can be a raw token ID number, or a GoblinScript expression such as ConditionCaster(\"Frightened\").",
+                        output = "creature",
+                        examples = {
+                            {
+                                script = "ConditionCaster(\"Frightened\")",
+                                text = "Cannot approach the creature that inflicted Frightened on this creature.",
+                            },
                         },
                     },
                 },
@@ -247,27 +284,6 @@ CharacterModifier.TypeInfo.movementrestriction = {
         Refresh()
     end,
 }
-
-function creature:GetMovementRestrictionFilter(token)
-    local mods = self:GetActiveModifiers()
-    local filters = {}
-    for _, mod in ipairs(mods) do
-        local typeInfo = CharacterModifier.TypeInfo[mod.mod.behavior]
-        if typeInfo ~= nil and typeInfo.GetMovementRestrictionFilter ~= nil then
-            local f = typeInfo.GetMovementRestrictionFilter(mod.mod, self, token)
-            if f ~= nil then
-                filters[#filters+1] = f
-            end
-        end
-    end
-    if #filters == 0 then return nil end
-    return function(loc)
-        for _, f in ipairs(filters) do
-            if not f(loc) then return false end
-        end
-        return true
-    end
-end
 
 function CharacterModifier:MovementAdvisoryText(creature, path, text)
 	local typeInfo = CharacterModifier.TypeInfo[self.behavior] or {}

--- a/Draw Steel Core Rules/MCDMCreature.lua
+++ b/Draw Steel Core Rules/MCDMCreature.lua
@@ -5118,6 +5118,27 @@ function creature:Titles()
     return results
 end
 
+function creature:MoveToLocPermitted(loc)
+    local token = dmhub.LookupToken(self)
+    if token == nil or (not token.valid) then
+        return true
+    end
+
+    local startLoc = token.loc
+
+    local modifiers = self:GetActiveModifiers()
+    for _, modContext in ipairs(modifiers) do
+        local typeInfo = CharacterModifier.TypeInfo[modContext.mod.behavior] or {}
+        if typeInfo.MoveToLocPermitted ~= nil then
+            if not typeInfo.MoveToLocPermitted(modContext.mod, modContext, self, startLoc, loc) then
+                return false
+            end
+        end
+    end
+
+    return true
+end
+
 dmhub.RegisterEventHandler("ClearTemporaryState", function()
     print("CLEARSTATE:: CLEARING STATE", #dmhub.allTokens)
 end)

--- a/DrawSteelActionBar/DrawSteelActionBar.lua
+++ b/DrawSteelActionBar/DrawSteelActionBar.lua
@@ -4823,6 +4823,13 @@ CreateAbilityController = function()
                         end
 
                         local filterTargetPredicate = g_currentAbility:TargetLocPassesFilterPredicate(g_token, g_currentSymbols)
+                        if not forcedMovement then
+                            local restrictionFilter = g_token.properties:GetMovementRestrictionFilter(g_token)
+                            if restrictionFilter ~= nil then
+                                local baseFilter = filterTargetPredicate
+                                filterTargetPredicate = function(loc) return baseFilter(loc) and restrictionFilter(loc) end
+                            end
+                        end
                         local radiusMarker = g_token:MarkMovementRadius(g_range,
                             { moveFlags = moveFlags, waypoints = waypoints, mask = mask, filter = filterTargetPredicate})
 
@@ -5262,6 +5269,13 @@ CalculateSpellTargeting = function(forceCast, initialSetup)
 
 
                 local filterTargetPredicate = g_currentAbility:TargetLocPassesFilterPredicate(g_token, g_currentSymbols)
+                if g_currentAbility:try_get("targeting", "direct") ~= "straightline" then
+                    local restrictionFilter = g_token.properties:GetMovementRestrictionFilter(g_token)
+                    if restrictionFilter ~= nil then
+                        local baseFilter = filterTargetPredicate
+                        filterTargetPredicate = function(loc) return baseFilter(loc) and restrictionFilter(loc) end
+                    end
+                end
 
                 print("MARK:: MovementRadius:: MARK", range)
                 g_radiusMarkers[#g_radiusMarkers + 1] = g_token:MarkMovementRadius(range,


### PR DESCRIPTION
## Summary

- Replaces the earlier `GetMovementRestrictionFilter` approach with `MoveToLocPermitted`, which hooks into `creature:MoveToLocPermitted` and the pathfinding overlay so restricted tiles are visually blocked during movement
- Target creature is specified as a GoblinScript expression evaluated against the creature's full symbol table — `ConditionCaster("Frightened")` works out of the box, as does any other GoblinScript expression that resolves to a creature
- Caches the resolved charid per frame (`_tmp_targetFrame` / `_tmp_targetCharid`) to avoid 400+ redundant `EvalGoblinScriptToObject` calls during a single movement hover

## Usage

In the modifier editor, set **Target** to a GoblinScript expression:
- `ConditionCaster("Frightened")` — cannot approach whoever inflicted Frightened
- Any other GoblinScript expression returning a creature

## Test plan

- [ ] Add a `movementrestriction` modifier to the Frightened condition with target `ConditionCaster("Frightened")`
- [ ] Inflict Frightened on a creature and verify the movement overlay blocks tiles closer to the source
- [ ] Verify movement to tiles at equal or greater distance is permitted
- [ ] Verify forced movement is unaffected
- [ ] Verify no performance slowdown when hovering over restricted tiles