### PR TITLE
Add Party.id default field

### DIFF
--- a/DMHub Game Rules/Party.lua
+++ b/DMHub Game Rules/Party.lua
@@ -15,6 +15,7 @@ local mod = dmhub.GetModLoading()
 --- @field allyParties nil|table<string, boolean> Set of party ids that are allied with this party.
 Party = RegisterGameType("Party")
 
+Party.id = ""
 Party.name = "New Party"
 Party.details = ""
 Party.tableName = "parties"


### PR DESCRIPTION
## Summary
- Adds `Party.id = ""` as a default field on the `Party` game type in `DMHub Game Rules/Party.lua`- This should fix errors when reimporting tables from the compendium that messes with the ID of Parties and throws an error