### PR TITLE
Fix mode pill selectors missing after re-opening ability editor

### DIFF
--- a/Draw Steel Ability Editor/AbilityEditor.lua
+++ b/Draw Steel Ability Editor/AbilityEditor.lua
@@ -3786,6 +3786,14 @@ local function _makeBehaviorPillPanel(ability, behavior, fireChange)
         classes = {"nae-behavior-pills", "collapsed"},
         data = {cacheKey = nil},
 
+        -- Self-initialize on create. On re-open of the editor, the behavior
+        -- list is built via behaviorList.create's FireEvent (single element),
+        -- which does not cascade to children, so pills would stay collapsed
+        -- until the next tree-wide fireChange. Fire our own refreshAbility
+        -- here so pills populate immediately. Matches the pattern used by
+        -- the behavior contentPanel below.
+        create = function(element) element:FireEvent("refreshAbility") end,
+
         refreshAbility = function(element)
             local shown = ability.multipleModes == true
             element:SetClass("collapsed", not shown)
@@ -3845,6 +3853,8 @@ local function _makeBehaviorPillPanel(ability, behavior, fireChange)
     local tierPanel = gui.Panel{
         classes = {"nae-behavior-pills", "collapsed"},
         data = {cacheKey = nil},
+
+        create = function(element) element:FireEvent("refreshAbility") end,
 
         refreshAbility = function(element)
             local hasPowerRollBefore = false
@@ -3910,6 +3920,8 @@ local function _makeBehaviorPillPanel(ability, behavior, fireChange)
     local strainPanel = gui.Panel{
         classes = {"nae-behavior-pills", "collapsed"},
         data = {cacheKey = nil},
+
+        create = function(element) element:FireEvent("refreshAbility") end,
 
         refreshAbility = function(element)
             local hasStrain = ability:IsStrain()


### PR DESCRIPTION
## Summary
- When an ability has `multipleModes` configured and you re-open it in the Ability Editor, the mode pill selectors were missing from every behavior card in the Effects section until you touched the modes on the Overview page.
- Root cause: the three pill panels (mode/tier/strain) in `_makeBehaviorPillPanel` only populated inside a `refreshAbility` handler, but had no `create` handler. On re-open, `behaviorList.create` uses `FireEvent` (single element) rather than `FireEventTree`, so the initial cascade never reached the pills, and they stayed in their default `collapsed` state until the next tree-wide `fireChange`.
- Fix: each of the three pill panels now fires `refreshAbility` on itself in a `create` handler, matching the pattern already used by the behavior `contentPanel`. Existing `cacheKey` guards prevent redundant rebuilds.

## Test plan
- [x] Open an ability with `multipleModes = true` and existing mode-tagged behaviors -> mode pills appear above each behavior immediately.
- [x] Close and re-open the editor without touching Overview -> mode pills still appear (previously required editing modes on Overview to surface them).
- [ ] Regression check: ability with a PowerRoll behavior followed by a damage behavior -> tier pills appear on re-open.
- [ ] Regression check: strained ability -> strain pills appear on re-open.
- [ ] Adding/removing modes still updates pills live via `fireChange`.

Co-Authored-By: Claude Opus 4.7 (1M context)