### PR TITLE
Triggered Ability Editor: validate broader symbol surface

### DIFF
--- a/DMHub Utils/GoblinScriptProse.lua
+++ b/DMHub Utils/GoblinScriptProse.lua
@@ -606,6 +606,10 @@ end
 
 local Render = {}
 
+-- Forward declaration so Render.atomNode's De Morgan branch can call
+-- joinChain (defined further down). Lua locals don't resolve forward.
+local joinChain
+
 local function resolveEntry(entry, ctx)
     if entry == nil then return nil end
     if type(entry) == "string" then return entry end
@@ -902,6 +906,55 @@ end
 function Render.atomBoolNode(atom, ctx, src, negated)
     if atom == nil then return rawSpan(src, 0, 0) end
     if atom.kind == "ident" or atom.kind == "dotted" then
+        -- Classification-boolean prose for dotted access on a role head.
+        -- `Self.Winded`, `Subject.Solo`, `Subject.Leader` etc. previously
+        -- rendered as "your winded" / "your solo" via the possessive form,
+        -- which reads as if the property were a possession. These are
+        -- actually classification states -- "are you winded?", "is the
+        -- subject a solo?". Render with copula form when the head is a
+        -- role; "Has X"-prefixed tails switch to have-form.
+        if atom.kind == "dotted" and atom.parts and #atom.parts >= 2 then
+            local parentKey = normalise(atom.parts[1])
+            local roleNoun, roleCop, roleCopNeg = nil, nil, nil
+            if parentKey == "self" then
+                roleNoun, roleCop, roleCopNeg = "you", "are", "are not"
+            elseif parentKey == "caster" then
+                roleNoun, roleCop, roleCopNeg = "the aura caster", "is", "is not"
+            elseif parentKey == "subject" then
+                local e = GoblinScriptProse.subjectProse[(ctx and ctx.subject) or ""]
+                    or GoblinScriptProse.subjectProse["self"]
+                if e then
+                    roleNoun = e.role
+                    -- Subject phrasings containing "you" take "are";
+                    -- singular "any X" / "another X" / "the X" take "is".
+                    if string.find(string.lower(roleNoun), "you", 1, true) then
+                        roleCop, roleCopNeg = "are", "are not"
+                    else
+                        roleCop, roleCopNeg = "is", "is not"
+                    end
+                end
+            end
+            if roleNoun then
+                local tailWords = {}
+                for i = 2, #atom.parts do
+                    tailWords[#tailWords + 1] = string.lower(atom.parts[i])
+                end
+                local tail = table.concat(tailWords, " ")
+                -- "Has X" tail switches to have-form: "you have a shield"
+                -- / "you do not have a shield".
+                local hasRest = string.match(tail, "^has%s+(.+)$")
+                if hasRest then
+                    local haveVerb, haveVerbNeg
+                    if roleNoun == "you" or string.find(string.lower(roleNoun), "you", 1, true) then
+                        haveVerb, haveVerbNeg = "have", "do not have"
+                    else
+                        haveVerb, haveVerbNeg = "has", "does not have"
+                    end
+                    return roleNoun .. " " .. (negated and haveVerbNeg or haveVerb) .. " " .. hasRest
+                end
+                return roleNoun .. " " .. (negated and roleCopNeg or roleCop) .. " " .. tail
+            end
+        end
         local frag = lookupSymbol(atom.parts, ctx)
         if frag == nil then return rawSpan(src, atom.start, atom.stop) end
         -- Check for a boolean-specific phrasing. Convention in
@@ -981,12 +1034,35 @@ function Render.atomNode(node, ctx, src)
             if inner.type == "isEq" then return Render.isEqNode(flipped, ctx, src) end
             return Render.hasEqNode(flipped, ctx, src)
         end
+        -- P5: De Morgan distribution for not(or)/not(and). Real bestiary
+        -- formulas like `not (Subject.Leader or Subject.Solo)` would
+        -- previously fall through to rawSpan and emit the literal source.
+        -- Distributing the negation produces natural prose:
+        --   not (A or B) = not A and not B
+        --   not (A and B) = not A or not B
+        if inner and (inner.type == "or" or inner.type == "and") then
+            local newConn = (inner.type == "or") and "and" or "or"
+            local parts = {}
+            for _, child in ipairs(inner.children or {}) do
+                local negated = {
+                    type = "not",
+                    child = child,
+                    start = child.start,
+                    stop = child.stop,
+                }
+                parts[#parts + 1] = Render.node(negated, ctx, src)
+            end
+            return joinChain(parts, newConn)
+        end
         return rawSpan(src, node.start, node.stop)
     end
     return rawSpan(src, node.start or 0, node.stop or 0)
 end
 
-local function joinChain(parts, connective)
+-- Assigns the forward-declared joinChain so atomNode's De Morgan branch
+-- can resolve it. Note: this is `joinChain = function(...)` (assignment),
+-- NOT `local function joinChain` (which would shadow the forward decl).
+joinChain = function(parts, connective)
     if #parts == 0 then return "" end
     if #parts == 1 then return parts[1] end
     if #parts == 2 then return parts[1] .. " " .. connective .. " " .. parts[2] end
@@ -995,18 +1071,35 @@ local function joinChain(parts, connective)
     return table.concat(body, ", ") .. ", " .. connective .. " " .. parts[#parts]
 end
 
+-- P5: render a child of an and/or node, wrapping it in literal parens
+-- when its connective differs from the parent's. English doesn't carry
+-- AND/OR precedence the way GoblinScript does, so `(A or B) and C`
+-- otherwise reads as `A or B and C` -- ambiguous in English, parses as
+-- `A or (B and C)`. Adding visual parens keeps the rendered prose
+-- unambiguous without forcing more elaborate rewrites. Atom-level
+-- children render without parens.
+local function renderChildForBoolean(child, parentConn, ctx, src)
+    local rendered = Render.node(child, ctx, src)
+    if rendered == nil or rendered == "" then return rendered end
+    if (parentConn == "and" and child.type == "or")
+            or (parentConn == "or" and child.type == "and") then
+        return "(" .. rendered .. ")"
+    end
+    return rendered
+end
+
 -- Render any node (boolean composition or atom-level).
 function Render.node(node, ctx, src)
     if node.type == "and" then
         local parts = {}
         for i, child in ipairs(node.children) do
-            parts[i] = Render.node(child, ctx, src)
+            parts[i] = renderChildForBoolean(child, "and", ctx, src)
         end
         return joinChain(parts, "and")
     elseif node.type == "or" then
         local parts = {}
         for i, child in ipairs(node.children) do
-            parts[i] = Render.node(child, ctx, src)
+            parts[i] = renderChildForBoolean(child, "or", ctx, src)
         end
         return joinChain(parts, "or")
     end
@@ -1208,7 +1301,20 @@ function GoblinScriptProse.ListReferencedSymbols(formula)
             -- declared registrations to be valid.
             local nxt = tokens[k + 1]
             local isCall = nxt and nxt.kind == "PUNCT" and nxt.value == "("
-            if not isDottedTail and not isCall then
+            -- Skip identifiers that appear as the RHS of an is/has comparison.
+            -- GoblinScript treats `Resource is Recovery` as equivalent to
+            -- `Resource is "Recovery"` -- the bare ident is shorthand for the
+            -- string literal, not a symbol reference. Real bestiary content
+            -- relies on this shorthand widely (Resource is Recovery / Main
+            -- Action, Damage Type is fire/acid/cold/..., Condition is Dazed,
+            -- Trigger Name is madesave, subject.type is Gnoll, etc.).
+            -- The tokeniser merges multi-word RHS ("Main Action") into a
+            -- single IDENT, so a single look-back at the immediate previous
+            -- OP token suffices.
+            local isRhsLiteral = prev and prev.kind == "OP"
+                and (prev.value == "is" or prev.value == "is not"
+                     or prev.value == "has" or prev.value == "has not")
+            if not isDottedTail and not isCall and not isRhsLiteral then
                 local key = string.lower(t.value)
                 if set[key] == nil then
                     set[key] = t.value
@@ -1318,6 +1424,83 @@ function GoblinScriptProse.ListReferencedDottedAccesses(formula)
 end
 
 --------------------------------------------------------------------------
+-- ListReferencedChainedAccesses
+--------------------------------------------------------------------------
+-- Walks the formula's tokens and returns a list of 3-deep chained dotted
+-- accesses (`<a>.<b>.<c>`). Used by the Test Trigger panel to surface
+-- per-resource numeric overrides for chains like `Subject.Resources.Recovery`,
+-- `Resources.Surges`, and `Self.Resources.Hero Tokens` -- ListReferencedDottedAccesses
+-- intentionally skips chains (it only emits 2-deep accesses), so the
+-- override system needed a parallel walker for the 3-deep case.
+--
+-- Returns a list of `{head, mid, tail, opHint, headLookup, midLookup, tailLookup}`
+-- where:
+--   head/mid/tail = original-cased identifier strings
+--   *Lookup       = lowercase + space-stripped form (matches runtime injection
+--                   identity)
+--   opHint        = same shape as ListReferencedDottedAccesses
+-- Chains 4+ deep are NOT emitted (no real-world usage), but each adjacent
+-- triple in a longer chain produces its own entry, so a 4-deep chain like
+-- `A.B.C.D` would emit two entries (A.B.C and B.C.D) -- callers can dedup
+-- on (head, mid, tail).
+function GoblinScriptProse.ListReferencedChainedAccesses(formula)
+    local result = {}
+    if formula == nil or formula == "" then return result end
+    local tokens = getParsed(formula)
+    if tokens == nil then return result end
+
+    local function deriveHint(opTokenValue, opTokenKind)
+        if opTokenValue == nil then return "bool" end
+        local v = string.lower(opTokenValue or "")
+        if v == "has" then return "has" end
+        if v == "is" or v == "=" or v == "!=" then return "compare-str" end
+        if v == ">=" or v == "<=" or v == ">" or v == "<" then
+            return "compare-num"
+        end
+        if v == "and" or v == "or" then return "bool" end
+        if opTokenKind == "PUNCT" and (v == ")" or v == "(") then return "bool" end
+        return "bool"
+    end
+
+    local function norm(s)
+        if type(s) ~= "string" then return "" end
+        return string.lower(string.gsub(s, "%s+", ""))
+    end
+
+    for k, t in ipairs(tokens) do
+        if t.kind == "IDENT" then
+            local d1 = tokens[k + 1]
+            local mid = tokens[k + 2]
+            local d2 = tokens[k + 3]
+            local tail = tokens[k + 4]
+            if d1 and d1.kind == "PUNCT" and d1.value == "."
+                    and mid and mid.kind == "IDENT"
+                    and d2 and d2.kind == "PUNCT" and d2.value == "."
+                    and tail and tail.kind == "IDENT" then
+                local opTok = tokens[k + 5]
+                -- Skip if tail is being called (`A.B.C(...)`) or extended
+                -- into a 4+ chain (`A.B.C.D` -- emit per-triple still
+                -- handles via the overlapping window).
+                local isCall = opTok and opTok.kind == "PUNCT" and opTok.value == "("
+                if not isCall then
+                    result[#result + 1] = {
+                        head = t.value,
+                        mid = mid.value,
+                        tail = tail.value,
+                        headLookup = norm(t.value),
+                        midLookup = norm(mid.value),
+                        tailLookup = norm(tail.value),
+                        opHint = deriveHint(opTok and opTok.value, opTok and opTok.kind),
+                    }
+                end
+            end
+        end
+    end
+
+    return result
+end
+
+--------------------------------------------------------------------------
 -- WalkLiteralComparisons
 --------------------------------------------------------------------------
 -- Walks the AST of a formula and invokes the callback once for each leaf
@@ -1327,9 +1510,16 @@ end
 -- formula doesn't parse.
 --
 -- Callback signature: callback(info) where info = {
---   op    = "has" | "is" | "=" | "!=" -- which operator
---   lhs   = <atom>   -- the LHS atom (kind = "ident" / "dotted" / "call")
---   rhs   = <string> -- the unquoted literal value
+--   op      = "has" | "is" | "=" | "!=" -- which operator
+--   lhs     = <atom>   -- the LHS atom (kind = "ident" / "dotted" / "call")
+--   rhs     = <string> -- the unquoted literal value
+--   rhsKind = "string" | "ident" -- "string" for quoted RHS ("Recovery"),
+--             "ident" for bare-ident RHS (Recovery). GoblinScript treats
+--             the latter as an implicit string literal in is/is-not RHS
+--             position, so consumers that validate against canonical tables
+--             (resources, conditions, damage types, ongoing effects) should
+--             treat both kinds the same. has/has-not don't appear with bare
+--             RHS in real content, so this only fires for isEq.
 --   negated = bool   -- true for "is not" / "has not" / "!="
 -- }
 function GoblinScriptProse.WalkLiteralComparisons(formula, callback)
@@ -1341,6 +1531,23 @@ function GoblinScriptProse.WalkLiteralComparisons(formula, callback)
         if tokens == nil or #tokens == 0 then return end
         if ast == nil then return end
 
+        -- Resolve a bare-ident or dotted RHS atom to the implicit string
+        -- literal it represents in is/is-not RHS position. Returns the
+        -- ident's display name (e.g. "Recovery", "Main Action") -- the
+        -- normalisation matches the case-insensitive comparison runtime
+        -- semantics. Returns nil for any other atom shape (calls, paren'd
+        -- sub-expressions, numbers).
+        local function rhsIdentName(atom)
+            if atom == nil then return nil end
+            if atom.kind == "ident" then return atom.name end
+            if atom.kind == "dotted" and atom.parts then
+                -- Dotted RHS like `Subject.X` is rare and probably refers
+                -- to an actual property -- don't treat as literal.
+                return nil
+            end
+            return nil
+        end
+
         local function visit(node)
             if node == nil then return end
             if node.type == "and" or node.type == "or" then
@@ -1351,23 +1558,51 @@ function GoblinScriptProse.WalkLiteralComparisons(formula, callback)
                 visit(node.child)
                 return
             end
-            if node.type == "hasEq" and node.right and node.right.kind == "string" then
-                callback({
-                    op = "has",
-                    lhs = node.left,
-                    rhs = node.right.value,
-                    negated = node.negated or false,
-                })
-                return
+            if node.type == "hasEq" and node.right then
+                if node.right.kind == "string" then
+                    callback({
+                        op = "has",
+                        lhs = node.left,
+                        rhs = node.right.value,
+                        rhsKind = "string",
+                        negated = node.negated or false,
+                    })
+                    return
+                end
+                local identName = rhsIdentName(node.right)
+                if identName ~= nil then
+                    callback({
+                        op = "has",
+                        lhs = node.left,
+                        rhs = identName,
+                        rhsKind = "ident",
+                        negated = node.negated or false,
+                    })
+                    return
+                end
             end
-            if node.type == "isEq" and node.right and node.right.kind == "string" then
-                callback({
-                    op = "is",
-                    lhs = node.left,
-                    rhs = node.right.value,
-                    negated = node.negated or false,
-                })
-                return
+            if node.type == "isEq" and node.right then
+                if node.right.kind == "string" then
+                    callback({
+                        op = "is",
+                        lhs = node.left,
+                        rhs = node.right.value,
+                        rhsKind = "string",
+                        negated = node.negated or false,
+                    })
+                    return
+                end
+                local identName = rhsIdentName(node.right)
+                if identName ~= nil then
+                    callback({
+                        op = "is",
+                        lhs = node.left,
+                        rhs = identName,
+                        rhsKind = "ident",
+                        negated = node.negated or false,
+                    })
+                    return
+                end
             end
             if node.type == "compare" and node.right and node.right.kind == "string"
                 and (node.op == "=" or node.op == "!=" or node.op == "~=" or node.op == "<>") then
@@ -1375,6 +1610,7 @@ function GoblinScriptProse.WalkLiteralComparisons(formula, callback)
                     op = node.op == "=" and "=" or "!=",
                     lhs = node.left,
                     rhs = node.right.value,
+                    rhsKind = "string",
                     negated = node.op ~= "=",
                 })
                 return
@@ -1469,12 +1705,20 @@ function GoblinScriptProse.ExtractSatisfyingValues(formula)
                 if name == nil then return end
                 if node.right.kind == "string" then setIfAbsent(name, node.right.value)
                 elseif node.right.kind == "number" then setIfAbsent(name, node.right.value)
+                elseif node.right.kind == "ident" and node.right.name then
+                    -- Bare-ident RHS is the engine's implicit-string-literal
+                    -- shorthand (`Resource is Recovery` ~= `Resource is "Recovery"`).
+                    -- Treat it as the literal so the test panel pre-fills the
+                    -- dropdown to the named resource. Same intent as quoted RHS.
+                    setIfAbsent(name, node.right.name)
                 end
             elseif node.type == "hasEq" and not node.negated then
                 local name = atomIdent(node.left)
                 if name == nil then return end
                 if node.right.kind == "string" then
                     setIfAbsent(name, { [node.right.value] = true })
+                elseif node.right.kind == "ident" and node.right.name then
+                    setIfAbsent(name, { [node.right.name] = true })
                 end
             elseif node.type == "atom" then
                 local name = atomIdent(node.atom)
@@ -1651,7 +1895,9 @@ function GoblinScriptProse.AttributeFailure(formula, ctx, evalLeaf)
                         }
                     end
                     if tonumber(v) == 0 or v == false or v == nil then
