### PR TITLE
Ability Editor update - full screen, preview cards update correctly, paste behaviours works correctly

### DIFF
--- a/DMHub Compendium/ActivatedAbilityEditor.lua
+++ b/DMHub Compendium/ActivatedAbilityEditor.lua
@@ -4769,9 +4769,6 @@ function ActivatedAbility:ShowEditActivatedAbilityDialog(options)
 
 	local activatedAbility = self
 
-	local dialogWidth = 1200
-	local dialogHeight = 980
-
 	local resultPanel = nil
 
 	-- When the sectioned ability editor is active (the default), theme the
@@ -4783,13 +4780,23 @@ function ActivatedAbility:ShowEditActivatedAbilityDialog(options)
 	local themed = abilityEditor ~= nil and dmhub.GetSettingValue("classicAbilityEditor") ~= true
 	local c = themed and abilityEditor.COLORS or nil
 
+	-- The sectioned editor renders as a full-screen modal; the classic
+	-- editor keeps its original compact dialog dimensions.
+	local dialogWidth = themed and "100%" or 1200
+	local dialogHeight = themed and "100%" or 980
+
+	-- mainFormPanel hosts the editor body (classic or sectioned). When the
+	-- sectioned editor is active it fills the full-screen dialog minus
+	-- room for the title strip (~40px) and the Create/Close button row
+	-- (60px height + margins). The classic editor keeps its original
+	-- 1100x840 canvas.
 	local styles = {
 		{
 			bgcolor = themed and c.BG or 'white',
 			pad = 0,
 			margin = 0,
-			width = 1100,
-			height = 840,
+			width = themed and "100%" or 1100,
+			height = themed and "100%-120" or 840,
 		},
 	}
 

