### PR TITLE
Set textAlignment topleft on overview multiline inputs

### DIFF
--- a/Draw Steel Ability Editor/AbilityEditor.lua
+++ b/Draw Steel Ability Editor/AbilityEditor.lua
@@ -2104,6 +2104,7 @@ local function _buildOverviewSection(ability, fireChange)
             classes = {"nae-field-textarea"},
             placeholderText = "Italicized narrative (not mechanics)...",
             multiline = true,
+            textAlignment = "topleft",
             characterLimit = 2000,
             text = ability:try_get("flavor", ""),
             change = function(element)
@@ -2119,6 +2120,7 @@ local function _buildOverviewSection(ability, fireChange)
             classes = {"nae-field-textarea"},
             placeholderText = "Effect text shown before the power roll tiers...",
             multiline = true,
+            textAlignment = "topleft",
             characterLimit = 2000,
             text = ability:try_get("preDescription", ""),
             change = function(element)
@@ -2134,6 +2136,7 @@ local function _buildOverviewSection(ability, fireChange)
             classes = {"nae-field-textarea"},
             placeholderText = "Effect text shown after the power roll tiers...",
             multiline = true,
+            textAlignment = "topleft",
             characterLimit = 2000,
             text = ability:try_get("description", ""),
             change = function(element)
@@ -2195,6 +2198,7 @@ local function _buildOverviewSection(ability, fireChange)
                 classes = {"nae-field-textarea"},
                 placeholderText = "Notes on unfinished parts...",
                 multiline = true,
+                textAlignment = "topleft",
                 characterLimit = 2048,
                 text = ability:try_get("implementationDetails", ""),
                 change = function(element)
@@ -2386,6 +2390,7 @@ _buildModesBlock = function(ability, fireChange)
                             characterLimit = 300,
                             placeholderText = "Enter rules details...",
                             multiline = true,
+                            textAlignment = "topleft",
                             text = entry.rules or "",
                             change = function(el)
                                 entry.rules = el.text


### PR DESCRIPTION
## Summary
- The five multiline `gui.Input` fields in the classic ability editor's Overview section (Flavor Text, Effect Before Power Roll, Effect After Power Roll, Implementation Notes, Mode Details) inherited `textAlignment = "topleft"` only via the `nae-field-textarea` class style at priority 3.
- That cascade is fragile -- any higher-priority style touching the `formInput` cascade (e.g. the priority-7 `formInput` override in `_sharedWidgetStyles`) could silently flip these inputs to `"left"` and have the cursor sit centered vertically in tall textareas.
- This sets `textAlignment = "topleft"` directly on each element so the alignment is locked in regardless of cascade changes. The new triggered ability editor already sets it inline -- this brings the classic editor in line with that pattern.

## Test plan
- [ ] Open an ability in the classic ability editor and confirm the five Overview multiline fields render text from the top-left, with the caret at the top-left when empty.
- [ ] Type multi-line text into each field and confirm wrapping/scrolling behaves the same as before.
- [ ] No visual regression on single-line inputs in the same panel (Name, Display Order, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)