### PR TITLE
Restore Special Properties toggles in new ability editor

### DIFF
--- a/Draw Steel Ability Editor/AbilityEditor.lua
+++ b/Draw Steel Ability Editor/AbilityEditor.lua
@@ -2914,6 +2914,50 @@ local function _buildCostAndActionSection(ability, fireChange)
         },
     }
 
+    -- 8. Special Properties. Boolean flags registered via
+    -- ActivatedAbility.RegisterProperty (MCDMActivatedAbility.lua:3119).
+    -- The classic editor exposes these through a "Add Special Property..."
+    -- SetEditor; we render them as stacked nae-toggle-check rows so they
+    -- match the section's styling. Iterating registeredProperties means any
+    -- future RegisterProperty call shows up automatically without touching
+    -- this editor. At time of writing the list is Use as Free Strike,
+    -- Use as Signature Ability, and Remain Hidden.
+    local propertyChecks = {}
+    for _, prop in ipairs(ActivatedAbility.registeredProperties or {}) do
+        local propId = prop.id
+        propertyChecks[#propertyChecks + 1] = gui.Check{
+            classes = {"nae-toggle-check"},
+            text = prop.name,
+            value = ability:HasProperty(propId),
+            change = function(element)
+                local props = ability:get_or_add("properties", {})
+                if element.value then
+                    props[propId] = true
+                else
+                    props[propId] = nil
+                end
+                fireChange()
+            end,
+        }
+    end
+
+    if #propertyChecks > 0 then
+        children[#children + 1] = gui.Panel{
+            classes = {"nae-field-row"},
+            flow = "vertical",
+            children = {
+                gui.Label{
+                    classes = {"nae-field-label"},
+                    text = "Special Properties",
+                },
+                gui.Panel{
+                    classes = {"nae-field-subgroup"},
+                    children = propertyChecks,
+                },
+            },
+        }
+    end
+
     return children
 end
 


### PR DESCRIPTION
## Summary
- The new sectioned ability editor dropped the classic "Add Special Property..." SetEditor, so authors can no longer toggle the registered `ActivatedAbility` properties (Use as Free Strike, Use as Signature Ability, Remain Hidden) from the UI even though the runtime still reads them (e.g. the `freestrike` / `usableasfreestrike` GoblinScript symbols).
- Re-adds them as stacked `nae-toggle-check` rows at the end of the Cost & Action section, iterating `ActivatedAbility.registeredProperties` so any future `RegisterProperty` call surfaces automatically without further editor changes.
- Data model matches the classic editor (`ability.properties[id] = true`), so existing content round-trips unchanged, including abilities that set multiple flags at once (e.g. the Summoner ability that is both `useasstrike` and `useassignature`).

## Test plan
- [ ] Open an ability in the new editor and confirm a "Special Properties" group appears at the bottom of Cost & Action with one toggle per registered property.
- [ ] Toggle Use as Free Strike on a melee ability and verify it appears in the Free Strike slot on the action bar.
- [ ] Toggle Use as Signature Ability and verify the ability is recognised as a signature in combat flow.
- [ ] Toggle Remain Hidden and verify using the ability no longer breaks hidden.
- [ ] Open an ability that already has multiple properties set (e.g. the Summoner's Melee/Ranged Summoner Strike) and confirm both checks render as on.
- [ ] Round-trip by saving, closing, and reopening the editor to confirm no data loss.

Generated with [Claude Code](https://claude.com/claude-code)