### PR TITLE
Ability editor: event-driven preview invalidation

### DIFF
--- a/Draw Steel Ability Editor/AbilityEditor.lua
+++ b/Draw Steel Ability Editor/AbilityEditor.lua
@@ -4579,14 +4579,20 @@ end
     The preview column is always visible; the editor runs as a full-screen
     modal so the detail column has enough room even with the preview mounted.
 
-    Polling: behaviors' EditorItems are shared base code and have no hook
-    into the editor's fireChange helper, so typing in fields like a power-
-    roll tier text updates the ability's data but never triggers a preview
-    rebuild. We use a thinkTime-based poll on previewSlot to schedule a
-    refresh every 250ms. The existing debounce in _schedulePreviewRefresh
-    coalesces this with keystroke-driven refreshes so we don't double-run.
+    Behaviour-driven invalidation: most preview content comes from top-level
+    ability fields edited in the form, which already route through fireChange.
+    The exception is the Power Roll behaviour (and the legacy Attack
+    behaviour), whose EditorItem inputs mutate fields visible on the preview
+    card -- tiers, roll formula, resistance attribute, modifiers. Those
+    handlers call element:FireEventOnParents("refreshAbilityPreview"), which
+    rootPanel handles by calling _schedulePreviewRefresh. The poll-every-250ms
+    pattern that previously lived here was removed because rebuilding the
+    entire preview subtree on a timer is expensive (especially with multiple
+    nested editors open). If you add a new behaviour type whose fields surface
+    on the preview tooltip, instrument its EditorItems change handlers the
+    same way -- see ActivatedAbilityPowerRollBehavior:EditorItems.
 ]]
-local function _makePreview(ability, schedulePreviewRefresh)
+local function _makePreview(ability)
     local previewSlot
     previewSlot = gui.Panel{
         id = "previewSlot",
@@ -4596,13 +4602,6 @@ local function _makePreview(ability, schedulePreviewRefresh)
         valign = "top",
         flow = "vertical",
         bgcolor = "clear",
-
-        thinkTime = 0.25,
-        think = function(element)
-            if schedulePreviewRefresh ~= nil then
-                schedulePreviewRefresh()
-            end
-        end,
 
         refreshPreview = function(element)
             -- Wrap the tooltip card in a width-constrained container so the
@@ -4944,7 +4943,7 @@ function AbilityEditor.GenerateEditor(ability, opts)
         children = {detailScroll, effectsBottomBar},
     }
 
-    previewCol, previewSlot = _makePreview(ability, _schedulePreviewRefresh)
+    previewCol, previewSlot = _makePreview(ability)
 
     -- In embedded mode the preview column is rehomed inside a floating overlay
     -- that sits pinned to the right edge of the body row. A thin tab lives
@@ -5094,6 +5093,16 @@ function AbilityEditor.GenerateEditor(ability, opts)
             ability = ability,
             selectedSectionId = SECTIONS[1].id,
         },
+        -- Behaviour-driven preview invalidation. EditorItem change handlers
+        -- on behaviours that surface fields on the preview card (currently
+        -- ActivatedAbilityPowerRollBehavior) call
+        -- element:FireEventOnParents("refreshAbilityPreview"), which bubbles
+        -- up to here. We feed it through the existing 150ms debounce so
+        -- multiple rapid events (e.g. a structural change that touches
+        -- several fields) coalesce into a single rebuild.
+        refreshAbilityPreview = function(element)
+            _schedulePreviewRefresh()
+        end,
         children = {
             titleStrip,
             gui.MCDMDivider{

--- a/Draw Steel Core Rules/MCDMAbilityRollBehavior.lua
+++ b/Draw Steel Core Rules/MCDMAbilityRollBehavior.lua
@@ -1700,6 +1700,12 @@ function ActivatedAbilityPowerRollBehavior:EditorItems(parentPanel)
             events = {
                 change = function(element)
                     self.roll = element.value
+                    -- Notify the Draw Steel ability editor to rebuild the
+                    -- preview card. Bubbles harmlessly into the void in
+                    -- editors that don't subscribe (classic editor, etc.).
+                    -- See AbilityEditor.lua's rootPanel refreshAbilityPreview
+                    -- handler.
+                    element:FireEventOnParents("refreshAbilityPreview")
                 end,
             },
 
@@ -1745,6 +1751,9 @@ function ActivatedAbilityPowerRollBehavior:EditorItems(parentPanel)
             rollPanel:SetClass("collapsed", self:try_get("resistanceRoll", false))
             resistanceTypePanel:SetClass("collapsed", not self:try_get("resistanceRoll", false))
             testPanel:SetClass("collapsed", not self:try_get("isTest", false))
+            -- resistanceRoll flips the preview header between roll text
+            -- and "Target makes a X resistance roll" -- notify the editor.
+            element:FireEventOnParents("refreshAbilityPreview")
         end,
     }
 
@@ -1832,6 +1841,8 @@ function ActivatedAbilityPowerRollBehavior:EditorItems(parentPanel)
             options = creature.attributeDropdownOptions,
             change = function(element)
                 self.resistanceAttr = element.idChosen
+                -- Preview shows the resistance attribute name in its header.
+                element:FireEventOnParents("refreshAbilityPreview")
             end,
         },
     }
