### PR TITLE
ThemeEngine: Add Void and Forest dev-only color schemes

### DIFF
--- a/DMHub Core UI/DefaultStyles.lua
+++ b/DMHub Core UI/DefaultStyles.lua
@@ -2208,6 +2208,131 @@ ThemeEngine.RegisterColorScheme{
     },
 }
 
+-- =============================================================================
+-- Void color scheme
+--
+-- Deep cosmic black-purple surfaces with silver starlight text and a muted
+-- arcane purple accent. Intended to feel menacing rather than electric --
+-- accent saturation is intentionally kept low.
+-- =============================================================================
+
+ThemeEngine.RegisterColorScheme{
+    id          = "void",
+    name        = "Void",
+    description = "Deep cosmic black-purple with silver starlight and muted arcane accents.",
+    colors = {
+        -- Surfaces
+        bg            = "#0A0612",
+        bgAlt         = "#16101F",
+        bgInverse     = "#D8D6E0",
+
+        -- Foreground / text
+        fg            = "#C5C2D1",
+        fgStrong      = "#EFEDF5",
+        fgMuted       = "#7A7388",
+        fgPending     = "#5C5668",
+        fgInverse     = "#0A0612",
+
+        -- Borders
+        border        = "#6E6680",
+        borderInverse = "#3A3050",
+
+        -- Accent + interactive (lower-saturation arcane purple)
+        accent        = "#6E3CB0",
+        accentHover   = "#A286C9",
+
+        -- Status (kept semantic so they read consistently across schemes)
+        success       = "#6BA84F",
+        info          = "#E9C868",
+        warning       = "#E08A2E",
+        danger        = "#C73131",
+
+        -- Disabled
+        disabled      = "#2A2336",
+    },
+    gradients = {
+        surfaceLinear = {
+            point_a = {x = 0, y = 0},
+            point_b = {x = 1, y = 1},
+            stops = {
+                {position = 0, color = "#1A1228"},
+                {position = 1, color = "#04020A"},
+            },
+        },
+        barTrack = {
+            point_a = {x = -0.02, y = 0},
+            point_b = {x = 1.02, y = 0},
+            stops = {
+                {position = 0, color = "#0A0612"},
+                {position = 1, color = "#1F1530"},
+            },
+        },
+    },
+}
+
+-- =============================================================================
+-- Forest color scheme
+--
+-- Deep forest-floor surfaces with sage-cream text, oak-bark bronze borders,
+-- and a muted moss-emerald accent. Brown undertones in the surfaces ground
+-- the green so it reads as a real woodland (canopy + bark + soil) rather
+-- than a flat green wash.
+-- =============================================================================
+
+ThemeEngine.RegisterColorScheme{
+    id          = "forest",
+    name        = "Forest",
+    description = "Deep forest floor with sage-cream text, oak-bark borders, and muted moss-emerald accents.",
+    colors = {
+        -- Surfaces (slight brown undertone in the dark greens)
+        bg            = "#10180E",
+        bgAlt         = "#1E2218",
+        bgInverse     = "#E0E5D2",
+
+        -- Foreground / text (sage-cream, like dappled sunlight)
+        fg            = "#CDD8B8",
+        fgStrong      = "#EAEFD8",
+        fgMuted       = "#7E8A6E",
+        fgPending     = "#5C6555",
+        fgInverse     = "#10180E",
+
+        -- Borders (oak-bark bronze rim ties brown across the chrome)
+        border        = "#7E6A52",
+        borderInverse = "#2A3828",
+
+        -- Accent + interactive (muted moss-emerald, not neon)
+        accent        = "#427B52",
+        accentHover   = "#6FA37A",
+
+        -- Status (kept semantic so they read consistently across schemes)
+        success       = "#6BA84F",
+        info          = "#E9C868",
+        warning       = "#E08A2E",
+        danger        = "#C73131",
+
+        -- Disabled
+        disabled      = "#2A3328",
+    },
+    gradients = {
+        surfaceLinear = {
+            point_a = {x = 0, y = 0},
+            point_b = {x = 1, y = 1},
+            stops = {
+                {position = 0, color = "#1F3326"},
+                {position = 1, color = "#070D09"},
+            },
+        },
+        barTrack = {
+            point_a = {x = -0.02, y = 0},
+            point_b = {x = 1.02, y = 0},
+            stops = {
+                {position = 0, color = "#10180E"},
+                {position = 1, color = "#1F3326"},
+            },
+        },
+    },
+}
+
 end
 
 -- After schemes and themes are registered, restore the user's


### PR DESCRIPTION
## Summary

Adds two new dev-only color schemes to `DMHub Core UI/DefaultStyles.lua`, registered alongside the existing My Little Pony scheme inside the `devmode()` block. Both appear in the standard color scheme picker for dev users only.

### Void
Deep cosmic black-purple surfaces with silver starlight text and a muted arcane purple accent. Saturation on the accent intentionally kept low so the scheme feels menacing rather than electric.

### Forest
Deep forest-floor surfaces with sage-cream text, oak-bark bronze borders, and a muted moss-emerald accent. Brown undertones in the surfaces ground the green so it reads as a real woodland (canopy + bark + soil) rather than a flat green wash.

## Notes
- Status colors (success / info / warning / danger) kept at default values in both schemes so semantics read consistently across the picker.
- `surfaceLinear` and `barTrack` gradients tuned per scheme; `surfaceRadial` inherits from default in both (no override needed).
- No code outside the registration block is touched.

## Test plan
- [ ] Toggle to each scheme via `ThemeEngine.SetActiveColorScheme("void")` / `("forest")` or via the color scheme picker in dev mode
- [ ] Verify chrome (top bar, dock panels, character sheet, ability editor modal) reads correctly in each
- [ ] Confirm both schemes appear in the picker only when `devmode()` is true

🤖 Generated with [Claude Code](https://claude.com/claude-code)