--- a/DMHub Compendium/ActivatedAbilityEditor.lua
+++ b/DMHub Compendium/ActivatedAbilityEditor.lua
@@ -3584,7 +3584,7 @@ function ActivatedAbilityBehavior:OngoingEffectEditor(parentPanel, list, options
 		editEffectButton = gui.Button{
 			width = 120,
 			height = 28,
-			halign = "right",
+			halign = "left",
 			text = "Edit Effect",
 			fontSize = 16,
 			click = function(element)
@@ -3613,7 +3613,7 @@ function ActivatedAbilityBehavior:OngoingEffectEditor(parentPanel, list, options
 	end
 
 	list[#list+1] = gui.Panel{
-		classes = "formPanel",
+		classes = {"formPanel", "formPanel-inline"},
 		gui.Label{
 			classes = "formLabel",
 			text = "Ongoing Effect:",

--- a/DMHub Core Panels/GoblinScriptEditor.lua
+++ b/DMHub Core Panels/GoblinScriptEditor.lua
@@ -132,6 +132,7 @@ function gui.GoblinScriptInput(options)
 		if inputText == nil then
 			inputText = gui.Input {
 				id = "GoblinScriptInput",
+				classes = {"goblinscript-inner-input"},
 				width = "100%",
 				minHeight = 30,
 				height = "auto",
@@ -850,6 +851,21 @@ function gui.GoblinScriptInput(options)
 	-- by passing halign in options.
 	if args.halign == nil then
 		args.halign = "left"
+	end
+
+	-- Always tag the outer wrapper with `goblinscript-outer` so themed
+	-- styles can target it specifically (e.g. to strip the 6px hpad that
+	-- the formInput class brings with it -- callers often pass
+	-- classes = "formInput" which reserves 6px layout padding on the
+	-- outer, causing the visible inner Input to sit 6px to the right of
+	-- a plain gui.Input in the row above). Merge rather than overwrite
+	-- so caller-supplied classes are preserved.
+	if type(args.classes) == "table" then
+		args.classes[#args.classes+1] = "goblinscript-outer"
+	elseif type(args.classes) == "string" then
+		args.classes = {args.classes, "goblinscript-outer"}
+	else
+		args.classes = {"goblinscript-outer"}
 	end
 
 	resultPanel = gui.Panel(args)

--- a/DMHub Game Rules/AbilityInvokeAbility.lua
+++ b/DMHub Game Rules/AbilityInvokeAbility.lua
@@ -631,24 +631,53 @@ function ActivatedAbilityInvokeAbilityBehavior:EditorItems(parentPanel)
 		}
 	}
 
+	-- Type row uses the stacked-label default (label above, controls
+	-- below) like the other form rows. The dropdown + Edit Ability
+	-- button share a horizontal sub-panel on the second line so the
+	-- button sits immediately next to the dropdown (only visible when
+	-- "Custom Ability" is selected). Same pattern as the Apply Ongoing
+	-- Effect behavior's Edit Effect button.
 	result[#result+1] = gui.Panel{
 		classes = {"formPanel"},
 		gui.Label{
 			classes = {"formLabel"},
 			text = "Type:",
 		},
-		gui.Dropdown{
-			options = {
-				{ text = "Custom Ability", id = "custom" },
-				{ text = "Named Ability", id = "named" },
-				cond(dmhub.GetTable("standardAbilities") ~= nil, { text = "Standard Ability", id = "standard" } ),
+		gui.Panel{
+			width = "auto",
+			height = "auto",
+			flow = "horizontal",
+			halign = "left",
+			valign = "center",
+			gui.Dropdown{
+				options = {
+					{ text = "Custom Ability", id = "custom" },
+					{ text = "Named Ability", id = "named" },
+					cond(dmhub.GetTable("standardAbilities") ~= nil, { text = "Standard Ability", id = "standard" } ),
+				},
+				idChosen = self.abilityType,
+				change = function(element)
+					self.abilityType = element.idChosen
+					parentPanel:FireEventTree("refreshInvoke")
+				end,
 			},
-			idChosen = self.abilityType,
-			change = function(element)
-				self.abilityType = element.idChosen
-				parentPanel:FireEventTree("refreshInvoke")
-			end,
-		}
+
+			gui.Button{
+				classes = {cond(self.abilityType ~= "custom", "collapsed-anim")},
+				width = "auto",
+				height = 28,
+				halign = "left",
+				lmargin = 8,
+				fontSize = 16,
+				text = "Edit Ability",
+				refreshInvoke = function(element)
+					element:SetClass("collapsed-anim", self.abilityType ~= "custom")
+				end,
+				click = function(element)
+					element.root:AddChild(self.customAbility:ShowEditActivatedAbilityDialog())
+				end,
+			},
+		},
 	}
 
 	result[#result+1] = gui.Check{
@@ -658,7 +687,7 @@ function ActivatedAbilityInvokeAbilityBehavior:EditorItems(parentPanel)
 			self.invokeOnCaster = element.value
 		end,
 	}
-	
+
 	result[#result+1] = gui.Check{
 		classes = {cond(self.abilityType == "custom", "collapsed-anim")},
 		text = "Target Player Casts",
@@ -668,21 +697,6 @@ function ActivatedAbilityInvokeAbilityBehavior:EditorItems(parentPanel)
 		end,
 		refreshInvoke = function(element)
 			element:SetClass("collapsed-anim", self.abilityType == "custom")
-		end,
-	}
-
-	result[#result+1] = gui.PrettyButton{
-		width = 200,
-		height = 50,
-		text = "Edit Ability",
-		create = function(element)
-			element:SetClass("collapsed", self.abilityType ~= "custom")
-		end,
-		refreshInvoke = function(element)
-			element:FireEventTree("create")
-		end,
-		click = function(element)
-			element.root:AddChild(self.customAbility:ShowEditActivatedAbilityDialog())
 		end,
 	}
 

--- a/DMHub Game Rules/AbilityPurgeEffects.lua
+++ b/DMHub Game Rules/AbilityPurgeEffects.lua
@@ -2204,6 +2204,7 @@ function ActivatedAbilityPurgeEffectsBehavior:EditorItems(parentPanel)
                 flow = "vertical",
                 width = 300,
                 height = "auto",
+                halign = "left",
 
                 gui.Panel{
                     flow = "vertical",

--- a/DMHub Game Rules/CharacterFeature.lua
+++ b/DMHub Game Rules/CharacterFeature.lua
@@ -894,8 +894,12 @@ function CharacterFeature:EditorPanel(editorPanelOptions)
 	-- rather than scrolling with the modifier list. Mirrors the ability
 	-- editor's effectsBottomBar (AbilityEditor.lua:4813) so the feature
 	-- panel feels consistent with the sectioned ability editor.
+	--
+	-- Skip the bar entirely in noscroll embeddings (e.g. OngoingEffectEditor
+	-- embeds EditorPanel with noscroll = true). Creating the Panel and
+	-- then not using it would orphan the panel and emit an engine warning.
 	local modifierBottomBar = nil
-	if themed and type(abilityEditor.OpenModifierPicker) == "function" then
+	if themed and not noscroll and type(abilityEditor.OpenModifierPicker) == "function" then
 		local function clipboardHasPasteable()
 			local item = dmhub.GetInternalClipboard()
 			if item == nil then return false end

--- a/DMHub Game Rules/CharacterFeature.lua
+++ b/DMHub Game Rules/CharacterFeature.lua
@@ -420,6 +420,65 @@ function CharacterFeature:EditorPanel(editorPanelOptions)
 		}
 	end
 
+	-- Dispatcher for a chosen modifier type id. Used by both the classic
+	-- dropdown (change) and the themed picker (onAdd). The special
+	-- "CLIPBOARD" id pastes the internal clipboard entry.
+	--
+	-- Defined in outer EditorPanel scope (not inside refreshModifiers) so
+	-- the persistent themed bottom bar below can reference it -- the bar
+	-- lives outside the scroll area and is built once, not per refresh.
+	local function addModifierById(typeId)
+		if typeId == nil or typeId == 'none' then return end
+
+		if typeId == 'CLIPBOARD' then
+			local clipboardItem = dmhub.GetInternalClipboard()
+			if clipboardItem ~= nil and clipboardItem.typeName == 'CharacterModifier' then
+				local modifier = DeepCopy(clipboardItem)
+				DeepReplaceGuids(modifier)
+				local modifiers = self:get_or_add("modifiers", {})
+				modifiers[#modifiers+1] = modifier
+				modifiersPanel:FireEvent('refreshModifiers')
+			elseif clipboardItem ~= nil and clipboardItem.typeName == "ActivatedAbility" then
+				local ability = DeepCopy(clipboardItem)
+				DeepReplaceGuids(ability)
+				local modifier = CharacterModifier.new{
+					guid = dmhub.GenerateGuid(),
+					name = ability.name,
+					description = "",
+					behavior = "activated",
+					activatedAbility = ability,
+				}
+				local modifiers = self:get_or_add("modifiers", {})
+				modifiers[#modifiers+1] = modifier
+				modifiersPanel:FireEvent('refreshModifiers')
+			end
+			return
+		end
+
+		local domains = nil
+		if self:has_key("domains") then
+			domains = DeepCopy(self.domains)
+		end
+		local modifier = CharacterModifier.new{
+			guid = dmhub.GenerateGuid(),
+			sourceguid = self.guid,
+			name = self.name,
+			source = self.source,
+			description = self.description,
+			behavior = typeId,
+			domains = domains,
+		}
+		local typeInfo = CharacterModifier.TypeInfo[modifier.behavior] or {}
+		if typeInfo.init then
+			typeInfo.init(modifier)
+		end
+
+		local modifiers = self:get_or_add("modifiers", {})
+		modifiers[#modifiers+1] = modifier
+
+		modifiersPanel:FireEvent('refreshModifiers')
+	end
+
 	modifiersPanel = gui.Panel{
 		classes = "modifiers-panel",
 
@@ -589,112 +648,7 @@ function CharacterFeature:EditorPanel(editorPanelOptions)
 				end
 			end
 
-			-- Dispatcher for a chosen modifier type id. Used by both the classic
-			-- dropdown (change) and the themed picker (onAdd). The special
-			-- "CLIPBOARD" id pastes the internal clipboard entry.
-			local function addModifierById(typeId)
-				if typeId == nil or typeId == 'none' then return end
-
-				if typeId == 'CLIPBOARD' then
-					local clipboardItem = dmhub.GetInternalClipboard()
-					if clipboardItem ~= nil and clipboardItem.typeName == 'CharacterModifier' then
-						local modifier = DeepCopy(clipboardItem)
-						DeepReplaceGuids(modifier)
-						local modifiers = self:get_or_add("modifiers", {})
-						modifiers[#modifiers+1] = modifier
-						modifiersPanel:FireEvent('refreshModifiers')
-					elseif clipboardItem ~= nil and clipboardItem.typeName == "ActivatedAbility" then
-						local ability = DeepCopy(clipboardItem)
-						DeepReplaceGuids(ability)
-						local modifier = CharacterModifier.new{
-							guid = dmhub.GenerateGuid(),
-							name = ability.name,
-							description = "",
-							behavior = "activated",
-							activatedAbility = ability,
-						}
-						local modifiers = self:get_or_add("modifiers", {})
-						modifiers[#modifiers+1] = modifier
-						modifiersPanel:FireEvent('refreshModifiers')
-					end
-					return
-				end
-
-				local domains = nil
-				if self:has_key("domains") then
-					domains = DeepCopy(self.domains)
-				end
-				local modifier = CharacterModifier.new{
-					guid = dmhub.GenerateGuid(),
-					sourceguid = self.guid,
-					name = self.name,
-					source = self.source,
-					description = self.description,
-					behavior = typeId,
-					domains = domains,
-				}
-				local typeInfo = CharacterModifier.TypeInfo[modifier.behavior] or {}
-				if typeInfo.init then
-					typeInfo.init(modifier)
-				end
-
-				local modifiers = self:get_or_add("modifiers", {})
-				modifiers[#modifiers+1] = modifier
-
-				modifiersPanel:FireEvent('refreshModifiers')
-			end
-
-			if themed and type(abilityEditor.OpenModifierPicker) == "function" then
-				-- Mirror the ability editor's bottom-bar layout: Add next to
-				-- Paste, with Paste collapsed-anim'd in only when the
-				-- internal clipboard holds a pasteable modifier/ability.
-				local function clipboardHasPasteable()
-					local item = dmhub.GetInternalClipboard()
-					if item == nil then return false end
-					return item.typeName == "CharacterModifier"
-						or item.typeName == "ActivatedAbility"
-					end
-
-				local pasteButton
-				pasteButton = gui.Button{
-					text = "Paste Modifier",
-					fontSize = 16,
-					width = 180,
-					height = 34,
-					halign = "left",
-					classes = {cond(not clipboardHasPasteable(), "collapsed-anim")},
-					click = function(element)
-						addModifierById("CLIPBOARD")
-					end,
-                    internalClipboardChanged = function(element)
-                        element:SetClass("collapsed-anim", not clipboardHasPasteable())
-                    end,
-				}
-
-				children[#children+1] = gui.Panel{
-					width = "auto",
-					height = "auto",
-					flow = "horizontal",
-					halign = "left",
-					valign = "center",
-					vmargin = 8,
-					bgcolor = "clear",
-					children = {
-						gui.Button{
-							text = "+ Add Modifier",
-							fontSize = 16,
-							width = 180,
-							height = 34,
-							halign = "left",
-							rmargin = 8,
-							click = function(element)
-								abilityEditor.OpenModifierPicker(self, addModifierById)
-							end,
-						},
-						pasteButton,
-					},
-				}
-			else
+			if not themed then
 				local options = DeepCopy(CharacterModifier.Types)
 				options[1].text = 'Add Modifier...'
 				table.sort(options, function(a, b)
@@ -935,14 +889,82 @@ function CharacterFeature:EditorPanel(editorPanelOptions)
 		children = innerRows,
 	}
 
-	local args = {
+	-- Themed mode builds a persistent Add / Paste Modifier bottom bar that
+	-- sits outside the scroll area (sticky at the bottom of the popup)
+	-- rather than scrolling with the modifier list. Mirrors the ability
+	-- editor's effectsBottomBar (AbilityEditor.lua:4813) so the feature
+	-- panel feels consistent with the sectioned ability editor.
+	local modifierBottomBar = nil
+	if themed and type(abilityEditor.OpenModifierPicker) == "function" then
+		local function clipboardHasPasteable()
+			local item = dmhub.GetInternalClipboard()
+			if item == nil then return false end
+			return item.typeName == "CharacterModifier"
+				or item.typeName == "ActivatedAbility"
+		end
+
+		local pasteButton
+		pasteButton = gui.Button{
+			text = "Paste Modifier",
+			fontSize = 16,
+			width = 180,
+			height = 34,
+			halign = "left",
+			classes = {cond(not clipboardHasPasteable(), "collapsed-anim")},
+			click = function(element)
+				addModifierById("CLIPBOARD")
+			end,
+			internalClipboardChanged = function(element)
+				element:SetClass("collapsed-anim", not clipboardHasPasteable())
+			end,
+		}
+
+		modifierBottomBar = gui.Panel{
+			classes = {"feature-modifier-bottom-bar"},
+			width = "100%",
+			height = "auto",
+			flow = "horizontal",
+			halign = "left",
+			valign = "center",
+			vmargin = 4,
+			hpad = 16,
+			bgcolor = "clear",
+			borderBox = true,
+			children = {
+				gui.Button{
+					text = "+ Add Modifier",
+					fontSize = 16,
+					width = 180,
+					height = 34,
+					halign = "left",
+					rmargin = 8,
+					click = function(element)
+						abilityEditor.OpenModifierPicker(self, addModifierById)
+					end,
+				},
+				pasteButton,
+			},
+		}
+	end
+
+	-- Scroll panel: holds the form rows + modifier cards (everything that
+	-- should scroll). In themed mode we wrap this in an outer vertical
+	-- container with the sticky bottom bar as a sibling; in classic mode
+	-- this IS the contentPanel (no bottom bar, dropdown lives inside the
+	-- scrolling modifiersPanel as before).
+	-- Scroll panel size depends on whether we're wrapping in an outer
+	-- themed container. With the bottom bar: the outer wrapper is 90%,
+	-- scroll is 100% of wrapper minus ~60px for the bar. Without the bar
+	-- (classic or noscroll): scroll is the returned panel, keep the old
+	-- 90% width and 90%/auto height.
+	local hasBottomBar = modifierBottomBar ~= nil and not noscroll
+	local scrollArgs = {
 		id = "featureScroll",
 		classes = 'content-panel',
 		vscroll = not noscroll,
 
-		width = "90%",
-        height = cond(noscroll, "auto", "90%"),
-
+		width = hasBottomBar and "100%" or "90%",
+		height = hasBottomBar and "100%-60" or cond(noscroll, "auto", "90%"),
 
 		styles = effectiveStyles,
 
@@ -959,15 +981,39 @@ function CharacterFeature:EditorPanel(editorPanelOptions)
 	}
 
 	if noscroll then
-		args.styles = DeepCopy(args.styles)
-		args.styles[1].height = "auto"
+		scrollArgs.styles = DeepCopy(scrollArgs.styles)
+		scrollArgs.styles[1].height = "auto"
 	end
 
+	-- Apply caller-supplied editorPanelOptions to the scroll panel so
+	-- things like modifierRefreshed event handlers still land where the
+	-- caller expects them (the element whose think callback fires them).
 	for k,v in pairs(editorPanelOptions) do
-		args[k] = v
+		scrollArgs[k] = v
 	end
 
-	contentPanel = gui.Panel(args)
+	local scrollPanel = gui.Panel(scrollArgs)
+
+	if not hasBottomBar then
+		-- Classic path (or themed without picker, or noscroll embedding):
+		-- scroll panel IS the returned contentPanel, same as before this
+		-- refactor.
+		contentPanel = scrollPanel
+	else
+		-- Themed path: outer vertical container holds the scroll + sticky
+		-- bottom bar. Width/height/halign mirror the original scroll
+		-- args so PopupEditor's frame sizing is unchanged.
+		contentPanel = gui.Panel{
+			classes = {'feature-content-wrapper'},
+			width = "90%",
+			height = cond(noscroll, "auto", "90%"),
+			halign = "center",
+			valign = "top",
+			flow = "vertical",
+			bgcolor = "clear",
+			children = { scrollPanel, modifierBottomBar },
+		}
+	end
 
 	return contentPanel
 

--- a/DMHub Game Rules/CharacterModifier.lua
+++ b/DMHub Game Rules/CharacterModifier.lua
@@ -216,8 +216,8 @@ function CharacterModifier:ResourceCostEditor(options)
 
 
 	local args = {
-		classes = "formPanel",
-	
+		classes = {"formPanel", "formPanel-inline"},
+
 		gui.Dropdown{
 			classes = "formDropdown",
 			idChosen = self:try_get("resourceCost", "none"),
@@ -260,7 +260,7 @@ function CharacterModifier:UsageLimitEditor(options)
 	options.perspell = nil
 
 	local args = {
-		classes = {'formPanel'},
+		classes = {'formPanel', 'formPanel-inline'},
 		children = {
 			gui.Dropdown{
 				selfStyle = {
@@ -952,7 +952,7 @@ CharacterModifier.TypeInfo.resistance = {
 
 			children[#children+1] = gui.Panel{
 				id = 'resistance-apply-container',
-				classes = {'formPanel', cond(#ResistanceEntry.types <= 1, "collapsed")},
+				classes = {'formPanel', 'formPanel-inline', cond(#ResistanceEntry.types <= 1, "collapsed")},
 				children = {
 					gui.Dropdown{
 						id = 'resistance-apply-dropdown',
@@ -1080,7 +1080,7 @@ CharacterModifier.TypeInfo.resistance = {
                     if val == true then
                         keywordsFound[keyword] = true
                         children[#children+1] = gui.Panel{
-                            classes = {"formPanel"},
+                            classes = {"formPanel", "formPanel-inline"},
                             data = {ord = keyword},
                             width = 200,
                             height = 14,

--- a/DMHub Game Rules/ModifierGrantSpells.lua
+++ b/DMHub Game Rules/ModifierGrantSpells.lua
@@ -128,7 +128,7 @@ CharacterModifier.TypeInfo.grantSpells = {
                 local spellInfo = spellsTable[spellid]
                 if spellInfo ~= nil then
                     children[#children+1] = gui.Panel{
-                        classes = {"formPanel"},
+                        classes = {"formPanel", "formPanel-inline"},
                         gui.Label{
                             classes = {"formLabel"},
                             text = spellInfo.name,

--- a/DMHub Game Rules/ModifierModifyAbilities.lua
+++ b/DMHub Game Rules/ModifierModifyAbilities.lua
@@ -667,7 +667,7 @@ CharacterModifier.TypeInfo.modifyability = {
 				local info = abilityModifierOptionsById[attr.id]
 				if info ~= nil then
 					children[#children+1] = gui.Panel{
-						classes = {"formPanel"},
+						classes = {"formPanel", "formPanel-inline"},
 						gui.Label{
 							classes = {"formLabel"},
 							width = 400,
@@ -847,7 +847,7 @@ CharacterModifier.TypeInfo.modifyability = {
 
 							for filterIndex,filter in ipairs(reasonedFilters) do
 								children[#children+1] = gui.Panel{
-									classes = {"formPanel"},
+									classes = {"formPanel", "formPanel-inline"},
 									gui.Label{
 										classes = "formLabel",
 										text = "Formula:",

--- a/DS_EDITOR_STYLING.md
+++ b/DS_EDITOR_STYLING.md
@@ -1,0 +1,214 @@
+# Draw Steel Editor Styling Guide
+
+Reference for any Draw Steel editor UI work — the Ability Editor, the forthcoming Feature Panel + Modifier Picker, the Triggered Ability editor rewrite, and the wider compendium restyling.
+
+This doc is the accumulated practical knowledge from building the sectioned Ability Editor. Read it before touching any editor surface. Repo-level UI patterns live in [UI_BEST_PRACTICES.md](UI_BEST_PRACTICES.md); this doc is DS-editor-specific.
+
+---
+
+## Palette
+
+Eight colors, used consistently across every DS editor. The canonical source is `AbilityEditor.COLORS` in `Draw Steel Ability Editor/AbilityEditor.lua`.
+
+| Token | Hex | Role |
+|---|---|---|
+| `BG` | `#080B09` | Outer dialog background |
+| `PANEL_BG` | `#10110F` | Control backgrounds (dropdown, input, button) |
+| `GOLD` | `#966D4B` | Borders, dividers (neutral state) |
+| `GOLD_BRIGHT` | `#F1D3A5` | Section headings, title, check-mark |
+| `GOLD_DIM` | `#E9B86F` | Hover states, nav selected bg |
+| `CREAM` | `#BC9B7B` | Neutral body text |
+| `CREAM_BRIGHT` | `#DFCFC0` | Emphasis text, control text |
+| `GRAY` | `#666663` | Placeholder, disabled |
+
+When a future editor needs a variant (e.g. an alt color for a specific panel type), pass a custom table to `AbilityEditor.GetSharedWidgetStyles(colors)` — the helper is palette-parameterized.
+
+## Shared widget styles (exported)
+
+Call site:
+
+```lua
+local styles = AbilityEditor.GetSharedWidgetStyles()  -- returns a fresh table
+-- or
+local styles = AbilityEditor.GetSharedWidgetStyles(myCustomColors)
+```
+
+Drop into the root panel's `styles = { ... }` list. Returns priority-3+ overrides covering:
+
+- `Styles.Form` base + left-anchoring overrides for `formPanel`/`formLabel`/`formDropdown`/`formInput`/`formValue`
+- `dropdown` + hover + open + `dropdownLabel`/`dropdownTriangle` on hover + `dropdown-list` + `dropdown-item` + hover
+- `input` + hover + focus
+- `button` + hover + press + disabled
+- `checkbox` + `checkbox-label` + `check-background` + `check-mark`
+- `delete-item-button` + hover (priority 11 to beat engine defaults)
+- `sliderLabel`
+
+Editor-specific styles (`nae-*` classes, section headings, nav rows, pills, etc.) are NOT in the shared pack — those live inline in `_editorStyles()` in the Ability Editor. The shared pack is for generic widgets only.
+
+## Form row pattern
+
+The **stacked label above, control below** layout is the DS form standard. Every editor row should follow it.
+
+- Row: `flow = "vertical"`, `width = "100%"`, `halign = "left"`, `valign = "top"`, `vmargin = 8`
+- Label: 14pt, `bold = true`, color `CREAM_BRIGHT`, `bmargin = 4`
+- Control: full-width themed input/dropdown/textarea/checkbox (the shared widget styles already theme these)
+- Inline variant (label + small control on one row) reserved for compact fields like 3-digit numbers
+
+`AbilityEditor.GetSharedFormStyles()` carries the `ds-field-row` / `ds-field-label` / `ds-field-row-inline` / `ds-field-label-inline` rules for editors that build their form chrome from scratch.
+
+### `formPanel` (legacy / modifier sub-editors)
+
+Modifier `createEditor` functions emit rows tagged `classes = {"formPanel"}` (with `formLabel`/`formInput` children). The themed style pack `AbilityEditor.GetThemedDialogStyles()` gives these the DS treatment automatically:
+
+- **Default (stacked):** a bare `formPanel` lays out as vertical flow, 100% width, with the `formLabel` stretched above its control. This matches the outer feature panel's Name / Source / Description rows.
+- **Opt-in inline:** add `"formPanel-inline"` to the classes list when the row hosts 2+ side-by-side widgets (Replace + New-Text inputs, Label + delete button, dropdown + dropdown, etc.). The `parent:formPanel-inline` selector restores the legacy horizontal flow + 140px label column for descendants, so children don't need their own inline class.
+
+```lua
+-- Stacked (default): Label above, input below.
+gui.Panel{
+    classes = {"formPanel"},
+    gui.Label{ classes = {"formLabel"}, text = "Name:" },
+    gui.Input{ classes = {"formInput"}, text = entry.name, ... },
+}
+
+-- Inline: Label + multiple widgets on one row (delete + dropdown + input, etc.).
+gui.Panel{
+    classes = {"formPanel", "formPanel-inline"},
+    gui.Label{ classes = {"formLabel"}, text = info.text },
+    gui.DeleteItemButton{ ... },
+}
+```
+
+When in doubt, default to stacked -- it is the lead-dev-blessed standard. Only add `formPanel-inline` when horizontal layout is intentional.
+
+**Gotcha -- conditionally-hidden children need `formPanel-inline`.** If a row's children use `SetClass('hidden', ...)` or `hidden = cond(...)` to hide/show widgets dynamically (rather than the whole row), that row must be inline. `hidden` suppresses rendering but keeps the layout slot -- in a vertical flow the hidden child reserves a blank row of dead space. Horizontal flow absorbs the width cleanly. `CharacterModifier:UsageLimitEditor()` is the canonical example: its "Uses:" label + GoblinScriptInput + "ID:" label + Input hide when refresh type is "none", and the row was horizontal by design.
+
+Classic mode (`classicAbilityEditor = true`) keeps the old `Styles.Form` pack and is unaffected by either default.
+
+## Conditional disclosure
+
+Fields that appear/disappear based on a parent toggle (e.g. Persistence sub-cluster) should use the `collapsed-anim` engine class for smooth expand/collapse, not rebuild on toggle.
+
+```lua
+classes = { "your-row-class", cond(isEnabled(), nil, "collapsed-anim") },
+refreshAbility = function(element)
+    element:SetClass("collapsed-anim", not isEnabled())
+end,
+```
+
+---
+
+## Gotchas
+
+Things that bit during the Ability Editor build. Read before the same wall of pain bites again.
+
+### Styling cascades
+
+- **Priority 3 beats engine defaults.** Priority 4 needed for dropdown hover overrides — the engine sets `dropdownLabel parent:hover color=black` and `dropdownTriangle parent:hover bgcolor=black` at `DMHub Titlescreen/Styles.lua:295`.
+- **Don't put `width = "100%"` on the base `dropdown` selector** — it overrides `formDropdown`'s 240px inside SourceReference.
+- **Class-toggled `width` on a panel doesn't always take.** Use direct `panel.width = N` assignment for column sizing (preview/detail columns do this).
+- **`scale` IS restylable** via class-based rules (used for chevron flips in collapsible sections).
+- **`delete-item-button` uses priority-10 internal styles** (`bgcolor=white` normal, `bgcolor=red` hover) — beat at priority 11.
+- **Textarea `textAlignment`** needs priority 3 so `"topleft"` beats the base `input` style's `"left"`.
+
+### Styles.Form integration
+
+- **Include `Styles.Form` first** in the root panel's `styles = { ... }`. Required for SourceReference widgets (they use `formPanel`/`formLabel`/`formDropdown`/`formInput` classes internally).
+- **Left-aligning Styles.Form descendants** requires `formPanel width="auto" halign="left"` + `formLabel minWidth=0` at priority 5. The base pack right-aligns them and overriding halign alone is not enough.
+- **SourceReference:Editor emits its own "Source:" label.** Don't wrap it in another label row or you get a duplicate.
+
+### Panel layout
+
+- **`collapsed = 1` zeros the layout slot.** `hidden = 1` only suppresses rendering and keeps the slot.
+- **`collapsed` is an engine-reserved class name.** `SetClassTree("collapsed", true)` nukes the entire subtree. Use private class names (`nae-narrow`, `nae-collapsed`, etc.) for state toggles.
+- **Always `borderBox = true`** with any `hpad`/`vpad`/`pad` — padding is otherwise added on top of the declared width.
+- **Do NOT rebuild panels on data change.** Use `SetClass` + `refresh*` events (`refreshAbility`, `refreshKeywords`, etc.). Dynamic children rebuilds should be change-guarded with a key derived from list-identity (see the behavior list key pattern in `AbilityEditor.lua`).
+- **Lazy section construction:** for big sectioned editors, construct only the active section's content on first activation. Building all sections upfront is the biggest source of open lag.
+
+### Lua language
+
+- **Forward-declared locals must be initialized to `nil`.** DMHub's Lua env errors on reads of uninitialized locals — `local x; if x ~= nil` throws "Attempt to read uninitialized variable". Always write `local x = nil`.
+- **Forward-declare self-referencing locals** for closures. `local p = gui.Panel{ click = function() p:SetClass(...) end }` is a bug — `p` is not in scope inside the initializer. Split into `local p` then `p = gui.Panel{...}`.
+- **`_tmp_` prefix** on a game-type field marks it as transient — the engine skips it during serialization. Reading a never-set `_tmp_` field errors; use `obj:try_get("_tmp_foo")` for safe access.
+- **`rawget(_G, "SomeGlobal")`** for cross-module global reads when the other module might not have loaded yet (handles nil safely).
+
+### DMHub API quirks
+
+- **`SetFocus` does not exist.** To focus an input, set `element.hasFocus = true` (property assignment, not a method call).
+- **`floating = true` must be inline** on the panel constructor, not in a `gui.Style{}` rule. Placing it in a style produces "Unknown style property" at runtime.
+- **`gui.panel.data` cleared on destroy.** After a dialog destroys, its panel objects still have Lua refs but their `data` bag is nil — deferred callbacks (debounced timers) that fire after destruction must `pcall` their `data` reads.
+- **`class.levels` is string-keyed** (`"level-1"`, `"tutoriallevel-3"`), not sequential. Use `pairs()`, never `ipairs()`. `#class.levels` returns 0.
+- **Subclass parent link** is `primaryClassId`, not `parentClass` (which is always empty).
+- **Inputs bake initial values at creation time.** After programmatically replacing a model object (e.g. template-apply), firing `refreshAbility` is not enough — rebuild the editor panel in its parent.
+
+### Refresh event scoping
+
+When a field edit should trigger a repaint, scope the refresh event to just the subtree that cares, not the whole editor:
+
+1. `refreshAbility` — tree-wide on the editor root. Use sparingly; many panels listen.
+2. Section-scoped events — fired on the owning section's content panel. Keeps handlers local.
+3. Direct-firing on a specific slot — e.g. `previewSlot:FireEvent("refreshPreview")` for the preview column. No tree walk at all.
+
+Debounce expensive rebuilds (preview cards, tooltip walks) with a short timer — 150ms coalesces rapid keystrokes to a single rebuild.
+
+### Module lifecycle
+
+- **Hot-reload-safe init:** `AbilityEditor = rawget(_G, "AbilityEditor") or {}` preserves the module table across reloads.
+- **Guard against stale closures** using `mod.unloaded`:
+  ```lua
+  dmhub.Schedule(delay, function()
+      if mod.unloaded then return end
+      -- ...
+  end)
+  ```
+- **Do NOT use `RegisterGameType` for a module namespace table** — it enforces strict field access and breaks the `rawget` pattern.
+
+---
+
+## MCP bridge (for testing)
+
+The DMHub MCP bridge lets Claude (or any tool) execute Lua inside the running app, reload modules, capture screenshots, and read console logs.
+
+### Starting the bridge
+
+In DMHub chat:
+- `/mcp` — start bridge for the current session
+- `/mcpauto` — start and persist across sessions
+
+Health check: `curl -s http://localhost:19876/health`
+
+### Tools
+
+Prefix `mcp__dmhub__`:
+
+- `check_connection` — is DMHub running + bridge reachable?
+- `execute_lua` — run arbitrary Lua in the global env; prints + return values are captured
+- `reload_lua` — equivalent to F4 (hot-reload all mods)
+- `get_console_log` — recent Unity console entries; supports `level` filter (`all`/`warning`/`error`), `pattern` substring, `last` N entries
+- `screenshot` / `screenshot_region` / `screenshot_panel` — visual verification
+- `inspect_ui` — panel hierarchy inspection at a coordinate
+- `restart_dmhub` / `start_dmhub` / `stop_dmhub` — process control
+
+### HTTP fallback
+
+If the MCP tools aren't available but the bridge is up:
+
+```bash
+curl -s http://localhost:19876/health
+curl -s -X POST -H "Content-Length: 0" http://localhost:19876/reload
+curl -s -X POST -H "Content-Type: application/json" \
+  -d '{"code": "print(\"hello\")"}' http://localhost:19876/execute
+curl -s -o /tmp/dmhub.png http://localhost:19876/screenshot
+```
+
+Endpoints: `/health` (GET), `/execute` (POST JSON `{code: "..."}`), `/reload` (POST empty), `/screenshot` (GET PNG), `/status` (GET).
+
+### Verification workflow
+
+After every Lua edit:
+
+1. `reload_lua` — no manual F4 needed
+2. `get_console_log` with `level = "error"` — catch load-time failures
+3. For visual changes, `screenshot_region` with `world`/`left`/`right` then `Read` the PNG
+
+Test-induced errors (from ad-hoc helpers forcing state) are usually distinguishable from production bugs by the `[string "code"]` source tag versus module names like `[string "Draw Steel Ability Editor : AbilityEditor"]`.

--- a/Draw Steel Ability Behaviors/AbilityMacro.lua
+++ b/Draw Steel Ability Behaviors/AbilityMacro.lua
@@ -31,7 +31,6 @@ function ActivatedAbilityMacroBehavior:EditorItems(parentPanel)
 
     result[#result+1] = gui.Panel{
         classes = {"formPanel"},
-        flow = "horizontal",
         gui.Label{
             classes = {"formLabel"},
             text = "Macro:",

--- a/Draw Steel Ability Editor/AbilityEditor.lua
+++ b/Draw Steel Ability Editor/AbilityEditor.lua
@@ -4683,6 +4683,12 @@ function AbilityEditor.GenerateEditor(ability)
         refreshAbility = function(element)
             element:SetClass("collapsed-anim", not _clipboardHasBehavior())
         end,
+        -- Fires when the internal clipboard changes (e.g. user copies a
+        -- behavior while this editor is open). Keeps the button's visibility
+        -- in sync without requiring the editor to be closed and reopened.
+        internalClipboardChanged = function(element)
+            element:SetClass("collapsed-anim", not _clipboardHasBehavior())
+        end,
     }
 
     effectsBottomBar = gui.Panel{

--- a/Draw Steel Ability Editor/AbilityEditor.lua
+++ b/Draw Steel Ability Editor/AbilityEditor.lua
@@ -4403,8 +4403,15 @@ end
 
     The preview column is always visible; the editor runs as a full-screen
     modal so the detail column has enough room even with the preview mounted.
+
+    Polling: behaviors' EditorItems are shared base code and have no hook
+    into the editor's fireChange helper, so typing in fields like a power-
+    roll tier text updates the ability's data but never triggers a preview
+    rebuild. We use a thinkTime-based poll on previewSlot to schedule a
+    refresh every 250ms. The existing debounce in _schedulePreviewRefresh
+    coalesces this with keystroke-driven refreshes so we don't double-run.
 ]]
-local function _makePreview(ability)
+local function _makePreview(ability, schedulePreviewRefresh)
     local previewSlot
     previewSlot = gui.Panel{
         id = "previewSlot",
@@ -4414,6 +4421,13 @@ local function _makePreview(ability)
         valign = "top",
         flow = "vertical",
         bgcolor = "clear",
+
+        thinkTime = 0.25,
+        think = function(element)
+            if schedulePreviewRefresh ~= nil then
+                schedulePreviewRefresh()
+            end
+        end,
 
         refreshPreview = function(element)
             -- Wrap the tooltip card in a width-constrained container so the
@@ -4739,7 +4753,7 @@ function AbilityEditor.GenerateEditor(ability)
         children = {detailScroll, effectsBottomBar},
     }
 
-    previewCol, previewSlot = _makePreview(ability)
+    previewCol, previewSlot = _makePreview(ability, _schedulePreviewRefresh)
 
     local bodyRow = gui.Panel{
         id = "bodyRow",

--- a/Draw Steel Ability Editor/AbilityEditor.lua
+++ b/Draw Steel Ability Editor/AbilityEditor.lua
@@ -1047,6 +1047,7 @@ local function _sharedWidgetStyles(colors)
             hpad = 6,
             vpad = 2,
             borderBox = true,
+            fontFace = "Berling",
             fontSize = 14,
             color = c.CREAM_BRIGHT,
             textAlignment = "left",
@@ -1086,6 +1087,7 @@ local function _sharedWidgetStyles(colors)
             priority = 3,
             bgcolor = "clear",
             color = c.CREAM_BRIGHT,
+            fontFace = "Berling",
             fontSize = 14,
             hpad = 6,
             vpad = 2,
@@ -1107,6 +1109,7 @@ local function _sharedWidgetStyles(colors)
             hpad = 6,
             vpad = 2,
             borderBox = true,
+            fontFace = "Berling",
             fontSize = 14,
             color = c.CREAM_BRIGHT,
             textAlignment = "left",
@@ -1578,35 +1581,58 @@ local function _themedDialogStyles(colors)
         vmargin = 4,
     }
 
-    -- Tighten formPanel/formLabel descendants so modifier sub-editor rows
-    -- match the behavior editor's density. Horizontal flow is preserved --
-    -- some modifier editors (Modify Power Roll's "Replace in Table" row)
-    -- emit multiple inputs in one formPanel expecting them side-by-side.
-    -- width = "auto" shrinks the row to fit its content, so combined with
-    -- halign = "left" everything anchors to the left edge instead of
-    -- centering within a 100%-wide row.
+    -- Stacked-label form pattern for modifier sub-editor rows: label on
+    -- its own line above the control, matching the outer feature panel's
+    -- Name / Source / Description fields. Rows that want multiple inputs
+    -- side-by-side (Modify Power Roll's "Replace in Table" / "New Text"
+    -- pair, damage-type swaps, etc.) opt in with the `formPanel-inline`
+    -- class, which restores the legacy horizontal layout + a fixed-width
+    -- label column. Parent-class selectors target the label and widgets
+    -- inside inline rows so the opt-in is a single class flip on the
+    -- parent -- children don't need to know.
     styles[#styles+1] = gui.Style{
         selectors = {"formPanel"},
         priority = 7,
-        flow = "horizontal",
-        width = "auto",
+        flow = "vertical",
+        width = "100%",
         height = "auto",
         minHeight = 0,
         halign = "left",
-        valign = "center",
+        valign = "top",
         pad = 0,
+        vmargin = 8,
+    }
+    styles[#styles+1] = gui.Style{
+        selectors = {"formPanel-inline"},
+        priority = 8,
+        flow = "horizontal",
+        width = "auto",
+        halign = "left",
+        valign = "center",
         vmargin = 4,
     }
     styles[#styles+1] = gui.Style{
         selectors = {"formLabel"},
         priority = 7,
-        width = 140,
+        width = "100%",
         halign = "left",
-        valign = "center",
+        valign = "top",
         fontSize = 14,
         bold = true,
         color = c.CREAM_BRIGHT,
         textAlignment = "left",
+        hmargin = 0,   -- base Styles.Form sets hmargin = 8, which indents
+                        -- the stacked-mode label text 8px to the right of
+                        -- the input frame below. Zero it so the label
+                        -- lines up with the input's visible left edge.
+        bmargin = 4,
+    }
+    styles[#styles+1] = gui.Style{
+        selectors = {"formLabel", "parent:formPanel-inline"},
+        priority = 8,
+        width = 140,
+        valign = "center",
+        bmargin = 0,
     }
     -- formInput is the classic class most modifier sub-editors attach to
     -- their gui.Input. Themed version gets DS chrome + left halign so the
@@ -1626,6 +1652,85 @@ local function _themedDialogStyles(colors)
         vpad = 2,
         borderBox = true,
         textAlignment = "left",
+    }
+
+    -- Alignment fix 1: callers of gui.GoblinScriptInput typically pass
+    -- `classes = "formInput"`, which brings a 6px hpad on the outer
+    -- wrapper Panel. That hpad reserves layout space on the left, so
+    -- the inner (visible) Input's frame sits 6px to the right of a
+    -- plain gui.Input's frame in the row above, AND the condition-box
+    -- edge doesn't line up with the Macro-input-box edge in the same
+    -- column. The outer wrapper has no bgimage so its border doesn't
+    -- render anyway -- only the hpad has visible effect on layout.
+    --
+    -- Fix: zero hpad on the outer wrapper (tagged `goblinscript-outer`
+    -- from the widget itself in DMHub Core Panels/GoblinScriptEditor.lua)
+    -- so the inner Input sits flush-left with plain Inputs. Leave the
+    -- inner `goblinscript-inner-input` alone so it keeps its default
+    -- 6px hpad -- that's the gap between the visible box border and
+    -- the editable text, matching what plain Inputs show.
+    styles[#styles+1] = gui.Style{
+        selectors = {"goblinscript-outer"},
+        priority = 8,
+        hpad = 0,
+    }
+
+    -- Alignment fix 2: the engine base pack gives dropdownLabel a
+    -- built-in 6px hmargin + fontSize 18 (DMHub Titlescreen/Styles.lua:284).
+    -- Inside a themed dialog the dropdown's chosen-text then sits 6px
+    -- right of the input text below it, and renders visibly larger.
+    -- Align with input body by zeroing the hmargin and dropping the
+    -- fontSize to match formInput's 14.
+    styles[#styles+1] = gui.Style{
+        selectors = {"dropdownLabel"},
+        priority = 8,
+        hmargin = 0,
+        fontSize = 14,
+        fontFace = "Berling",
+        color = c.CREAM_BRIGHT,
+    }
+
+    -- gui.Table theming. The engine's Styles.Table pack paints rows in
+    -- neutral grays (#222 / #444) and white labels -- jarring inside the
+    -- DS gold/cream frame. Override at priority 8 so the theme wins
+    -- wherever `Styles.Table` is spliced alongside these styles. Applies
+    -- to every gui.Table rendered under a themed dialog (power roll tier
+    -- table, rollable tables, etc.). Row bg alternates between PANEL_BG
+    -- and a slightly-lighter offset to keep the stripe subtle; a thin
+    -- gold hairline separates rows. Labels pick up CREAM_BRIGHT; inputs
+    -- nested in rows still use the formInput theming.
+    styles[#styles+1] = gui.Style{
+        selectors = {"row"},
+        priority = 8,
+        width = "auto",
+        height = "auto",
+        bgimage = "panels/square.png",
+        border = {y1 = 0, y2 = 1, x1 = 0, x2 = 0},
+        borderColor = c.GOLD .. "55",
+    }
+    styles[#styles+1] = gui.Style{
+        selectors = {"row", "oddRow"},
+        priority = 8,
+        bgcolor = c.PANEL_BG,
+    }
+    styles[#styles+1] = gui.Style{
+        selectors = {"row", "evenRow"},
+        priority = 8,
+        bgcolor = c.BG,
+    }
+    styles[#styles+1] = gui.Style{
+        selectors = {"row", "highlight"},
+        priority = 8,
+        bgcolor = c.GOLD_DIM,
+    }
+    styles[#styles+1] = gui.Style{
+        selectors = {"row", "label"},
+        priority = 8,
+        pad = 8,
+        fontSize = 16,
+        color = c.CREAM_BRIGHT,
+        width = "auto",
+        height = "auto",
     }
 
     return styles

--- a/Draw Steel Ability Editor/AbilityEditor.lua
+++ b/Draw Steel Ability Editor/AbilityEditor.lua
@@ -38,14 +38,11 @@ end
     ============================================================================
     Layout constants
     ============================================================================
-    The compendium dialog (ActivatedAbilityEditor.lua:4762) gives us a 1200x980
-    outer frame, with an inner content region of roughly 1100x840. We claim the
-    full inner region with a three-column body under a title strip.
+    The compendium dialog (ActivatedAbilityEditor.lua) is resized to fill the
+    screen when the sectioned editor is active. We claim 100% of that area
+    with a three-column body under a title strip.
 ]]
 local LAYOUT = {
-    ROOT_WIDTH = 1100,
-    ROOT_HEIGHT = 840,
-
     TITLE_HEIGHT = 44,
 
     NAV_WIDTH = 220,
@@ -54,9 +51,7 @@ local LAYOUT = {
     -- enough room for that plus padding, so description text wraps to the
     -- card's natural width rather than being squeezed.
     PREVIEW_WIDTH = 440,
-    -- When collapsed the preview column shrinks to just the reveal chevron.
-    PREVIEW_COLLAPSED_WIDTH = 40,
-    -- Detail width falls out as whatever the nav and preview leave behind.
+    -- Detail column fills whatever remains between nav and preview.
 
     NAV_BUTTON_HEIGHT = 42,
     NAV_BUTTON_VMARGIN = 6,
@@ -654,18 +649,7 @@ local function _editorStyles()
             textAlignment = "left",
             rmargin = 4,
         },
-        -- Preview column. Two states: expanded (full preview card visible)
-        -- and narrow (thin strip with just the chevron + clickable reveal
-        -- target). The state class is `nae-narrow` rather than `collapsed`,
-        -- because the engine treats `collapsed` as an auto-hide class on
-        -- every element it lands on -- `SetClassTree("collapsed", true)` was
-        -- hiding the chevron and everything else in the subtree. Using a
-        -- private class name keeps propagation safe.
-        -- Width is driven by direct `previewCol.width = N` assignment in
-        -- applyPreviewState (not via class) because class-based width
-        -- resolution did not take effect reliably. hpad is likewise driven
-        -- inline by the applyPreviewState mutation (not shown here) so the
-        -- 40px narrow column has room for a 16px chevron.
+        -- Preview column. Always visible; fixed width from LAYOUT.PREVIEW_WIDTH.
         gui.Style{
             selectors = {"nae-preview-col"},
             bgcolor = "clear",
@@ -673,13 +657,7 @@ local function _editorStyles()
         gui.Style{
             selectors = {"nae-preview-body"},
             width = "100%",
-            -- 20px toggle strip + 4px bottom margin = 24px header area.
-            height = "100%-24",
-        },
-        -- In narrow state hide the preview card entirely.
-        gui.Style{
-            selectors = {"nae-preview-body", "nae-narrow"},
-            collapsed = 1,
+            height = "100%",
         },
         gui.Style{
             selectors = {"nae-preview-heading"},
@@ -688,47 +666,7 @@ local function _editorStyles()
             bold = true,
             color = COLORS.GOLD_BRIGHT,
             textAlignment = "left",
-        },
-        -- In narrow state hide the "Preview" heading -- no room in 40px.
-        gui.Style{
-            selectors = {"nae-preview-heading", "nae-narrow"},
-            collapsed = 1,
-        },
-        -- Preview toggle header -- a thin horizontal strip with the chevron
-        -- icon pinned to the right. Lives at the top of the preview column,
-        -- so it stays visible when the body is collapsed.
-        gui.Style{
-            selectors = {"nae-preview-toggle-row"},
-            width = "100%",
-            height = 20,
-            flow = "horizontal",
-            halign = "left",
-            valign = "top",
-            bgcolor = "clear",
             bmargin = 4,
-        },
-        -- Image-based chevron. Uses the same InventoryArrow asset as
-        -- gui.PagingArrow, which is a known-working horizontal chevron.
-        -- scale = {x = -1, y = 1} points the arrow right (expanded state:
-        -- click to collapse); in narrow state the x-scale flips to point
-        -- the arrow left (click to expand). Gold tint via bgcolor.
-        gui.Style{
-            selectors = {"nae-preview-toggle-chevron"},
-            width = 16,
-            height = 16,
-            valign = "center",
-            bgimage = "panels/InventoryArrow.png",
-            bgcolor = COLORS.GOLD_BRIGHT,
-            scale = {x = -1, y = 1},
-            transitionTime = 0.15,
-        },
-        gui.Style{
-            selectors = {"nae-preview-toggle-chevron", "nae-narrow"},
-            scale = {x = 1, y = 1},
-        },
-        gui.Style{
-            selectors = {"nae-preview-toggle-chevron", "hover"},
-            bgcolor = COLORS.CREAM_BRIGHT,
         },
         -- Title strip
         gui.Style{
@@ -760,9 +698,8 @@ local function _editorStyles()
             textAlignment = "left",
             hmargin = 12,
         },
-        -- Detail col width is driven by direct `detailCol.width = N`
-        -- assignment in applyPreviewState, alongside the preview column.
-        -- The border budget (8px off the total) is applied there.
+        -- Detail col width is set once at construction time (the preview
+        -- column is always visible, no collapse handling needed).
 
         -- ================================================================
         -- Effects section: behavior list
@@ -4464,12 +4401,10 @@ end
     content when the root panel fires "refreshPreview" -- field editors fire
     this through their shared fireChange() helper.
 
-    The preview column is collapsible: a chevron in the column's top-right
-    toggles a "collapsed" class on the column + heading + body. The detail
-    column gets a "preview-collapsed" class that widens it. Per-section
-    defaults (PREVIEW_DEFAULTS) drive the state when switching nav buttons.
+    The preview column is always visible; the editor runs as a full-screen
+    modal so the detail column has enough room even with the preview mounted.
 ]]
-local function _makePreview(ability, onToggle)
+local function _makePreview(ability)
     local previewSlot
     previewSlot = gui.Panel{
         id = "previewSlot",
@@ -4552,52 +4487,26 @@ local function _makePreview(ability, onToggle)
         children = { previewSlot },
     }
 
-    -- Top strip: toggle chevron + (when expanded) the "Preview" heading
-    -- live in the same horizontal row. The whole strip is clickable so the
-    -- user has a large hit target.
-    local toggleStrip = gui.Panel{
-        classes = {"nae-preview-toggle-row"},
-        id = "previewToggle",
-        click = function(element)
-            if onToggle ~= nil then
-                onToggle()
-            end
-        end,
-        children = {
-            gui.Label{
-                classes = {"nae-preview-heading"},
-                text = "Preview",
-                width = "100%-24",
-                halign = "left",
-                valign = "center",
-            },
-            gui.Panel{
-                classes = {"nae-preview-toggle-chevron"},
-            },
-        },
+    local headingLabel = gui.Label{
+        classes = {"nae-preview-heading"},
+        text = "Preview",
+        width = "100%",
+        halign = "left",
+        valign = "top",
     }
 
     local colPanel = gui.Panel{
         classes = {"nae-preview-col"},
         id = "previewCol",
-        -- Initial width is the expanded state; applyPreviewState overwrites
-        -- this via direct assignment on toggle and on section switch.
         width = LAYOUT.PREVIEW_WIDTH,
         height = "100%",
         flow = "vertical",
-        -- halign omitted: in horizontal flow, the bodyRow places us after
-        -- nav + detail naturally. Setting halign = "right" was making the
-        -- engine push us flush to bodyRow's right edge, eliminating the
-        -- small slack that kept the preview card clear of the gold border.
         valign = "top",
-        -- Minimal hpad so the card uses nearly the full column width.
-        -- applyPreviewState flips this to 4 for the narrow state to fit
-        -- the 16px chevron.
         hpad = 4,
         vpad = LAYOUT.COL_VPAD,
         borderBox = true,
         children = {
-            toggleStrip,
+            headingLabel,
             scrollArea,
         },
     }
@@ -4623,45 +4532,10 @@ function AbilityEditor.GenerateEditor(ability)
     local effectsBottomBar = nil
     local previewSlot = nil
 
-    -- Preview column state. Single source of truth on the root panel's data
-    -- bag. Widths are driven via direct `panel.width = N` assignment because
-    -- class-based width resolution did not take effect reliably in this
-    -- engine version (prior attempt logged in STATUS.md / NOTES.md). The
-    -- class toggle still drives the heading/body collapse and the chevron
-    -- scale flip via style rules.
-    -- Private class name `nae-narrow` (NOT `collapsed`) so unrelated
-    -- descendants don't auto-hide via the engine-reserved `collapsed`
-    -- class rule.
-    local function applyPreviewState(narrow)
-        if rootPanel == nil then return end
-        rootPanel.data.previewNarrow = narrow
-        local previewWidth = narrow and LAYOUT.PREVIEW_COLLAPSED_WIDTH or LAYOUT.PREVIEW_WIDTH
-        -- Border budget: 8px reserved so nav + detail + preview don't clip
-        -- the root's 2px gold border on either side.
-        previewCol.width = previewWidth
-        detailCol.width = LAYOUT.ROOT_WIDTH - LAYOUT.NAV_WIDTH - previewWidth - 8
-        previewCol:SetClassTree("nae-narrow", narrow)
-        -- When expanding from narrow, flush any deferred preview rebuild
-        -- that was skipped while the preview was collapsed.
-        if not narrow and rootPanel.data.previewDirty and previewSlot ~= nil then
-            rootPanel.data.previewDirty = false
-            previewSlot:FireEvent("refreshPreview")
-        end
-    end
-
-    -- Manual toggle. Also updates the user's sticky preference so that
-    -- leaving and re-entering a non-Effects section restores whatever the
-    -- user last chose (rather than snapping back to expanded).
-    local function togglePreview()
-        local current = rootPanel.data.previewNarrow or false
-        local newNarrow = not current
-        rootPanel.data.userPreviewNarrow = newNarrow
-        applyPreviewState(newNarrow)
-    end
-
     -- Debounce state for preview rebuilds. Coalesces rapid edits (e.g.
     -- keystrokes in a text field) into a single tooltip rebuild per 150ms
-    -- window, and skips rebuilds entirely when the preview is collapsed.
+    -- window. The preview is always visible now, so every debounced flush
+    -- fires the refresh unconditionally.
     local _previewDirty = false
     local _previewTimerActive = false
 
@@ -4674,15 +4548,6 @@ function AbilityEditor.GenerateEditor(ability)
             _previewTimerActive = false
             if not _previewDirty then return end
             _previewDirty = false
-            -- Skip rebuild when preview is collapsed; mark dirty for expand.
-            -- Guard: after the dialog is destroyed the engine clears the
-            -- panel's data bag, so rootPanel.data errors. pcall because
-            -- gui panels don't have try_get (that's a game-type method).
-            local ok, rpData = pcall(function() return rootPanel ~= nil and rootPanel.data or nil end)
-            if ok and rpData ~= nil and rpData.previewNarrow then
-                rpData.previewDirty = true
-                return
-            end
             if previewSlot ~= nil then
                 previewSlot:FireEvent("refreshPreview")
             end
@@ -4722,23 +4587,16 @@ function AbilityEditor.GenerateEditor(ability)
             end
         end
 
-        -- Effects always forces narrow on entry (its behavior list +
-        -- per-behavior editor want the wide detail column). Every other
-        -- section restores the user's sticky preference -- so if they
-        -- had the preview expanded on Overview, bounce into Effects
-        -- (auto-narrowed), then bounce back, Overview is expanded again.
-        -- Manual re-expansion within Effects updates the preference, so
-        -- then moving to Overview stays expanded too.
+        -- The Effects section gets a fixed bottom bar (Add/Paste buttons);
+        -- other sections hide it and reclaim the space. The preview column
+        -- stays visible in every section.
         if sectionId == "effects" then
-            applyPreviewState(true)
             if effectsBottomBar ~= nil then
                 effectsBottomBar:SetClass("nae-not-effects", false)
                 effectsBottomBar:SetClass("collapsed", false)
                 detailScroll.height = "100%-42"
             end
         else
-            local pref = rootPanel.data.userPreviewNarrow or false
-            applyPreviewState(pref)
             if effectsBottomBar ~= nil then
                 effectsBottomBar:SetClass("nae-not-effects", true)
                 effectsBottomBar:SetClass("collapsed", true)
@@ -4862,10 +4720,9 @@ function AbilityEditor.GenerateEditor(ability)
     detailCol = gui.Panel{
         classes = {"nae-detail-col"},
         id = "detailCol",
-        -- Initial width for the expanded preview state. applyPreviewState
-        -- overwrites this whenever the preview toggles or the section
-        -- changes. 8px border budget matches the calculation there.
-        width = LAYOUT.ROOT_WIDTH - LAYOUT.NAV_WIDTH - LAYOUT.PREVIEW_WIDTH - 8,
+        -- Fills the remaining width between nav (fixed) and preview (fixed).
+        -- 8px border budget matches the nav + preview + border allowance.
+        width = string.format("100%%-%d", LAYOUT.NAV_WIDTH + LAYOUT.PREVIEW_WIDTH + 8),
         height = "100%",
         flow = "vertical",
         halign = "left",
@@ -4876,12 +4733,12 @@ function AbilityEditor.GenerateEditor(ability)
         children = {detailScroll, effectsBottomBar},
     }
 
-    previewCol, previewSlot = _makePreview(ability, togglePreview)
+    previewCol, previewSlot = _makePreview(ability)
 
     local bodyRow = gui.Panel{
         id = "bodyRow",
         width = "100%",
-        height = LAYOUT.ROOT_HEIGHT - LAYOUT.TITLE_HEIGHT - 12,
+        height = string.format("100%%-%d", LAYOUT.TITLE_HEIGHT + 12),
         flow = "horizontal",
         halign = "left",
         valign = "top",
@@ -4915,16 +4772,15 @@ function AbilityEditor.GenerateEditor(ability)
         classes = {"nae-root"},
         id = "abilityEditorRoot",
         styles = _editorStyles(),
-        width = LAYOUT.ROOT_WIDTH,
-        height = LAYOUT.ROOT_HEIGHT,
+        width = "100%",
+        height = "100%",
         halign = "center",
         valign = "center",
         flow = "vertical",
         borderBox = true,
         -- No root-level padding: the outer compendium dialog already pads
         -- around us, and any root hpad here would subtract from the inner
-        -- area that nav+detail+preview column widths are computed against,
-        -- causing the right column to overflow.
+        -- area that nav+detail+preview column widths are computed against.
         hpad = 0,
         vpad = 0,
         bgcolor = COLORS.BG,
@@ -4935,13 +4791,6 @@ function AbilityEditor.GenerateEditor(ability)
         data = {
             ability = ability,
             selectedSectionId = SECTIONS[1].id,
-            -- Live preview column state. `previewNarrow` is the current
-            -- render state; `userPreviewNarrow` is the user's sticky
-            -- preference which is restored when leaving a forced-narrow
-            -- section (Effects) and returning to any other section.
-            previewNarrow = false,
-            userPreviewNarrow = false,
-            previewDirty = false,
         },
         children = {
             titleStrip,
@@ -4954,8 +4803,7 @@ function AbilityEditor.GenerateEditor(ability)
         },
     }
 
-    -- Initial selection + initial preview render. selectSection also applies
-    -- the section's default preview state.
+    -- Initial selection + initial preview render.
     selectSection(SECTIONS[1].id)
     if previewSlot ~= nil then
         previewSlot:FireEvent("refreshPreview")

--- a/Draw Steel Ability Editor/AbilityEditorBehaviorPicker.lua
+++ b/Draw Steel Ability Editor/AbilityEditorBehaviorPicker.lua
@@ -368,15 +368,6 @@ local BEHAVIOR_GROUPS = {
     {id = "scripting",  label = "Scripting & Advanced"},
 }
 
-local SUGGESTED_CHIPS = {
-    "deal damage",
-    "heal an ally",
-    "push the target",
-    "apply an effect",
-    "make a power roll",
-    "create an object",
-}
-
 -- IDs to exclude from the picker. Shapes are internal, "none" is a
 -- placeholder entry at index 1 of ActivatedAbility.Types.
 local EXCLUDED_IDS = {
@@ -617,52 +608,6 @@ function AbilityEditor.OpenBehaviorPicker(ability, onAdd)
                     bgimage = "panels/square.png",
                     bgcolor = COLORS.GOLD .. "66",
                     vmargin = 8,
-                }
-            end
-
-            -- Suggested chips (when search is empty and no recent)
-            if query == nil and #AbilityEditor._recentBehaviors == 0 then
-                local chipChildren = {}
-                for _, chipText in ipairs(SUGGESTED_CHIPS) do
-                    local ct = chipText
-                    chipChildren[#chipChildren + 1] = gui.Panel{
-                        width = "auto",
-                        height = 22,
-                        flow = "horizontal",
-                        halign = "left",
-                        valign = "center",
-                        hpad = 8,
-                        rmargin = 6,
-                        bmargin = 4,
-                        bgcolor = COLORS.PANEL_BG,
-                        borderWidth = 1,
-                        borderColor = COLORS.GOLD,
-                        cornerRadius = 11,
-                        borderBox = true,
-                        press = function()
-                            searchInput.text = ct
-                            resultsPanel:FireEvent("updateResults")
-                        end,
-                        gui.Label{
-                            width = "auto",
-                            height = "auto",
-                            fontSize = 12,
-                            color = COLORS.CREAM_BRIGHT,
-                            textAlignment = "left",
-                            text = ct,
-                        },
-                    }
-                end
-                children[#children + 1] = gui.Panel{
-                    width = "100%",
-                    height = "auto",
-                    flow = "horizontal",
-                    wrap = true,
-                    halign = "left",
-                    valign = "top",
-                    bmargin = 8,
-                    bgcolor = "clear",
-                    children = chipChildren,
                 }
             end
 

--- a/Draw Steel Core Rules/DSAbilityImprovement.lua
+++ b/Draw Steel Core Rules/DSAbilityImprovement.lua
@@ -165,7 +165,7 @@ CharacterModifier.TypeInfo.abilityimprovement = {
                 local info = CharacterModifier.ImprovementParamsById[param.id]
                 if info ~= nil then
                     children[#children+1] = gui.Panel{
-                        classes = {"formPanel"},
+                        classes = {"formPanel", "formPanel-inline"},
                         gui.Label{
                             classes = {"formLabel"},
                             width = 400,

--- a/Draw Steel Core Rules/DSModifyHRChecklist.lua
+++ b/Draw Steel Core Rules/DSModifyHRChecklist.lua
@@ -81,7 +81,7 @@ CharacterModifier.TypeInfo.modifyresourcechecklist = {
                     flow = "vertical",
 
                     gui.Panel{
-                        classes = {"formPanel"},
+                        classes = {"formPanel", "formPanel-inline"},
                         gui.Label{
                             classes = {"formLabel"},
                             text = "Name:",

--- a/Draw Steel Core Rules/MCDMAbilityRollBehavior.lua
+++ b/Draw Steel Core Rules/MCDMAbilityRollBehavior.lua
@@ -1696,7 +1696,6 @@ function ActivatedAbilityPowerRollBehavior:EditorItems(parentPanel)
         },
 
         gui.GoblinScriptInput{
-            halign = "right",
             value = self.roll,
             events = {
                 change = function(element)
@@ -1865,7 +1864,6 @@ function ActivatedAbilityPowerRollBehavior:EditorItems(parentPanel)
                     },
 
                     gui.GoblinScriptInput{
-                        halign = "right",
                         width = 300,
                         value = modifier.condition,
                         events = {
@@ -1986,7 +1984,7 @@ function ActivatedAbilityPowerRollBehavior:EditorItems(parentPanel)
             gui.Input{
                 text = self.tiers[i],
                 characterLimit = 350,
-                halign = "right",
+                halign = "left",
                 change = function(element)
                     self.tiers[i] = element.text
                 end

--- a/Draw Steel Core Rules/MCDMModifyTriggers.lua
+++ b/Draw Steel Core Rules/MCDMModifyTriggers.lua
@@ -184,7 +184,7 @@ CharacterModifier.RegisterTriggerModifier{
 
         -- Variation ability support (like ActivatedAbilityEditor variations).
         children[#children+1] = gui.Panel{
-            classes = {"formPanel"},
+            classes = {"formPanel", "formPanel-inline"},
             flow = "horizontal",
             width = "auto",
             height = "auto",
@@ -607,7 +607,7 @@ CharacterModifier.TypeInfo.modifytrigger = {
                 local info = triggerModifierOptionsById[entry.id]
                 if info ~= nil then
                     children[#children+1] = gui.Panel{
-                        classes = {"formPanel"},
+                        classes = {"formPanel", "formPanel-inline"},
                         gui.Label{
                             classes = {"formLabel"},
                             width = 400,

--- a/Draw Steel Core Rules/MCDModifyPowerRolls.lua
+++ b/Draw Steel Core Rules/MCDModifyPowerRolls.lua
@@ -1916,6 +1916,7 @@ CharacterModifier.TypeInfo.power = {
                 gui.Panel{
                     width = 300,
                     height = "auto",
+                    halign = "left",
                     flow = "vertical",
                     children = damageTypeChildren,
                 }
@@ -1999,8 +2000,9 @@ CharacterModifier.TypeInfo.power = {
                         for i,adjustment in ipairs(adjustments) do
                             local panel = gui.Panel{
                                 flow = "horizontal",
-                                width = "100%",
+                                width = "auto",
                                 height = 30,
+                                halign = "left",
                                 gui.Dropdown{
                                     width = 120,
                                     halign = "left",
@@ -2051,9 +2053,10 @@ CharacterModifier.TypeInfo.power = {
                                 },
 
                                 gui.DeleteItemButton{
-                                    halign = "right",
                                     width = 12,
                                     height = 12,
+                                    valign = "center",
+                                    lmargin = 8,
                                     click = function()
                                         table.remove(adjustments, i)
                                         Refresh()
@@ -2135,7 +2138,7 @@ CharacterModifier.TypeInfo.power = {
             }
 
             children[#children+1] = gui.Panel{
-                classes = {"formPanel", cond(modifier.rollType == "project_roll", "collapsed-anim")},
+                classes = {"formPanel", "formPanel-inline", cond(modifier.rollType == "project_roll", "collapsed-anim")},
                 gui.Label{
                     classes = {"formLabel"},
                     text = "Replace in Table:",

--- a/Draw Steel Modifiers/ModifierCastingOrigin.lua
+++ b/Draw Steel Modifiers/ModifierCastingOrigin.lua
@@ -58,7 +58,7 @@ CharacterModifier.TypeInfo.castingorigin = {
 			for keyword, _ in pairs(modifier.keywordFilter) do
 				local kw = keyword
 				keywordEntries[#keywordEntries+1] = gui.Panel{
-					classes = {"formPanel"},
+					classes = {"formPanel", "formPanel-inline"},
 					data = {
 						ord = kw,
 					},

--- a/Draw Steel Modifiers/ModifierForcedMovement.lua
+++ b/Draw Steel Modifiers/ModifierForcedMovement.lua
@@ -92,7 +92,7 @@ CharacterModifier.TypeInfo.forcedmovement = {
             }
 
             children[#children+1] = gui.Panel{
-                classes = {"formPanel"},
+                classes = {"formPanel", "formPanel-inline"},
                 fromDropdown,
                 gui.Label{
                     text = "->",

--- a/Draw Steel Modifiers/ModifierGrowingResources.lua
+++ b/Draw Steel Modifiers/ModifierGrowingResources.lua
@@ -40,7 +40,7 @@ CharacterModifier.TypeInfo.growingresources = {
             for i,row in ipairs(modifier.progression) do
 
                 children[#children+1] = gui.Panel{
-                    classes = {"formPanel"},
+                    classes = {"formPanel", "formPanel-inline"},
                     gui.Label{
                         classes = {"formLabel"},
                         text = "Level:",


### PR DESCRIPTION
## Summary

Four small, independent fixes to the sectioned ability editor, one per commit:

- **Remove dead empty-state chip row from behavior picker.** The "deal damage" / "push the target" / etc. suggested-query chips fed multi-word phrases into a literal-substring filter and always returned zero results. The grouped behavior list with its one-line descriptions already serves as the discovery surface.
- **Make the ability editor a full-screen modal with an always-visible preview.** Converts the outer compendium dialog to fill the screen when the sectioned editor is active and switches the editor root to 100%/100%. The preview column is now visible in every section (including Effects), so the collapse system (`applyPreviewState`, `togglePreview`, `nae-narrow` styles, sticky preference) is removed.
- **Refresh the Paste Behavior button when the internal clipboard changes.** Adds an `internalClipboardChanged` handler mirroring the existing Paste Modifier pattern in `CharacterFeature.lua:669`. Copying a behavior while the editor is already open now reveals the button immediately instead of requiring a close-and-reopen.
- **Poll the preview slot so behavior field edits refresh the card live.** Behavior `EditorItems` are shared base code and have no hook into the editor's `fireChange` helper, so typing in e.g. a power-roll tier updated the model silently while the preview stayed stale until another field (name, keywords, etc.) was edited. A 250ms `thinkTime` on `previewSlot` calls the existing debounced `_schedulePreviewRefresh`; the 150ms debounce coalesces think ticks with keystroke-driven refreshes so there is no double-work.

## Test plan

- [x] Open the ability editor from the compendium and confirm it fills the screen with the Create / Close buttons still visible.
- [x] Confirm the preview card is visible on every section (Overview, Cost & Action, Targeting, Effects, Presentation).
- [x] Open the behavior picker on a blank ability and confirm the chip row is gone and the grouped list still renders.
- [x] On the Effects section, edit a power-roll tier text field and confirm the preview card updates within ~400ms without switching tabs.
- [x] Copy a behavior, keep the editor open, and confirm the "Paste Behavior" button appears immediately.
- [x] Edit an Overview field (name) and confirm the preview still updates as before (sanity check that the debounce/polling combination is fine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)