@@ -1869,6 +1880,9 @@ function ActivatedAbilityPowerRollBehavior:EditorItems(parentPanel)
                         events = {
                             change = function(element)
                                 modifier.condition = element.value
+                                -- Edge/bane condition feeds DescribeRoll,
+                                -- which the preview header consumes.
+                                element:FireEventOnParents("refreshAbilityPreview")
                             end,
                         },
 
@@ -1896,6 +1910,8 @@ function ActivatedAbilityPowerRollBehavior:EditorItems(parentPanel)
                             local modifiers = self:try_get("modifiers", {})
                             table.remove(modifiers, i)
                             parentPanel:FireEvent("refreshBehavior")
+                            -- Modifier removal can change DescribeRoll output.
+                            parentPanel:FireEventOnParents("refreshAbilityPreview")
                         end,
                     },
                 }
@@ -1970,6 +1986,8 @@ function ActivatedAbilityPowerRollBehavior:EditorItems(parentPanel)
                     }
 
                     parentPanel:FireEvent("refreshBehavior")
+                    -- Modifier addition can change DescribeRoll output.
+                    parentPanel:FireEventOnParents("refreshAbilityPreview")
                 end,
             }
         },
@@ -1987,6 +2005,11 @@ function ActivatedAbilityPowerRollBehavior:EditorItems(parentPanel)
                 halign = "left",
                 change = function(element)
                     self.tiers[i] = element.text
+                    -- Tier text appears verbatim on the preview card. This
+                    -- is the field the original "preview won't update"
+                    -- bug was about. See AbilityEditor.lua's
+                    -- refreshAbilityPreview handler on rootPanel.
+                    element:FireEventOnParents("refreshAbilityPreview")
                 end
             },
         }


### PR DESCRIPTION
## Summary

The Live Preview in the new Ability Editor rebuilt the entire tooltip subtree every ~0.4s on a `thinkTime=0.25` poll, regardless of whether any field had changed. With multiple ability editors open at once the UI became nearly unresponsive -- each editor was constructing a fresh preview tree several times per second.

This PR replaces the polling firehose with event-driven invalidation. The `previewSlot` think block is deleted; the Power Roll behaviour's `EditorItems` change handlers now bubble a `refreshAbilityPreview` event up the panel tree, which `rootPanel` funnels through the existing 150ms debounce.

## Why this scope

`MCDMActivatedAbility:Render` only reads fields from two behaviour types: `ActivatedAbilityPowerRollBehavior` and the legacy `ActivatedAbilityAttackBehavior` (TODO'd for removal). Every other field on the preview card comes from top-level ability fields edited via the editor's own form, which already route through `fireChange()` -> `_schedulePreviewRefresh()`. The poll therefore only existed to catch Power Roll behaviour edits that bypassed `fireChange`. Six change handlers in `MCDMAbilityRollBehavior:EditorItems` are instrumented:

- `roll` formula
- `rollType` dropdown (test / resistance toggle)
- `resistanceAttr` dropdown
- `modifier.condition` (edge/bane formulas)
- modifier add / delete
- tier text inputs (the original \"preview won't update\" bug)

`FireEventOnParents` bubbles harmlessly into the void in editors that don't subscribe, so the shared EditorItems code remains compatible with the classic editor and other callers.

## Caveats / followups

- The legacy `ActivatedAbilityAttackBehavior` is not instrumented here. Its `EditorItems` delegates to shared base helpers (`RollEditor`, `DamageTypeEditor`, etc.) used by non-DS editors, so the blast radius would be wider. Per `MCDMActivatedAbility.lua:700` it's slated for removal anyway. If any current ability still uses it, its preview will only refresh when some other event triggers `_schedulePreviewRefresh` -- worth a quick check for live usage before removing the render branch.
- Same anti-pattern exists in `NewTriggeredAbilityEditor.lua` for the trigger preview / mechanical view panels. Not addressed in this PR -- needs its own audit of which fields surface on those panels.

## Test plan

- [x] Open the Ability Editor on a Power Roll ability. Edit tier text, click off -> preview updates on commit.
- [x] Open 3 nested ability editors (the original repro). UI remains responsive; no rebuild storm.
- [x] Edit `roll` formula / rollType / resistance attr / add and remove modifiers -> preview refreshes on each commit.
- [x] Edit top-level fields (name, keywords, distance, target, description) -> preview still refreshes via the unchanged `fireChange()` path.