-                        if child.type == "and" or child.type == "or" then
+                        if child.type == "and" or child.type == "or"
+                                or (child.type == "not" and child.child
+                                    and (child.child.type == "or" or child.child.type == "and")) then
                             local nested = walk(child)
                             if nested ~= nil then return nested end
                         end
@@ -1673,9 +1919,44 @@ function GoblinScriptProse.AttributeFailure(formula, ctx, evalLeaf)
                     local childSrc = rawSpan(formula, child.start, child.stop)
                     local v, err = evalLeaf(childSrc)
                     local info = leafInfo(child, v, err)
+                    -- P6: drill into OR-of-AND. A child that's itself an
+                    -- AND has a specific failing leaf inside it -- recurse
+                    -- and attach so the consumer can render "needed X
+                    -- (A failed inside the AND)" or similar. Other compound
+                    -- shapes (nested OR, not-compound) get the same
+                    -- recursive lookup. Keep the top-level info so the
+                    -- existing renderer keeps working unchanged.
+                    if (child.type == "and" or child.type == "or"
+                            or (child.type == "not" and child.child
+                                and (child.child.type == "or" or child.child.type == "and"))) then
+                        local nested = walk(child)
+                        if nested ~= nil then
+                            info.subAttr = nested
+                        end
+                    end
                     clauses[#clauses + 1] = info
                 end
                 return { kind = "or", clauses = clauses }
+            elseif node.type == "not" and node.child
+                    and (node.child.type == "or" or node.child.type == "and") then
+                -- P6: not(or)/not(and) attribution. The outer not failed,
+                -- so the inner expression evaluated to TRUE. List the
+                -- clauses inside the inner that were truthy -- those are
+                -- the ones the user needs to flip off.
+                local inner = node.child
+                local trueClauses = {}
+                for _, child in ipairs(inner.children or {}) do
+                    local childSrc = rawSpan(formula, child.start, child.stop)
+                    local v, err = evalLeaf(childSrc)
+                    if err == nil and not (tonumber(v) == 0 or v == false or v == nil) then
+                        trueClauses[#trueClauses + 1] = leafInfo(child, v, nil)
+                    end
+                end
+                return {
+                    kind = "not-compound",
+                    innerKind = inner.type,
+                    trueClauses = trueClauses,
+                }
             else
                 local nodeSrc = rawSpan(formula, node.start, node.stop)
                 local v, err = evalLeaf(nodeSrc)

--- a/Draw Steel Ability Editor/NewTriggeredAbilityEditor.lua
+++ b/Draw Steel Ability Editor/NewTriggeredAbilityEditor.lua
@@ -2398,6 +2398,31 @@ local function unknownLiterals(formula, triggerId)
     return results
 end
 
+-- Detect bare-ident RHS literals on is/has comparisons that the engine
+-- silently MIS-handles. Single-word bare RHS (`Resource is Recovery`) is
+-- treated by the engine as an implicit string literal -- works correctly.
+-- Multi-word bare RHS (`Resource is Main Action`) is NOT treated as a
+-- string literal -- the engine returns 0 and the comparison silently
+-- fails. Authors writing this form think it works (it reads like the
+-- single-word form) but it's a content bug. Surfaces as a Mech View
+-- chip so the author sees the issue at edit time and can quote the RHS.
+--
+-- Returns a list of `{rhs, op}` entries for each broken comparison.
+-- Empty list means no issues. Detection is purely structural -- we don't
+-- need the trigger context here.
+local function multiWordBareRhsIssues(formula)
+    if formula == nil or formula == "" then return {} end
+    local results = {}
+    GoblinScriptProse.WalkLiteralComparisons(formula, function(info)
+        if info.rhsKind ~= "ident" then return end
+        if type(info.rhs) ~= "string" then return end
+        if string.find(info.rhs, "%s") then
+            results[#results + 1] = { rhs = info.rhs, op = info.op }
+        end
+    end)
+    return results
+end
+
 -- Collapse the behaviour list using the behaviour prose engine (opt-in #5;
 -- BEHAVIOUR_PROSE.md). Falls back to per-behaviour SummarizeBehavior +
 -- type-label comma join if the engine is unavailable. Returns (text, isEmpty).
@@ -2491,22 +2516,40 @@ local function buildMechanicalView(ability)
         if #unknown > 0 then
             condChip = "Unknown: " .. unknown[1]
         else
-            -- Edit-time canonical-table validation. Catches typos in string
-            -- literals on hasEq / isEq leaves where the LHS is a known
-            -- canonical-set field (Ongoing Effects, Conditions, Damage
-            -- Type, Resource). Chip uses a gold warning color to
-            -- distinguish from the red "Unknown: <ident>" chip; the latter
-            -- represents a structural problem (formula references a
-            -- symbol that doesn't exist on this trigger), the former a
-            -- typo-class issue (literal won't match anything at runtime).
-            local literals = unknownLiterals(condition, triggerId)
-            if #literals > 0 then
-                local first = literals[1]
-                local extra = #literals > 1 and string.format(" +%d more", #literals - 1) or ""
+            -- Multi-word bare-ident RHS check first -- this is a hard
+            -- runtime bug (engine returns 0; comparison silently fails),
+            -- so it outranks the typo-class literal chip. Author needs to
+            -- quote the RHS: `Resource is "Main Action"` instead of bare.
+            -- Chip text is plain-language and shows the fix directly --
+            -- earlier wording ("Quote multi-word RHS: is X") was correct
+            -- but unreadable for anyone who doesn't already know the
+            -- problem.
+            local broken = multiWordBareRhsIssues(condition)
+            if #broken > 0 then
+                local first = broken[1]
+                local extra = #broken > 1 and string.format(" +%d more", #broken - 1) or ""
                 condChip = {
-                    text = string.format('Unknown %s: "%s"%s', first.label, first.literal, extra),
-                    color = "#cca350",
+                    text = string.format('Add quotes: "%s"%s', first.rhs, extra),
+                    color = "#a14b3a",  -- red: this is a runtime bug, not just a typo
                 }
+            else
+                -- Edit-time canonical-table validation. Catches typos in string
+                -- literals on hasEq / isEq leaves where the LHS is a known
+                -- canonical-set field (Ongoing Effects, Conditions, Damage
+                -- Type, Resource). Chip uses a gold warning color to
+                -- distinguish from the red "Unknown: <ident>" chip; the latter
+                -- represents a structural problem (formula references a
+                -- symbol that doesn't exist on this trigger), the former a
+                -- typo-class issue (literal won't match anything at runtime).
+                local literals = unknownLiterals(condition, triggerId)
+                if #literals > 0 then
+                    local first = literals[1]
+                    local extra = #literals > 1 and string.format(" +%d more", #literals - 1) or ""
+                    condChip = {
+                        text = string.format('Unknown %s: "%s"%s', first.label, first.literal, extra),
+                        color = "#cca350",
+                    }
+                end
             end
         end
     end
@@ -3158,6 +3201,33 @@ local function discoverTestInputs(ability)
         return "text"  -- compare-str, default
     end
 
+    -- Look up the declared type of a dotted leaf on a typed object symbol.
+    -- Used to upgrade the opHint-derived widget kind when we have richer
+    -- type info -- e.g. `cast.PrimaryTarget` is creature-typed (per
+    -- ActivatedAbilityCast.helpSymbols), so the comparison `cast.PrimaryTarget = self`
+    -- needs a creature picker rather than a text input.
+    local OBJECT_LEAF_HELPSYMBOLS = {
+        ability = function() return rawget(_G, "ActivatedAbility") and ActivatedAbility.helpSymbols end,
+        spellcast = function() return rawget(_G, "ActivatedAbilityCast") and ActivatedAbilityCast.helpSymbols end,
+        path = function() return rawget(_G, "PathMoved") and PathMoved.helpSymbols end,
+    }
+    local function leafDeclaredType(symType, tailKey)
+        local source = OBJECT_LEAF_HELPSYMBOLS[symType]
+        if source == nil then return nil end
+        local syms = source()
+        if type(syms) ~= "table" then return nil end
+        -- Lookup keys in helpSymbols mirror the runtime injection identity
+        -- (lowercase + space-stripped). The dotted-walker passes tailKey as
+        -- lowercase (may contain space for multi-word). Try both forms.
+        local def = syms[tailKey]
+        if def == nil then
+            local stripped = string.gsub(tailKey, "%s+", "")
+            def = syms[stripped]
+        end
+        if type(def) ~= "table" then return nil end
+        return def.type
+    end
+
     for symKey, symDef in pairs(trigger.symbols) do
         if type(symDef) == "table" then
             local symName = symDef.name or tostring(symKey)
@@ -3190,7 +3260,25 @@ local function discoverTestInputs(ability)
                 local entry = dottedTailsForLookupKey(id)
                 if entry ~= nil then
                     for tailKey, tailInfo in pairs(entry.tails) do
-                        local leafKind = kindFromOpHint(tailInfo.opHint)
+                        -- Prefer the leaf's declared type from the object's
+                        -- helpSymbols when we recognise the field; fall back
+                        -- to the operator-hint heuristic. This upgrades
+                        -- compare-str on `cast.PrimaryTarget` to a creature
+                        -- picker (declared type "creature") instead of a
+                        -- bare text input.
+                        local declared = leafDeclaredType(symType, tailKey)
+                        local leafKind
+                        if declared == "creature" then
+                            leafKind = "creature-leaf"
+                        elseif declared == "number" then
+                            leafKind = "number"
+                        elseif declared == "boolean" then
+                            leafKind = "boolean"
+                        elseif declared == "set" then
+                            leafKind = "set"
+                        else
+                            leafKind = kindFromOpHint(tailInfo.opHint)
+                        end
                         -- C4 followup: if the tail is a known bounded-set
                         -- field, attach a valueOptionsSource so the panel
                         -- renders a dropdown instead of a free-text input.
@@ -3291,7 +3379,12 @@ local TEST_OPTION_BUILDERS = {
         local options = {}
         local t = dmhub.GetTable("characterResources") or {}
         for _, r in pairs(t) do
-            if r.grouping ~= "Actions" and not r:try_get("hidden", false) then
+            -- Include all groupings (incl. "Actions") -- the runtime
+            -- dispatches `useresource` events for action resources too,
+            -- so formulas like `Resource is Main Action`/`Resource is
+            -- Maneuver`/`Resource is Trigger` need the picker to surface
+            -- those names. Only filter row-hidden resources.
+            if not r:try_get("hidden", false) then
                 options[#options + 1] = { id = string.lower(r.name), text = r.name }
             end
         end
@@ -3432,7 +3525,45 @@ local function buildEvalContext(ability, scenario)
         if fo == nil or props == nil then return nil end
         local condValues = collectOverrideValues(fo, headKey, "Conditions")
         local oeValues   = collectOverrideValues(fo, headKey, "OngoingEffects")
-        if #condValues == 0 and #oeValues == 0 then return nil end
+        local boolValues = collectOverrideValues(fo, headKey, "Booleans")
+        -- Numeric overrides store the raw value alongside the key. Collect
+        -- separately so we preserve the typed value (number) instead of the
+        -- collected key form.
+        local numericOverrides = {}
+        local hasNumeric = false
+        local numericPrefix = headKey .. ":Numbers:"
+        for key, value in pairs(fo) do
+            if string.sub(key, 1, #numericPrefix) == numericPrefix then
+                local name = string.sub(key, #numericPrefix + 1)
+                local n = tonumber(value)
+                if n ~= nil then
+                    numericOverrides[name] = n
+                    hasNumeric = true
+                end
+            end
+        end
+        -- Resource overrides. Same shape as numeric: stored as raw text
+        -- under "<head>:Resources:<resourceName>"; parsed at injection time
+        -- and folded into a stub CharacterResourceCollection that mirrors
+        -- the real one but returns the override value for the named
+        -- resource(s). Empty/blank entries fall through to the real value.
+        local resourceOverrides = {}
+        local hasResource = false
+        local resourcePrefix = headKey .. ":Resources:"
+        for key, value in pairs(fo) do
+            if string.sub(key, 1, #resourcePrefix) == resourcePrefix then
+                local name = string.sub(key, #resourcePrefix + 1)
+                local n = tonumber(value)
+                if n ~= nil then
+                    resourceOverrides[name] = n
+                    hasResource = true
+                end
+            end
+        end
+        if #condValues == 0 and #oeValues == 0 and #boolValues == 0
+                and not hasNumeric and not hasResource then
+            return nil
+        end
         local tbl = {}
         if #condValues > 0 then
             -- Set-membership form: Subject.Conditions has "Flanked"
@@ -3457,6 +3588,53 @@ local function buildEvalContext(ability, scenario)
                 local key = normaliseSymbolKey(value)
                 if key ~= "" then tbl[key] = true end
             end
+        end
+        -- P2: bare-boolean creature-property overrides (Hero, Dying,
+        -- Captain, Your Turn, ...). Per-value boolean only -- there's no
+        -- StringSet to augment. The same key shape resolves both bare
+        -- (`Hero`) and dotted (`Self.Hero`) access at evaluation time.
+        for _, value in ipairs(boolValues) do
+            local key = normaliseSymbolKey(value)
+            if key ~= "" then tbl[key] = true end
+        end
+        -- P3: numeric creature-property overrides (Subject.Stamina,
+        -- Resources.Recovery, Combat Round, ...). Same per-key injection
+        -- but the value is the parsed number rather than `true`.
+        for name, n in pairs(numericOverrides) do
+            local key = normaliseSymbolKey(name)
+            if key ~= "" then tbl[key] = n end
+        end
+        -- Chained resource overrides (Subject.Resources.Recovery,
+        -- Resources.Surges, ...). Build a stub CharacterResourceCollection
+        -- whose lookupSymbols mirror the real collection's BUT shadow the
+        -- overridden resource quantities. The stub is set as tbl.resources;
+        -- when GoblinScript dot-accesses it via Subject.Resources.<X>, the
+        -- compiled access path wraps the stub with GenerateSymbols(stub),
+        -- which then calls stub.lookupSymbols[<x>](stub) -- our shadow
+        -- function ignores the receiver and returns the override.
+        if hasResource then
+            local realResourcesFn = props.lookupSymbols and props.lookupSymbols["resources"]
+            local realCollection = nil
+            if realResourcesFn ~= nil then
+                local ok, c = pcall(realResourcesFn, props)
+                if ok then realCollection = c end
+            end
+            local stub = { lookupSymbols = {} }
+            if realCollection ~= nil and type(realCollection.lookupSymbols) == "table" then
+                for k, fn in pairs(realCollection.lookupSymbols) do
+                    stub.lookupSymbols[k] = function(_) return fn(realCollection) end
+                end
+            end
+            for name, n in pairs(resourceOverrides) do
+                -- Match the runtime's resource-symbol normalisation:
+                -- lowercase + non-word stripped (matches Resource.lua:1104
+                -- `string.gsub(string.lower(resourceInfo.name), "%W", "")`).
+                local key = string.gsub(string.lower(name), "%W", "")
+                if key ~= "" then
+                    stub.lookupSymbols[key] = function(_) return n end
+                end
+            end
+            tbl.resources = stub
         end
         return tbl
     end
@@ -3527,6 +3705,16 @@ local function buildEvalContext(ability, scenario)
         if dot ~= nil then
             local head = string.sub(symKey, 1, dot - 1)
             local tail = string.sub(symKey, dot + 1)
+            -- Runtime injection identity for multi-word dotted access:
+            -- GoblinScript merges `Primary Target` into a single IDENT
+            -- "Primary Target" but the dot-access lookup normalises to
+            -- lowercase + space-stripped (`primarytarget`). Stored stub
+            -- keys must match that form -- otherwise a tail like
+            -- "primary target" (with embedded space, lowercased) won't be
+            -- found. Verified empirically: `obj.Primary Target` resolves
+            -- via `symbols("primarytarget")`. Head is already normalised
+            -- by ListReferencedDottedAccesses' lookupKey (no space).
+            tail = string.gsub(tail, "%s+", "")
             stubTables[head] = stubTables[head] or {}
             local v = info.value
             if info.kind == "set" then
@@ -3869,9 +4057,58 @@ local function discoverInFormulaOverrides(ability)
         end
     end)
 
+    -- P2: helpSymbol boolean lookup. Real bestiary content references
+    -- bare creature properties without `Self.` prefix (`Hero`, `Dying`,
+    -- `Captain`, `Taken Turn`, `Your Turn`, ...) and dotted (`Subject.Solo`,
+    -- `Subject.Leader`). These resolve at runtime via creature:LookupSymbol
+    -- against the receiver, but the test panel had no way to flip them on
+    -- without setting up actual game state. Now they get a "Pretend X is Y"
+    -- checkbox per referenced boolean.
+    --
+    -- P3: same idea, but for numeric-typed helpSymbols (`Subject.Stamina`,
+    -- `Subject.Maximum Stamina`, `Resources.Recovery`, `Combat Round`, ...).
+    -- Surfaces a numeric input row instead of a checkbox.
+    --
+    -- Lookup keyed by both the helpSymbol's lowercase name AND the
+    -- space-stripped form, so authors who write `YourTurn` or `Your Turn`
+    -- both match the canonical entry.
+    local helpSymbolBoolByLowerName = {}
+    local helpSymbolNumByLowerName = {}
+    pcall(function()
+        if creature == nil or type(creature.helpSymbols) ~= "table" then return end
+        for k, def in pairs(creature.helpSymbols) do
+            if type(k) == "string" and not k:find("^__") and type(def) == "table" then
+                local displayName = def.name or k
+                local target
+                if def.type == "boolean" then
+                    target = helpSymbolBoolByLowerName
+                elseif def.type == "number" then
+                    target = helpSymbolNumByLowerName
+                end
+                if target ~= nil then
+                    target[string.lower(displayName)] = displayName
+                    local stripped = string.lower(string.gsub(displayName, "%s+", ""))
+                    if stripped ~= string.lower(displayName) then
+                        target[stripped] = displayName
+                    end
+                    -- Also key by the lookup-table key itself so authors
+                    -- writing the lookup key form (e.g. `yourturn`) match.
+                    if string.lower(k) ~= string.lower(displayName) then
+                        target[string.lower(k)] = displayName
+                    end
+                end
+            end
+        end
+    end)
+
     -- Resolver: given a (head, identifier) pair, look up the canonical
-    -- name across both tables and add the override under the matching
-    -- set. Used by both shape 2 (dotted) and shape 3 (bare).
+    -- name across all four tables (conditions, ongoing effects, boolean
+    -- helpSymbols, numeric helpSymbols) and add the override under the
+    -- matching category. Used by both shape 2 (dotted) and shape 3 (bare).
+    -- Conditions/effects take precedence over helpSymbols when a name
+    -- appears in both -- the override mechanism for conditions has
+    -- richer semantics (set membership + bare boolean) and matches
+    -- author intent for compendium-defined state.
     local function tryAddByCanonicalName(headLower, identLower)
         local condName = conditionByLowerName[identLower]
         if condName then
@@ -3881,6 +4118,16 @@ local function discoverInFormulaOverrides(ability)
         local effName = effectByLowerName[identLower]
         if effName then
             addOverride(headLower, "OngoingEffects", effName)
+            return
+        end
+        local boolName = helpSymbolBoolByLowerName[identLower]
+        if boolName then
+            addOverride(headLower, "Booleans", boolName)
+            return
+        end
+        local numName = helpSymbolNumByLowerName[identLower]
+        if numName then
+            addOverride(headLower, "Numbers", numName)
         end
     end
 
@@ -3929,6 +4176,44 @@ local function discoverInFormulaOverrides(ability)
                 local stripped = string.lower(string.gsub(ident, "%s+", ""))
                 if stripped ~= identLower then
                     tryAddByCanonicalName("self", stripped)
+                end
+            end
+        end
+    end)
+
+    -- Shape 4: chained resource access. Real bestiary content uses
+    -- `Subject.Resources.Recovery > 0`, `Resources.Surges >= 5`, etc. --
+    -- the middle segment "Resources" returns a CharacterResourceCollection
+    -- whose lookupSymbols expose per-resource numeric quantities. The
+    -- 2-deep dotted walker doesn't surface these because the trailing
+    -- ".Recovery" is buried under the chain. Detect explicitly here.
+    --
+    -- Two head shapes:
+    --   <head>.Resources.<X>   -- head in {subject, self, caster}
+    --   Resources.<X>          -- bare; implicit Self
+    -- Resources.<X> already produces a 2-deep dotted access entry with
+    -- head="Resources", but that head isn't subject/self so shape 2 above
+    -- skipped it. Pick it up here and re-attribute to the implicit "self"
+    -- head so the eval-time injection (tbl.resources = stub) lands on the
+    -- caster side.
+    pcall(function()
+        local chains = GoblinScriptProse.ListReferencedChainedAccesses(condition)
+        for _, c in ipairs(chains or {}) do
+            local headLower = c.headLookup
+            local midLower = c.midLookup
+            if midLower == "resources"
+                    and (headLower == "subject" or headLower == "self" or headLower == "caster") then
+                addOverride(headLower, "Resources", c.tail)
+            end
+        end
+        -- Bare Resources.<X> -> 2-deep entry under head "resources". The
+        -- main shape-2 walk skipped it because head isn't subject/self.
+        -- Re-emit as a self-side resource override.
+        local accesses = GoblinScriptProse.ListReferencedDottedAccesses(condition)
+        for headKey, entry in pairs(accesses or {}) do
+            if string.lower(headKey) == "resources" then
+                for _, tailInfo in pairs(entry.tails or {}) do
+                    addOverride("self", "Resources", tailInfo.displayTail)
                 end
             end
         end
@@ -4142,8 +4427,22 @@ local function buildTestTriggerCard(ability, opts)
                 v = { raw = raw, kind = sym.kind }
                 state.symbolValues[sym.id] = v
             end
+            local effectiveValue
+            if sym.kind == "creature-leaf" then
+                -- Creature-typed dotted leaf (cast.PrimaryTarget = self,
+                -- ...) -- v.raw is a token id chosen via the picker; resolve
+                -- to the live token's properties for object-identity
+                -- comparison at eval time. Picker fills v.raw with the
+                -- first scene token by default; nil falls through to no
+                -- override (the leaf evaluates to nil, mirroring runtime
+                -- behaviour when the cast object lacks the field).
+                local pickedToken = tokenById(v.raw)
+                effectiveValue = pickedToken and pickedToken.properties or nil
+            else
+                effectiveValue = coerceSymbolInputValue(sym.kind, v.raw)
+            end
             scenario.symbolValues[sym.id] = {
-                value = coerceSymbolInputValue(sym.kind, v.raw),
+                value = effectiveValue,
                 raw = v.raw,
                 kind = sym.kind,  -- C4: needed by buildEvalContext to know
                                   -- whether to wrap a "set" leaf as StringSet.
@@ -4430,7 +4729,16 @@ local function buildTestTriggerCard(ability, opts)
             headline = "<b>Fails</b> -- needed at least one of: " .. table.concat(proseParts, "; ") .. "."
             local srcParts = {}
             for _, c in ipairs(attr.clauses or {}) do
-                if c.detail and c.detail ~= "" then
+                -- P6: if the clause is itself a compound (AND / nested OR /
+                -- not-compound), prefer the per-leaf attribution from its
+                -- subAttr -- it tells the user *which* sub-clause inside
+                -- that compound failed, not just "the AND was false".
+                if c.subAttr ~= nil and c.subAttr.kind == "and"
+                        and c.subAttr.failingProse ~= nil then
+                    srcParts[#srcParts + 1] = string.format(
+                        "<i>%s</i> failed at <i>%s</i>",
+                        c.src or "?", c.subAttr.failingSrc or c.subAttr.failingProse)
+                elseif c.detail and c.detail ~= "" then
                     srcParts[#srcParts + 1] = c.detail
                 elseif c.detail == nil then
                     srcParts[#srcParts + 1] = string.format("<i>%s</i> (%s)",
@@ -4449,6 +4757,27 @@ local function buildTestTriggerCard(ability, opts)
                     attr.src or "?", describeValueForDisplay(attr.value))
             elseif attr.detail ~= "" then
                 detail = attr.detail
+            end
+        elseif attr.kind == "not-compound" then
+            -- P6: not(or/and) failed because the inner expression was true.
+            -- List the clauses inside the inner that were truthy -- those
+            -- are what the user must flip off (or apply via override).
+            local proseParts = {}
+            local detailParts = {}
+            for _, c in ipairs(attr.trueClauses or {}) do
+                proseParts[#proseParts + 1] = c.prose or c.src or "?"
+                detailParts[#detailParts + 1] = string.format("<i>%s</i> (%s)",
+                    c.src or "?", describeValueForDisplay(c.value))
+            end
+            if #proseParts == 0 then
+                headline = "<b>Fails</b> -- the inner expression was true."
+            else
+                headline = "<b>Fails</b> -- needed " .. table.concat(proseParts, " and ")
+                    .. " to be false."
+            end
+            if #detailParts > 0 then
+                detail = "These clauses were true: " .. table.concat(detailParts, ", ")
+                if not detail:match("%.$") then detail = detail .. "." end
             end
         else
             headline = "<b>Fails</b> -- the condition was not met."
@@ -4748,19 +5077,21 @@ local function buildTestTriggerCard(ability, opts)
         })
     end
 
-    -- Path C: in-formula state-override section. Renders one group per
-    -- head (Subject / Trigger Owner) containing a "Pretend X has Y"
-    -- checkbox per overrideable value -- conditions and ongoing effects
-    -- merged into a single list. The internal Conditions vs
-    -- OngoingEffects split is implementation detail (the engine derives
-    -- conditions from ongoing effects in many cases per Creature.lua:7892);
-    -- surfacing it as separate UI groups confused authors who think of
-    -- "Flanked" as a state, not a tagged effect category.
+    -- Path C + P2 + P3: in-formula state-override section. Renders one
+    -- group per head (Subject / Trigger Owner) split into three subgroups:
+    --   * "Pretend X has:"  -- conditions + ongoing effects (existing)
+    --   * "Pretend X is:"   -- bare-boolean creature-property overrides (P2)
+    --   * "Pretend X stats:"-- numeric creature-property overrides (P3)
+    -- Conditions/OngoingEffects merge under one heading because the engine
+    -- derives many conditions from effects (Creature.lua:7892) and surfacing
+    -- the split confuses authors. Booleans and Numbers are physically
+    -- separate categories so each gets its own subgroup.
     --
-    -- State lives in state.formulaOverrides keyed by "<head>:<set>:<value>";
-    -- eval-time injection via buildEvalContext + buildOverrideSymbolTable
-    -- still uses the (head, set) split because Conditions and
-    -- OngoingEffects inject into different lookupSymbols entries.
+    -- State lives in state.formulaOverrides keyed by "<head>:<set>:<value>".
+    -- Boolean overrides store `true`; numeric overrides store the raw
+    -- string (parsed at injection time). Eval-time injection via
+    -- buildEvalContext + buildOverrideSymbolTable handles the storage shape
+    -- per category.
     --
     -- Returns nil when no overrides are available so the caller can skip
     -- the whole section (matching buildGateRow's "no-gate -> nil" pattern).
@@ -4771,109 +5102,340 @@ local function buildTestTriggerCard(ability, opts)
         local headOrder = { "subject", "self" }
         local headLabels = { subject = "Subject", self = "Trigger Owner" }
 
+        -- Helper: build a "Pretend <head> has:" subgroup for the merged
+        -- Conditions + OngoingEffects values (existing behaviour). Returns
+        -- nil if no values for either set.
+        local function buildHasGroup(head, headOpts)
+            local entriesByKey = {}
+            local entryOrder = {}
+            for _, setName in ipairs({"Conditions", "OngoingEffects"}) do
+                local values = headOpts[setName]
+                if values ~= nil then
+                    for _, value in ipairs(values) do
+                        local dedupKey = string.lower(value)
+                        local entry = entriesByKey[dedupKey]
+                        if entry == nil then
+                            entry = { value = value, setNames = {} }
+                            entriesByKey[dedupKey] = entry
+                            entryOrder[#entryOrder + 1] = entry
+                        end
+                        local already = false
+                        for _, existing in ipairs(entry.setNames) do
+                            if existing == setName then
+                                already = true
+                                break
+                            end
+                        end
+                        if not already then
+                            entry.setNames[#entry.setNames + 1] = setName
+                        end
+                    end
+                end
+            end
+            if #entryOrder == 0 then return nil end
+            table.sort(entryOrder, function(a, b)
+                return string.lower(a.value) < string.lower(b.value)
+            end)
+            local heading = string.format("Pretend %s has:", headLabels[head])
+            local checks = {
+                gui.Label{
+                    text = heading,
+                    color = COLORS.GOLD_DIM,
+                    fontSize = 13,
+                    bold = true,
+                    width = "100%",
+                    height = "auto",
+                    halign = "left",
+                    bmargin = 2,
+                },
+            }
+            for _, entry in ipairs(entryOrder) do
+                local initialOn = false
+                for _, setName in ipairs(entry.setNames) do
+                    local key = head .. ":" .. setName .. ":" .. entry.value
+                    if state.formulaOverrides[key] == true then
+                        initialOn = true
+                        break
+                    end
+                end
+                local entryRef = entry
+                checks[#checks + 1] = gui.Check{
+                    text = entry.value,
+                    value = initialOn,
+                    vmargin = 2,
+                    lmargin = 12,
+                    change = function(element)
+                        for _, setName in ipairs(entryRef.setNames) do
+                            local key = head .. ":" .. setName .. ":" .. entryRef.value
+                            state.formulaOverrides[key] = element.value
+                        end
+                        refreshTest()
+                    end,
+                }
+            end
+            return gui.Panel{
+                width = "100%",
+                height = "auto",
+                flow = "vertical",
+                halign = "left",
+                bgcolor = "clear",
+                tmargin = 6,
+                children = checks,
+            }
+        end
+
+        -- P2: build a "Pretend <head> is:" subgroup for bare-boolean
+        -- creature-property overrides (Hero, Dying, Captain, Your Turn,
+        -- Solo, Leader, ...). One checkbox per referenced helpSymbol.
+        local function buildIsGroup(head, headOpts)
+            local boolValues = headOpts.Booleans
+            if boolValues == nil or #boolValues == 0 then return nil end
+            -- Dedup case-insensitively in case the same name appeared via
+            -- both bare and dotted forms.
+            local seen = {}
+            local sorted = {}
+            for _, value in ipairs(boolValues) do
+                local k = string.lower(value)
+                if not seen[k] then
+                    seen[k] = true
+                    sorted[#sorted + 1] = value
+                end
+            end
+            table.sort(sorted, function(a, b) return string.lower(a) < string.lower(b) end)
+            local heading = string.format("Pretend %s is:", headLabels[head])
+            local checks = {
+                gui.Label{
+                    text = heading,
+                    color = COLORS.GOLD_DIM,
+                    fontSize = 13,
+                    bold = true,
+                    width = "100%",
+                    height = "auto",
+                    halign = "left",
+                    bmargin = 2,
+                },
+            }
+            for _, value in ipairs(sorted) do
+                local key = head .. ":Booleans:" .. value
+                local initialOn = state.formulaOverrides[key] == true
+                local valueRef = value
+                checks[#checks + 1] = gui.Check{
+                    text = value,
+                    value = initialOn,
+                    vmargin = 2,
+                    lmargin = 12,
+                    change = function(element)
+                        local k = head .. ":Booleans:" .. valueRef
+                        state.formulaOverrides[k] = element.value
+                        refreshTest()
+                    end,
+                }
+            end
+            return gui.Panel{
+                width = "100%",
+                height = "auto",
+                flow = "vertical",
+                halign = "left",
+                bgcolor = "clear",
+                tmargin = 6,
+                children = checks,
+            }
+        end
+
+        -- P3: build a "Pretend <head> stats:" subgroup for numeric
+        -- creature-property overrides (Stamina, Maximum Stamina, Combat
+        -- Round, Resources.Recovery, ...). One numeric input per referenced
+        -- numeric helpSymbol. Empty value falls through to the real token
+        -- value at evaluation time.
+        local function buildStatsGroup(head, headOpts)
+            local numValues = headOpts.Numbers
+            if numValues == nil or #numValues == 0 then return nil end
+            local seen = {}
+            local sorted = {}
+            for _, value in ipairs(numValues) do
+                local k = string.lower(value)
+                if not seen[k] then
+                    seen[k] = true
+                    sorted[#sorted + 1] = value
+                end
+            end
+            table.sort(sorted, function(a, b) return string.lower(a) < string.lower(b) end)
+            local heading = string.format("Pretend %s stats:", headLabels[head])
+            local rows = {
+                gui.Label{
+                    text = heading,
+                    color = COLORS.GOLD_DIM,
+                    fontSize = 13,
+                    bold = true,
+                    width = "100%",
+                    height = "auto",
+                    halign = "left",
+                    bmargin = 2,
+                },
+            }
+            for _, value in ipairs(sorted) do
+                local key = head .. ":Numbers:" .. value
+                local initialRaw = state.formulaOverrides[key]
+                if type(initialRaw) ~= "string" and type(initialRaw) ~= "number" then
+                    initialRaw = ""
+                end
+                local valueRef = value
+                local row = gui.Panel{
+                    width = "100%",
+                    height = "auto",
+                    flow = "horizontal",
+                    halign = "left",
+                    valign = "center",
+                    vmargin = 2,
+                    lmargin = 12,
+                    bgcolor = "clear",
+                    children = {
+                        gui.Label{
+                            text = value .. ":",
+                            color = COLORS.CREAM_BRIGHT,
+                            fontSize = 13,
+                            width = 200,
+                            height = "auto",
+                            halign = "left",
+                            valign = "center",
+                            rmargin = 6,
+                        },
+                        gui.Input{
+                            text = tostring(initialRaw or ""),
+                            placeholderText = "(use real value)",
+                            characterLimit = 12,
+                            width = 80,
+                            height = 22,
+                            fontSize = 13,
+                            change = function(element)
+                                local raw = element.text or ""
+                                local k = head .. ":Numbers:" .. valueRef
+                                if raw == "" then
+                                    state.formulaOverrides[k] = nil
+                                else
+                                    state.formulaOverrides[k] = raw
+                                end
+                                refreshTest()
+                            end,
+                        },
+                    },
+                }
+                rows[#rows + 1] = row
+            end
+            return gui.Panel{
+                width = "100%",
+                height = "auto",
+                flow = "vertical",
+                halign = "left",
+                bgcolor = "clear",
+                tmargin = 6,
+                children = rows,
+            }
+        end
+
+        -- Chained resource overrides (Subject.Resources.Recovery, ...).
+        -- Same widget shape as buildStatsGroup but the bucket is "Resources"
+        -- and the heading reads "Pretend X resources:". Shares the same
+        -- numeric-input semantics: blank value falls through to the real
+        -- token's resource quantity at evaluation time.
+        local function buildResourcesGroup(head, headOpts)
+            local resValues = headOpts.Resources
+            if resValues == nil or #resValues == 0 then return nil end
+            local seen = {}
+            local sorted = {}
+            for _, value in ipairs(resValues) do
+                local k = string.lower(value)
+                if not seen[k] then
+                    seen[k] = true
+                    sorted[#sorted + 1] = value
+                end
+            end
+            table.sort(sorted, function(a, b) return string.lower(a) < string.lower(b) end)
+            local heading = string.format("Pretend %s resources:", headLabels[head])
+            local rows = {
+                gui.Label{
+                    text = heading,
+                    color = COLORS.GOLD_DIM,
+                    fontSize = 13,
+                    bold = true,
+                    width = "100%",
+                    height = "auto",
+                    halign = "left",
+                    bmargin = 2,
+                },
+            }
+            for _, value in ipairs(sorted) do
+                local key = head .. ":Resources:" .. value
+                local initialRaw = state.formulaOverrides[key]
+                if type(initialRaw) ~= "string" and type(initialRaw) ~= "number" then
+                    initialRaw = ""
+                end
+                local valueRef = value
+                local row = gui.Panel{
+                    width = "100%",
+                    height = "auto",
+                    flow = "horizontal",
+                    halign = "left",
+                    valign = "center",
+                    vmargin = 2,
+                    lmargin = 12,
+                    bgcolor = "clear",
+                    children = {
+                        gui.Label{
+                            text = value .. ":",
+                            color = COLORS.CREAM_BRIGHT,
+                            fontSize = 13,
+                            width = 200,
+                            height = "auto",
+                            halign = "left",
+                            valign = "center",
+                            rmargin = 6,
+                        },
+                        gui.Input{
+                            text = tostring(initialRaw or ""),
+                            placeholderText = "(use real value)",
+                            characterLimit = 12,
+                            width = 80,
+                            height = 22,
+                            fontSize = 13,
+                            change = function(element)
+                                local raw = element.text or ""
+                                local k = head .. ":Resources:" .. valueRef
+                                if raw == "" then
+                                    state.formulaOverrides[k] = nil
+                                else
+                                    state.formulaOverrides[k] = raw
+                                end
+                                refreshTest()
+                            end,
+                        },
+                    },
+                }
+                rows[#rows + 1] = row
+            end
+            return gui.Panel{
+                width = "100%",
+                height = "auto",
+                flow = "vertical",
+                halign = "left",
+                bgcolor = "clear",
+                tmargin = 6,
+                children = rows,
+            }
+        end
+
         local groups = {}
         for _, head in ipairs(headOrder) do
             local headOpts = overrideOpts[head]
             if headOpts ~= nil then
-                -- Merge Conditions + OngoingEffects into a single sorted
-                -- display list, deduped by lowercased value. A single
-                -- formula may reference the same state via both shapes
-                -- (`Subject.Flanked` AND `Subject.Conditions has "Flanked"`)
-                -- which would otherwise produce two checkboxes labelled
-                -- the same. Each entry tracks every setName the value
-                -- appeared under so toggling the checkbox sets ALL the
-                -- related state.formulaOverrides keys -- the eval-time
-                -- injection then covers whichever form the formula used.
-                local entriesByKey = {}
-                local entryOrder = {}
-                for _, setName in ipairs({"Conditions", "OngoingEffects"}) do
-                    local values = headOpts[setName]
-                    if values ~= nil then
-                        for _, value in ipairs(values) do
-                            local dedupKey = string.lower(value)
-                            local entry = entriesByKey[dedupKey]
-                            if entry == nil then
-                                entry = { value = value, setNames = {} }
-                                entriesByKey[dedupKey] = entry
-                                entryOrder[#entryOrder + 1] = entry
-                            end
-                            -- Track each origin set; if same setName
-                            -- appears twice (shouldn't happen but be safe),
-                            -- we still only store it once at storage time.
-                            local already = false
-                            for _, existing in ipairs(entry.setNames) do
-                                if existing == setName then
-                                    already = true
-                                    break
-                                end
-                            end
-                            if not already then
-                                entry.setNames[#entry.setNames + 1] = setName
-                            end
-                        end
-                    end
-                end
-                if #entryOrder > 0 then
-                    -- Sort case-insensitively for stable visual order.
-                    table.sort(entryOrder, function(a, b)
-                        return string.lower(a.value) < string.lower(b.value)
-                    end)
-
-                    local heading = string.format("Pretend %s has:", headLabels[head])
-                    local checks = {
-                        gui.Label{
-                            text = heading,
-                            color = COLORS.GOLD_DIM,
-                            fontSize = 13,
-                            bold = true,
-                            width = "100%",
-                            height = "auto",
-                            halign = "left",
-                            bmargin = 2,
-                        },
-                    }
-                    for _, entry in ipairs(entryOrder) do
-                        -- Initial state: on if ANY of the related override
-                        -- keys is on. Avoids the checkbox appearing
-                        -- "off" when the user previously toggled it via
-                        -- a different form's storage slot.
-                        local initialOn = false
-                        for _, setName in ipairs(entry.setNames) do
-                            local key = head .. ":" .. setName .. ":" .. entry.value
-                            if state.formulaOverrides[key] == true then
-                                initialOn = true
-                                break
-                            end
-                        end
-                        local entryRef = entry  -- capture for closure stability
-                        checks[#checks + 1] = gui.Check{
-                            text = entry.value,
-                            value = initialOn,
-                            vmargin = 2,
-                            lmargin = 12,
-                            change = function(element)
-                                -- Set every related override key so the
-                                -- eval-time injection covers all formula
-                                -- forms (set-membership AND bare-boolean,
-                                -- across Conditions AND OngoingEffects).
-                                for _, setName in ipairs(entryRef.setNames) do
-                                    local key = head .. ":" .. setName .. ":" .. entryRef.value
-                                    state.formulaOverrides[key] = element.value
-                                end
-                                refreshTest()
-                            end,
-                        }
-                    end
-                    groups[#groups + 1] = gui.Panel{
-                        width = "100%",
-                        height = "auto",
-                        flow = "vertical",
-                        halign = "left",
-                        bgcolor = "clear",
-                        tmargin = 6,
-                        children = checks,
-                    }
-                end
+                local hasGroup = buildHasGroup(head, headOpts)
+                if hasGroup ~= nil then groups[#groups + 1] = hasGroup end
+                local isGroup = buildIsGroup(head, headOpts)
+                if isGroup ~= nil then groups[#groups + 1] = isGroup end
+                local statsGroup = buildStatsGroup(head, headOpts)
+                if statsGroup ~= nil then groups[#groups + 1] = statsGroup end
+                local resGroup = buildResourcesGroup(head, headOpts)
+                if resGroup ~= nil then groups[#groups + 1] = resGroup end
             end
         end
 
@@ -4910,6 +5472,23 @@ local function buildTestTriggerCard(ability, opts)
                 end,
             }
             return fieldRow(sym.name, toggle)
+        end
+
+        -- Creature-typed dotted leaf on an object symbol (e.g.
+        -- cast.PrimaryTarget, cast.FirstTarget). Picks a scene token --
+        -- buildScenario resolves the stored token id to props for the
+        -- eval-time stub. Reuses buildTokenPickerButton like the role
+        -- slots so the UI is identical.
+        if sym.kind == "creature-leaf" then
+            local pickerTitle = "Choose Token for " .. sym.name
+            local control = buildTokenPickerButton(
+                ability, nil, nil, v.raw,
+                function(tokenId)
+                    v.raw = tokenId
+                    refreshTest()
+                end,
+                pickerTitle, nil)
+            return fieldRow(sym.name, control)
         end
 
         if sym.kind == "unsupported" then


### PR DESCRIPTION
## Summary

Closes the gaps between what authors actually write in trigger condition formulas and what the Mech View flags as Unknown / what the Test Trigger panel can simulate. Driven by a corpus sweep of 318 unique conditionFormulas across classes, subclasses, complications, titles, gear, abilities, globalrulemods, ongoing effects, and bestiary content.

## What changed

**Mech View (no more false positives)**
- Stop flagging bare-ident RHS of `is`/`has` as Unknown. `Resource is Recovery`, `Damage Type is fire`, `Condition is Dazed`, etc. are GoblinScript shorthand for an implicit string literal and should pass validation.
- Extend literal validation to also fire on bare-ident RHS so typos like `Resource is Recoveryyyy` still produce a gold "Unknown resource: ..." chip.
- New red chip when a multi-word bare-ident RHS is detected (`Resource is Main Action`). The GoblinScript engine silently mis-handles this shape -- the runtime resource injection preserves the space (`"main action"`), the engine's bare-RHS fallback strips it (`"mainaction"`), the comparison never matches, the trigger silently never fires. Chip reads `Add quotes: "Main Action"` so the fix is shown directly.

**Test Trigger panel (broader override surface)**
- "Pretend Self/Subject is X" boolean checkboxes for any `creature.helpSymbols` boolean entry referenced in the formula -- bare (`Hero`, `Dying`, `Captain`, `Your Turn`, `Taken Turn`) AND dotted (`Subject.Solo`, `Subject.Leader`, `Self.Winded`).
- "Pretend Self/Subject stats:" numeric inputs for numeric helpSymbol entries -- `Subject.Stamina`, `Combat Round`, `Subject.Critical Threshold`, `Subject.Recoveries Available to Spend`, etc.
- "Pretend Self/Subject resources:" inputs for chained `Subject.Resources.<X>` and bare `Resources.<X>` patterns. Eval-time injection swaps in a stub `CharacterResourceCollection` that mirrors the real one with overridden values.
- Creature-typed dotted leaves on object symbols (e.g. `cast.PrimaryTarget = self`) now use a token picker instead of a free-text input, with proper props injection so identity comparisons work.
- Multi-word dotted leaves no longer mismatch the runtime lookup -- the stub key is now space-stripped to match how GoblinScript normalises `obj.Primary Target` -> `symbols("primarytarget")`.
- Resource dropdown includes the "Actions" grouping (Main Action, Maneuver, Trigger, Villain Action, etc.) since the `useresource` event fires for those too.
- Pre-fill works for bare-ident RHS the same as for quoted RHS.

**Prose engine improvements**
- De Morgan distribution for `not (or)` / `not (and)` -- `not (Subject.Leader or Subject.Solo)` now renders as readable English instead of falling back to the raw source.
- Visual paren disambiguation for nested boolean composition (`(A or B) and C` no longer reads as `A or B and C`).
- New copula path for dotted bare-boolean access on role heads -- `Self.Winded` reads "you are winded" instead of "your winded"; `Subject.Solo` reads "any enemy is solo" (subject-aware verb form). `Has X` tails switch to have-form ("you have a shield").

**Failure attribution**
- New `not-compound` attribution kind for `not (or)` / `not (and)` failures -- lists the specific clauses that were truthy (the ones the user needs to flip off).
- OR-of-AND attribution drills into each failing AND clause via a new `subAttr` field so the user sees "AND-clause failed at X" instead of just "the whole AND was false".

## Coverage

318 unique conditionFormulas in the compendium audit. Patterns now handled:

| Pattern | Before | After |
|---|---|---|
| `Resource is Recovery` | Mech View flagged "Unknown: Recovery" | Recognised as bare-ident-string |
| `Resource is Main Action` | Silently mis-handled by engine | Red chip directing author to quote |
| `Your Turn`, `Hero`, `Captain` | No way to set in test panel | Boolean checkbox |
| `Subject.Solo`, `Subject.Leader` | No way to set | Boolean checkbox |
| `Subject.Stamina <= 30` | No way to set | Numeric input |
| `Subject.Resources.Recovery > 0` | No way to set | Numeric input via stub collection |
| `cast.PrimaryTarget = self` | Free-text input (broken) | Token picker |
| `not (Subject.Leader or Subject.Solo)` | Raw fallback prose, no attribution | De Morgan prose + per-clause attribution |
| `(Tier Three and Friends(self,subject)) or (Tier One and not Friends(...))` | Top-level OR fail with no per-leaf info | OR-of-AND attribution naming the failing AND-leaf |

## Verification

Live-tested against six representative formulas from the corpus (Lists of Heaven, Anticipating Strike, Animal Form Drawback, Shattering item, Beastheart Rage, Tactician Finish Them, Disrupting II). All previously-broken behaviours fixed; no regressions on the existing C-series tests.

## Follow-ups

- Engine quirk on multi-word bare-ident RHS is a content-side fix in the short term (separate scheduled agent will sweep the compendium and quote affected formulas). Engine-side fix would be cleaner -- either strip spaces from the runtime resource value AS WELL, or don't strip them from the bare-RHS fallback. Worth raising with whoever owns the GoblinScript C++ side.
- Atom-prose richness for `Has X` and similar classifier booleans could use per-symbol metadata rather than the heuristic ("has"-prefix detection). Out of scope for this PR.

## Test plan

- [ ] Reload Lua in DMHub
- [ ] Open Conduit -> The Lists of Heaven; verify no Unknown chips, "Pretend Trigger Owner is: Your Turn" checkbox, Resource dropdown pre-fills to Recovery, Run Test passes
- [ ] Open Null -> Anticipating Strike; verify red "Add quotes" chip appears (will clear once compendium content is fixed)
- [ ] Open Animal Form complication -> Animal Form Drawback; verify prose reads "you are winded" (not "your winded")
- [ ] Open Shattering item; verify cast.Primary Target becomes a token picker; pick Trigger Owner = same as Cast.Primary Target; Run Test passes
- [ ] Open Tactician -> Finish Them!; verify "Pretend Subject is: Leader / Solo" checkboxes, run with neither ticked passes, with either ticked fails with attribution naming which clause was true
- [ ] Open Fate Domain Piety; verify OR-of-AND attribution names the failing leaf inside each AND
- [ ] Open Vanguard -> Melee Superiority; verify Trigger Name input pre-fills

🤖 Generated with [Claude Code](https://claude.com/claude-code)