### PR TITLE
Ability editor: embedded mode for Standard Abilities compendium

### DIFF
--- a/DMHub Compendium/ActivatedAbilityEditor.lua
+++ b/DMHub Compendium/ActivatedAbilityEditor.lua
@@ -62,7 +62,7 @@ ActivatedAbility.CatHelpSymbols = function(a,b)
 	return res
 end
 
-function ActivatedAbility:GenerateEditor()
+function ActivatedAbility:GenerateEditor(opts)
 
 	-- Route to the sectioned Draw Steel ability editor unless the user has
 	-- opted back into the classic editor via the "Use classic ability editor"
@@ -70,7 +70,7 @@ function ActivatedAbility:GenerateEditor()
 	-- which loads after this module, so we use rawget for the lookup.
 	local abilityEditor = rawget(_G, "AbilityEditor")
 	if abilityEditor ~= nil and dmhub.GetSettingValue("classicAbilityEditor") ~= true then
-		return abilityEditor.GenerateEditor(self)
+		return abilityEditor.GenerateEditor(self, opts)
 	end
 
 	local resourceOptions = {}

--- a/Draw Steel Ability Editor/AbilityEditor.lua
+++ b/Draw Steel Ability Editor/AbilityEditor.lua
@@ -46,11 +46,17 @@ local LAYOUT = {
     TITLE_HEIGHT = 44,
 
     NAV_WIDTH = 220,
+    -- Narrower nav rail in embedded hosts (Standard Abilities compendium) so
+    -- the detail column keeps plenty of room for wide behavior forms.
+    NAV_WIDTH_EMBEDDED = 180,
     -- Ability tooltip cards render at ~400px native (see CreateAbilityTooltip
     -- in DMHub Compendium/ActivatedAbilityEditor.lua:34). Give the preview
     -- enough room for that plus padding, so description text wraps to the
     -- card's natural width rather than being squeezed.
     PREVIEW_WIDTH = 440,
+    -- In embedded mode the preview column collapses into a thin tab pinned
+    -- to the right edge; clicking it toggles the full-width preview overlay.
+    PREVIEW_TAB_WIDTH = 28,
     -- Detail column fills whatever remains between nav and preview.
 
     NAV_BUTTON_HEIGHT = 42,
@@ -4639,13 +4645,22 @@ end
     Root editor
     ============================================================================
 ]]
-function AbilityEditor.GenerateEditor(ability)
+function AbilityEditor.GenerateEditor(ability, opts)
+    opts = opts or {}
+    -- Embedded mode: host container is narrow (e.g. the Standard Abilities
+    -- compendium inlines the editor at ~1000px) so the preview column is
+    -- replaced with a floating overlay that is collapsed by default and
+    -- toggled via a 28px tab pinned to the right edge of the body row.
+    local embedded = opts.embedded == true
     local sectionContents = {}
     local navButtons = {}
 
     -- Forward-declare so nav button click handlers can close over it.
     local rootPanel
     local previewCol
+    local previewHost
+    local previewTab
+    local previewTabLabel
     local detailCol
     local detailScroll = nil
     local effectsBottomBar = nil
