### PR TITLE
Fix misleading descriptions for Modify Cast and Manipulate Targets

### DIFF
--- a/Draw Steel Ability Editor/AbilityEditorBehaviorPicker.lua
+++ b/Draw Steel Ability Editor/AbilityEditorBehaviorPicker.lua
@@ -106,9 +106,9 @@ local BEHAVIOR_METADATA = {
         group = "movement",
     },
     manipulate_targets = {
-        description = "Teleport or reposition targeted creatures.",
-        tags = {"teleport", "swap", "reposition", "move"},
-        group = "movement",
+        description = "Prompt the caster to add or replace the ability's targets.",
+        tags = {"target", "add", "replace", "prompt", "pick"},
+        group = "scripting",
     },
     manipulate_target_locs = {
         description = "Manipulate remembered target locations.",
@@ -207,8 +207,8 @@ local BEHAVIOR_METADATA = {
         group = "modifiers",
     },
     modify_cast = {
-        description = "Modify how the ability is cast or targeted.",
-        tags = {"cast", "override", "modify", "change"},
+        description = "Add a damage bonus, edge, bane, surge, or ignore damage immunity.",
+        tags = {"damage", "edge", "bane", "surge", "immunity", "bonus", "cast"},
         group = "modifiers",
     },
     pay_ability_cost = {


### PR DESCRIPTION
## Summary
- **Modify Cast**: previous description ("Modify how the ability is cast or targeted") suggested it could change targeting, but the behavior only adds cast params (damage bonus, edges, banes, surges, ignore damage immunity). Updated description and tags accordingly.
- **Manipulate Targets**: previous description ("Teleport or reposition targeted creatures") was wrong — the behavior prompts the caster to pick additional creatures and either adds them to or replaces the target list. Updated description, replaced movement-themed tags, and moved the entry from the Movement group to Scripting & Advanced.

## Test plan
- [ ] Open the Add Behavior picker in the ability editor and confirm:
  - Modify Cast still appears under Modifiers & Resources with the new description.
  - Manipulate Targets now appears under Scripting & Advanced with the new description.
  - Searching "damage", "edge", "immunity" surfaces Modify Cast.
  - Searching "add", "replace", "prompt" surfaces Manipulate Targets.
  - Searching "teleport"/"reposition" no longer surfaces Manipulate Targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)