### PR TITLE
Fix solo monsters not replenishing actions/movement on their second turn

### DIFF
--- a/DMHub Game Rules/AbilityInitiative.lua
+++ b/DMHub Game Rules/AbilityInitiative.lua
@@ -104,7 +104,7 @@ function ActivatedAbilityInitiativeBehavior:Cast(ability, casterToken, targets, 
                             local speed = token.properties:CurrentMovementSpeed()
                             if speed > 0 then
                                 token.properties.moveDistance = speed
-                                token.properties.moveDistanceRoundId = q:GetRoundId()
+                                token.properties.moveDistanceRoundId = q:GetTurnId()
                             end
                         end,
                     }

--- a/DMHub Game Rules/Creature.lua
+++ b/DMHub Game Rules/Creature.lua
@@ -6226,7 +6226,7 @@ function creature:Moved(path)
             execute = function()
                 if dmhub.GetSettingValue("truediagonals") then self.moveDiag = diagonals + newDiagonals end
                 self.moveDistance = self:DistanceMovedThisTurn() + cost
-                self.moveDistanceRoundId = dmhub.initiativeQueue:GetRoundId()
+                self.moveDistanceRoundId = dmhub.initiativeQueue:GetTurnId()
             end,
         }
     end
@@ -6239,7 +6239,7 @@ function creature:SpendMovementInFeet(moveCost)
 
     local cost = moveCost/dmhub.FeetPerTile
 	self.moveDistance = self:DistanceMovedThisTurn() + cost
-	self.moveDistanceRoundId = dmhub.initiativeQueue:GetRoundId()
+	self.moveDistanceRoundId = dmhub.initiativeQueue:GetTurnId()
     return cost
 end
 
@@ -6257,7 +6257,7 @@ function creature:DistanceMovedThisTurn()
         return 0
     end
 
-	if dmhub.initiativeQueue:GetRoundId() ~= self:try_get("moveDistanceRoundId", "") then
+	if dmhub.initiativeQueue:GetTurnId() ~= self:try_get("moveDistanceRoundId", "") then
 		return 0
 	end
 
@@ -6269,7 +6269,7 @@ function creature:DiagonalsMovedThisTurn()
 		return 0
 	end
 
-	if dmhub.initiativeQueue:GetRoundId() ~= self:try_get("moveDistanceRoundId", "") then
+	if dmhub.initiativeQueue:GetTurnId() ~= self:try_get("moveDistanceRoundId", "") then
 		return 0
 	end
 

--- a/Draw Steel Core Rules/MCDMAbilityBehavior.lua
+++ b/Draw Steel Core Rules/MCDMAbilityBehavior.lua
@@ -591,7 +591,7 @@ local g_rulePatterns = {
                             return
                         end
                         casterToken.properties.moveDistance = casterToken.properties:DistanceMovedThisTurn() + jumpDistance
-                        casterToken.properties.moveDistanceRoundId = dmhub.initiativeQueue:GetRoundId()
+                        casterToken.properties.moveDistanceRoundId = dmhub.initiativeQueue:GetTurnId()
                     end,
                 }
             end

--- a/Draw Steel Core Rules/MCDMInitiativeQueue.lua
+++ b/Draw Steel Core Rules/MCDMInitiativeQueue.lua
@@ -579,7 +579,7 @@ function InitiativeQueue:GetTurnId()
 		return nil
 	end
 
-	return string.format("%s-%s", self:GetRoundId(), entry.initiativeid)
+	return string.format("%s-%s-%d", self:GetRoundId(), entry.initiativeid, entry.turnsTaken)
 end
 
 --called by DMHub to query the current combat round. zero-based result.


### PR DESCRIPTION
## Summary

- `GetTurnId()` previously returned the same string for both turns of a solo monster (same round ID + same initiative entry ID), so \"per turn\" resources like Main Action and Maneuver saw a matching refresh ID on turn 2 and treated themselves as already-used
- Movement tracking used `GetRoundId()` (even coarser), which never changes between a solo monster's two turns within the same round
- Fix: append `entry.turnsTaken` to `GetTurnId()` so each turn of a multi-turn creature gets a distinct ID, and switch movement tracking from `GetRoundId()` to `GetTurnId()`

## Files changed

- **`Draw Steel Core Rules/MCDMInitiativeQueue.lua`** — `GetTurnId()` now formats as `"{roundId}-{initiativeid}-{turnsTaken}"`, giving solo monster turns unique IDs (`...-0` and `...-1`)
- **`DMHub Game Rules/Creature.lua`** — `moveDistanceRoundId` stored/checked with `GetTurnId()` in `Moved()`, `SpendMovementInFeet()`, `DistanceMovedThisTurn()`, `DiagonalsMovedThisTurn()`
- **`DMHub Game Rules/AbilityInitiative.lua`** — same fix in the skip-turn movement tracking
- **`Draw Steel Core Rules/MCDMAbilityBehavior.lua`** — same fix in jump distance tracking

## Test plan

- [ ] Verify a solo monster (with Extra Turns = 1) gets a fresh Main Action, Maneuver, and full movement speed on their second turn each round
- [ ] Verify normal monsters (1 turn/round) still have their actions and movement reset correctly at the start of each new turn
- [ ] Verify movement accumulates correctly within a single turn (moving twice on the same turn counts the total distance)