@@ -4729,10 +4744,12 @@ function AbilityEditor.GenerateEditor(ability)
         sectionContents[#sectionContents + 1] = _makeSectionContent(sectionDef, ability, fireChange)
     end
 
+    local navWidth = embedded and LAYOUT.NAV_WIDTH_EMBEDDED or LAYOUT.NAV_WIDTH
+
     local navCol = gui.Panel{
         classes = {"nae-nav-col"},
         id = "navCol",
-        width = LAYOUT.NAV_WIDTH,
+        width = navWidth,
         height = "100%",
         flow = "vertical",
         halign = "left",
@@ -4842,12 +4859,17 @@ function AbilityEditor.GenerateEditor(ability)
         end,
     }
 
+    -- Embedded mode reserves only the tab width in the flex row; the full
+    -- preview column floats as an overlay above the detail column when
+    -- toggled. Fullscreen mode reserves the full preview column width.
+    local previewReserve = embedded and LAYOUT.PREVIEW_TAB_WIDTH or LAYOUT.PREVIEW_WIDTH
+
     detailCol = gui.Panel{
         classes = {"nae-detail-col"},
         id = "detailCol",
         -- Fills the remaining width between nav (fixed) and preview (fixed).
         -- 8px border budget matches the nav + preview + border allowance.
-        width = string.format("100%%-%d", LAYOUT.NAV_WIDTH + LAYOUT.PREVIEW_WIDTH + 8),
+        width = string.format("100%%-%d", navWidth + previewReserve + 8),
         height = "100%",
         flow = "vertical",
         halign = "left",
@@ -4860,6 +4882,101 @@ function AbilityEditor.GenerateEditor(ability)
 
     previewCol, previewSlot = _makePreview(ability, _schedulePreviewRefresh)
 
+    -- In embedded mode the preview column is rehomed inside a floating overlay
+    -- that sits pinned to the right edge of the body row. A thin tab lives
+    -- inside the overlay at its left edge; clicking the tab grows or shrinks
+    -- the overlay width between PREVIEW_TAB_WIDTH (collapsed) and PREVIEW_WIDTH
+    -- (open). `clip = true` hides the preview column when the overlay is
+    -- collapsed so it doesn't bleed past the tab. In fullscreen mode the
+    -- preview column sits in the flex row directly (original behavior).
+    local bodyChildren
+    if embedded then
+        -- Hover lives on the chevron label (not the full-height tab) so the
+        -- tooltip anchors to the small centered label rather than the tall
+        -- tab strip. The default tooltip position (valign="bottom",
+        -- halign="center") then sits just below the chevron, at cursor
+        -- height, instead of at the screen bottom.
+        previewTabLabel = gui.Label{
+            text = "<",
+            fontSize = 32,
+            bold = true,
+            color = COLORS.GOLD_BRIGHT,
+            width = "auto",
+            height = "auto",
+            halign = "center",
+            valign = "center",
+            hover = function(element)
+                if previewHost == nil then return end
+                local open = previewHost.data.previewOpen == true
+                element.tooltip = gui.Tooltip(open and "Hide Preview" or "Show Preview")(element)
+            end,
+        }
+
+        previewTab = gui.Panel{
+            classes = {"nae-preview-tab"},
+            id = "previewTab",
+            width = LAYOUT.PREVIEW_TAB_WIDTH,
+            height = "100%",
+            flow = "vertical",
+            halign = "left",
+            valign = "top",
+            bgcolor = COLORS.PANEL_BG,
+            hpad = 0,
+            vpad = 8,
+            borderBox = true,
+            click = function(element)
+                if previewHost == nil then return end
+                local open = not (previewHost.data.previewOpen == true)
+                previewHost.data.previewOpen = open
+                local previewW = open and LAYOUT.PREVIEW_WIDTH or LAYOUT.PREVIEW_TAB_WIDTH
+                previewHost.width = previewW
+                -- Shrink the detail column by the same amount so the form
+                -- reflows instead of being covered by the expanding preview.
+                if detailCol ~= nil then
+                    detailCol.width = string.format("100%%-%d", navWidth + previewW + 8)
+                end
+                if previewTabLabel ~= nil then
+                    previewTabLabel.text = open and ">" or "<"
+                end
+                -- Refresh preview content on open so it reflects edits made
+                -- while the overlay was collapsed.
+                if open and previewSlot ~= nil then
+                    previewSlot:FireEvent("refreshPreview")
+                end
+            end,
+            children = { previewTabLabel },
+        }
+
+        -- In embedded mode the preview host is a flex sibling of detailCol
+        -- (not floating) so growing its width physically reflows the detail
+        -- column. `clip = true` hides the 440px-wide previewCol child when
+        -- the host is collapsed to PREVIEW_TAB_WIDTH.
+        previewHost = gui.Panel{
+            classes = {"nae-preview-overlay"},
+            id = "previewOverlay",
+            halign = "left",
+            valign = "top",
+            width = LAYOUT.PREVIEW_TAB_WIDTH,
+            height = "100%",
+            flow = "horizontal",
+            bgcolor = COLORS.BG,
+            -- bgimage is required for `clip` to take effect; the engine uses
+            -- the bgimage as the clip mask. Without it, previewCol (440 wide)
+            -- bleeds past the host's collapsed 28px footprint and the edge of
+            -- "Preview" / the ability card peeks through next to the tab.
+            bgimage = "panels/square.png",
+            clipHidden = true,
+            borderBox = true,
+            clip = true,
+            data = { previewOpen = false },
+            children = { previewTab, previewCol },
+        }
+
+        bodyChildren = { navCol, detailCol, previewHost }
+    else
+        bodyChildren = { navCol, detailCol, previewCol }
+    end
+
     local bodyRow = gui.Panel{
         id = "bodyRow",
         width = "100%",
@@ -4869,11 +4986,7 @@ function AbilityEditor.GenerateEditor(ability)
         valign = "top",
         bgcolor = "clear",
         borderBox = true,
-        children = {
-            navCol,
-            detailCol,
-            previewCol,
-        },
+        children = bodyChildren,
     }
 
     local titleStrip = gui.Panel{
@@ -4948,7 +5061,7 @@ function AbilityEditor.GenerateEditor(ability)
             local parent = rootPanel.parent
             if parent ~= nil then
                 parent.children = {
-                    AbilityEditor.GenerateEditor(ability),
+                    AbilityEditor.GenerateEditor(ability, opts),
                 }
             end
         end

--- a/Draw Steel Core Rules/MCDMImporterCompendium.lua
+++ b/Draw Steel Core Rules/MCDMImporterCompendium.lua
@@ -933,6 +933,7 @@ local function CreateEditAbilityEffectsPanel(tableName)
             setdata = function(element, item)
                 element.children = {
                     item:GenerateEditor{
+                        embedded = true,
                     }
                 }
             end,


### PR DESCRIPTION
## Summary

- Adds `opts.embedded` flag to `AbilityEditor.GenerateEditor`. When set, the editor switches to a layout designed for inline use in a narrow container (~1000px) instead of the fullscreen modal host.
- In embedded mode the nav rail narrows to 180px and the preview column is replaced with a 28px collapsible tab on the right edge; clicking the tab grows the overlay to the full 440px preview and reflows the detail column in lockstep so the preview doesn't cover the form.
- Enabled at the single inline call site: the Standard Abilities compendium. Every other caller (`ShowEditActivatedAbilityDialog`, character sheets, action bar, inventory, templates, targeting editor) passes no opts and retains the original fullscreen layout.

### Why

The Standard Abilities compendium embeds the editor directly in its ~1000px content pane rather than launching it as a fullscreen modal. The editor's existing three-column math (`100% - 220 - 440 - 8`) collapsed the detail column to ~330px in that host, overlaying behavior forms with the preview and hiding fields like the Invoke Ability "Edit Ability" button when Type = Custom was selected.

### Changes

- `Draw Steel Ability Editor/AbilityEditor.lua` — `opts.embedded` plumbing; new `NAV_WIDTH_EMBEDDED` and `PREVIEW_TAB_WIDTH` constants; floating → flex preview overlay with `clip = true` + `clipHidden = true` for clean collapsed state; hover tooltip on the chevron label (not the full-height tab) so it anchors at cursor height.
- `DMHub Compendium/ActivatedAbilityEditor.lua` — `ActivatedAbility:GenerateEditor(opts)` forwards opts.
- `Draw Steel Core Rules/MCDMImporterCompendium.lua` — Standard Abilities panel passes `{ embedded = true }`.

## Test plan

- [x] Standard Abilities compendium: select an ability with an Invoke Ability behavior + Type=Custom. Verify the "Edit Ability" button is visible and the form isn't covered by the preview.
- [x] Click the preview tab: overlay expands to 440px, detail column reflows narrower, chevron flips to `>`.
- [x] Click again: overlay collapses to 28px tab, detail reclaims the width, chevron flips back to `<`.
- [x] Hover the chevron: tooltip reads "Show Preview" when collapsed, "Hide Preview" when open, and appears near the cursor.
- [x] Fullscreen callers unaffected: open an ability from the action bar / character sheet — 220 nav, 440 preview, no tab, no toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)