### PR TITLE
Fix crash when target is killed before roll completes

### DIFF
--- a/Draw Steel UI/DSActionBar.lua
+++ b/Draw Steel UI/DSActionBar.lua
@@ -4789,7 +4789,7 @@ function GameHud.CreateActionBar(self, dialog, tokenInfo)
                                         end
 
                                         local sourceToken = token
-                                        local range = tonumber(trigger.powerRollModifier.range)
+                                        local range = tonumber(ExecuteGoblinScript(trigger.powerRollModifier.range, token.properties:LookupSymbol(symbols), 10))
                                         local rangeType = trigger.powerRollModifier.powerRollModifier:try_get("changeTargetRange", "none")
                                         if rangeType == "ability" then
                                             sourceToken = dmhub.GetTokenById(trigger.casterid)
@@ -4944,7 +4944,7 @@ function GameHud.CreateActionBar(self, dialog, tokenInfo)
                                             end
 
                                             local sourceToken = token
-                                            local range = tonumber(trigger.powerRollModifier.range)
+                                            local range = tonumber(ExecuteGoblinScript(trigger.powerRollModifier.range, token.properties:LookupSymbol(symbols), 10))
                                             local rangeType = trigger.powerRollModifier.powerRollModifier:try_get("changeTargetRange", "none")
                                             if rangeType == "ability" then
                                                 sourceToken = dmhub.GetTokenById(trigger.casterid)

--- a/DrawSteelActionBar/DrawSteelTriggerPanel.lua
+++ b/DrawSteelActionBar/DrawSteelTriggerPanel.lua
@@ -398,7 +398,7 @@ mod.shared.CreateTriggerPanel = function()
                                         end
 
                                         local sourceToken = g_token
-                                        local range = tonumber(trigger.powerRollModifier.range)
+                                        local range = tonumber(ExecuteGoblinScript(trigger.powerRollModifier.range, g_token.properties:LookupSymbol(symbols), 10))
                                         local rangeType = trigger.powerRollModifier.powerRollModifier:try_get("changeTargetRange", "none")
                                         if rangeType == "ability" then
                                             sourceToken = dmhub.GetTokenById(trigger.casterid)
@@ -555,7 +555,7 @@ mod.shared.CreateTriggerPanel = function()
                                             end
 
                                             local sourceToken = g_token
-                                            local range = tonumber(trigger.powerRollModifier.range)
+                                            local range = tonumber(ExecuteGoblinScript(trigger.powerRollModifier.range, g_token.properties:LookupSymbol(symbols), 10))
                                             local rangeType = trigger.powerRollModifier.powerRollModifier:try_get("changeTargetRange", "none")
                                             if rangeType == "ability" then
                                                 sourceToken = dmhub.GetTokenById(trigger.casterid)
@@ -722,7 +722,7 @@ mod.shared.CreateTriggerPanel = function()
                                         end
 
                                         local sourceToken = g_token
-                                        local range = tonumber(trigger.powerRollModifier.range)
+                                        local range = tonumber(ExecuteGoblinScript(trigger.powerRollModifier.range, g_token.properties:LookupSymbol(symbols), 10))
                                         local rangeType = trigger.powerRollModifier.powerRollModifier:try_get("changeTargetRange", "none")
                                         if rangeType == "ability" then
                                             sourceToken = dmhub.GetTokenById(trigger.casterid)
@@ -1109,7 +1109,7 @@ mod.shared.CreateTriggerPanel = function()
                                             end
 
                                             local sourceToken = g_token
-                                            local range = tonumber(trigger.powerRollModifier.range)
+                                            local range = tonumber(ExecuteGoblinScript(trigger.powerRollModifier.range, g_token.properties:LookupSymbol(symbols), 10))
                                             local rangeType = trigger.powerRollModifier.powerRollModifier:try_get("changeTargetRange", "none")
                                             if rangeType == "ability" then
                                                 sourceToken = dmhub.GetTokenById(trigger.casterid)

--- a/Timeline/EmbeddedRollDialog.lua
+++ b/Timeline/EmbeddedRollDialog.lua
@@ -4193,13 +4193,14 @@ function GameHud.CreateEmbeddedRollDialog()
                                 if c ~= nil then
                                     local tokenUsed = dmhub.LookupToken(c)
                                     if tokenUsed ~= nil then
+                                        local targetProperties = target.token ~= nil and target.token.properties or nil
                                         local rollSymbols
-                                        if rollProperties ~= nil then
-                                            rollSymbols = rollProperties:GetSymbols(m_rollInfo, target.token.properties)
+                                        if rollProperties ~= nil and targetProperties ~= nil then
+                                            rollSymbols = rollProperties:GetSymbols(m_rollInfo, targetProperties)
                                         end
                                         modifier:InstallSymbolsFromContext {
                                             triggerer = c:LookupSymbol {},
-                                            abilitytarget = target.token.properties:LookupSymbol {},
+                                            abilitytarget = targetProperties ~= nil and targetProperties:LookupSymbol {} or nil,
                                             abilitycaster = creatureUsed:LookupSymbol {},
                                             tier = rollSymbols,
                                         }


### PR DESCRIPTION
## Summary

- When a target creature is killed and its token removed before the roll dialog's `completeFunction` runs, `target.token` is nil
- Accessing `target.token.properties` in two places (for `rollSymbols` and `abilitytarget`) crashed with `attempt to index a nil value`
- This was reproducible with power roll triggers (e.g. Gunslinger gunshot trigger) where the triggering ally's attack kills the target

## Test plan

- [ ] Trigger a power roll reaction against a monster
- [ ] Have the monster die from the triggering hit before the reaction roll completes
- [ ] Confirm no crash / stuck coroutine dialog