### PR TITLE
Fix reorder arrows for same-type behaviors in ability editor

### DIFF
--- a/Draw Steel Ability Editor/AbilityEditor.lua
+++ b/Draw Steel Ability Editor/AbilityEditor.lua
@@ -3822,7 +3822,15 @@ end
 local function _behaviorListKey(ability)
     local parts = {}
     for _, b in ipairs(ability.behaviors or {}) do
-        parts[#parts + 1] = b:try_get("guid", b.typeName or "?")
+        local id = b:try_get("guid")
+        if id == nil then
+            id = b:try_get("_tmp_keyId")
+            if id == nil then
+                id = dmhub.GenerateGuid()
+                b._tmp_keyId = id
+            end
+        end
+        parts[#parts + 1] = id
     end
     return #parts .. ":" .. table.concat(parts, ",")
 end


### PR DESCRIPTION
## Summary
- Fix Move Up / Move Down arrows in the new ability editor not working when an ability contains two behaviors of the same type with no guid (e.g. two Apply Ongoing Effect).
- Replace the typeName-based fallback in the behavior-list change guard with a lazy-assigned transient guid so every behavior has a stable unique identity.

## Why
`_behaviorListKey` (`Draw Steel Ability Editor/AbilityEditor.lua`) builds a key from `b:try_get("guid", b.typeName or "?")` and the `behaviorList.refreshAbility` handler skips the rebuild when the key is unchanged. Newly-created behaviors don't have a `guid` (only clipboard-pasted ones do), so the fallback uses `typeName`. Two Apply Ongoing Effect behaviors produce identical key entries, so swapping them via the arrows leaves the key string unchanged and the rebuild is skipped.

The arrow `press` handlers in `_makeBehaviorPanel` do swap `ability.behaviors[i]` and `ability.behaviors[i-1]` correctly -- the bug is purely that the visible list never redraws. Adding any different-typed behavior (or pasted-from-clipboard behavior) breaks the symmetry and lets subsequent rebuilds run, which is why the workaround the user discovered (add another behavior type) appears to fix it.

## Fix
Lazy-assign a transient `_tmp_keyId` guid per behavior in `_behaviorListKey`. `_tmp_` fields are skipped during serialization (per CLAUDE.md), so this introduces no schema or data changes. Behaviors that already have a real `guid` continue to use it preferentially.

## Test plan
- [x] Reproduced the bug live in DMHub: created an ability with two Apply Ongoing Effect behaviors, confirmed `_behaviorListKey` returns the same string before and after a swap.
- [x] Applied the fix and reloaded; confirmed the keys now differ after a swap and stabilize on subsequent calls (no new GUIDs minted).
- [ ] Reviewer: open the new ability editor, add two Apply Ongoing Effect behaviors with different parameters, use the up/down arrows -- they should reorder visibly without needing a third behavior of a different type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)