### PR TITLE
Fix Add Additional Cost Modifier button text overflow

### DIFF
--- a/Draw Steel Core Rules/PowerTableTriggers.lua
+++ b/Draw Steel Core Rules/PowerTableTriggers.lua
@@ -855,9 +855,13 @@ CharacterModifier.TypeInfo.powertabletrigger = {
             end
 
             children[#children+1] = gui.Button{
-                width = 260,
-                height = 26,
-                fontSize = 18,
+                width = "auto",
+                height = "auto",
+                minWidth = 260,
+                hpad = 16,
+                vpad = 6,
+                borderBox = true,
+                fontSize = 16,
                 text = "Add Additional Cost Modifier",
                 click = function(element)
 


### PR DESCRIPTION
## Summary
- The "Add Additional Cost Modifier" button in the Power Roll Trigger modifier editor had its label overflowing the button bounds (fontSize 18 + 28 chars of text packed into a 260x26 fixed box).
- Switch to auto width/height with `hpad = 16`, `vpad = 6`, `borderBox = true`, and `minWidth = 260` so the text always fits regardless of fontSize rendering, while keeping a reasonable minimum visual footprint.
- Also reduce fontSize from 18 to 16 to match the convention used by other "Add X Modifier" buttons in the codebase.

## Test plan
- [x] Reload mods in DMHub and open a Power Roll Trigger modifier editor
- [x] Confirm the "Add Additional Cost Modifier" button label renders on a single line within button bounds
- [ ] Sanity check that clicking the button still adds a new additional cost modifier entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)