### PR TITLE
Markdown editor: live preview pane, formatting toolbar, and scroll sync

### DIFF
--- a/DocumentSystem/MarkdownDocument.lua
+++ b/DocumentSystem/MarkdownDocument.lua
@@ -1878,6 +1878,7 @@ function MarkdownDocument:EditPanel(args)
         height = "auto",
         halign = "right",
         valign = "center",
+        rmargin = 246,
         fontSize = CustomDocument.ScaleFontSize(16),
         refreshLength = function(element, text)
             local len = #text
@@ -3361,6 +3362,7 @@ function MarkdownDocument:EditPanel(args)
         gui.Panel {
             width = "100%",
             height = 16,
+            tmargin = 8,
             markdownReferenceLabel,
             gui.Button{
                 text = "Preview",

--- a/DocumentSystem/MarkdownDocument.lua
+++ b/DocumentSystem/MarkdownDocument.lua
@@ -3187,6 +3187,15 @@ function MarkdownDocument:EditPanel(args)
         }
     end
 
+    local headingOptions = {
+        { id = "",       text = "Heading" },
+        { id = "# ",     text = "H1" },
+        { id = "## ",    text = "H2" },
+        { id = "### ",   text = "H3" },
+        { id = "#### ",  text = "H4" },
+        { id = "##### ", text = "H5" },
+    }
+
     local toolbar = gui.Panel{
         width = "100%",
         height = 28,
@@ -3201,6 +3210,21 @@ function MarkdownDocument:EditPanel(args)
         ToolbarButton("I", 16, 28, WrapHandler("*", "*")),
         ToolbarButton("U", 16, 28, WrapHandler("__", "__")),
         ToolbarButton("S", 16, 28, WrapHandler("~~", "~~")),
+
+        gui.Dropdown{
+            width = 80, height = 24, idChosen = "",
+            options = headingOptions,
+            change = function(element)
+                if element.idChosen ~= "" then
+                    LineHandler(element.idChosen)()
+                    element.idChosen = ""
+                end
+            end,
+        },
+
+        ToolbarButton("List",    12, 44, LineHandler("* ")),
+        ToolbarButton("Divider", 12, 56, InsertHandler("\n---\n", 5)),
+        ToolbarButton("Link",    12, 40, InsertHandler("[]", 1)),
     }
 
     local editorColumn

--- a/DocumentSystem/MarkdownDocument.lua
+++ b/DocumentSystem/MarkdownDocument.lua
@@ -3296,13 +3296,7 @@ function MarkdownDocument:EditPanel(args)
         width = showPreviewSetting:Get() and "50%" or "100%",
         height = "100%",
         borderBox = true,
-        flow = "vertical",
-        toolbar,
-        gui.Panel{
-            width = "100%",
-            height = "100% available",
-            editInput,
-        },
+        editInput,
     }
 
     resultPanel = gui.Panel {
@@ -3316,9 +3310,11 @@ function MarkdownDocument:EditPanel(args)
             self = doc or self
         end,
 
+        toolbar,
+
         gui.Panel{
             width = "98%",
-            height = "90% available",
+            height = "100% available",
             halign = "center",
             valign = "top",
             flow = "horizontal",

--- a/DocumentSystem/MarkdownDocument.lua
+++ b/DocumentSystem/MarkdownDocument.lua
@@ -2988,6 +2988,36 @@ function MarkdownDocument:EditPanel(args)
         }) end
     end
 
+    local lastSyncedCaret = -1
+    local function SyncPreviewScroll(input, previewPanel)
+        if previewPanel:HasClass("collapsed") then
+            return
+        end
+        local caret = input.caretPosition or 0
+        if caret == lastSyncedCaret then
+            return
+        end
+        lastSyncedCaret = caret
+
+        local text = input.text or ""
+        local caretLine = 0
+        for i = 1, math.min(caret, #text) do
+            if text:sub(i, i) == "\n" then
+                caretLine = caretLine + 1
+            end
+        end
+
+        local _, totalNewlines = text:gsub("\n", "\n")
+        local totalLines = totalNewlines + 1
+        local ratio = 0
+        if totalLines > 0 then
+            ratio = caretLine / totalLines
+        end
+
+        local clamped = math.max(0, math.min(1, 1 - ratio))
+        previewPanel.vscrollPosition = clamped
+    end
+
     editInput = gui.Input {
         id = "editorPanel",
         classes = { "monospace" },

--- a/DocumentSystem/MarkdownDocument.lua
+++ b/DocumentSystem/MarkdownDocument.lua
@@ -3018,6 +3018,8 @@ function MarkdownDocument:EditPanel(args)
         previewPanel.vscrollPosition = clamped
     end
 
+    local previewPanel
+
     editInput = gui.Input {
         id = "editorPanel",
         classes = { "monospace" },
@@ -3060,6 +3062,7 @@ function MarkdownDocument:EditPanel(args)
 
         caretReady = function(element)
             UpdateAutocomplete(element)
+            SyncPreviewScroll(element, previewPanel)
         end,
 
         think = function(element)
@@ -3071,6 +3074,7 @@ function MarkdownDocument:EditPanel(args)
             else
                 UpdateLinkInfo(element)
             end
+            SyncPreviewScroll(element, previewPanel)
         end,
     }
 
@@ -3079,7 +3083,6 @@ function MarkdownDocument:EditPanel(args)
         annotations = self.annotations,
     }
 
-    local previewPanel
     previewPanel = gui.Panel{
         classes = showPreviewSetting:Get() and {} or { "collapsed" },
         width = "50%-16",

--- a/DocumentSystem/MarkdownDocument.lua
+++ b/DocumentSystem/MarkdownDocument.lua
@@ -3368,6 +3368,7 @@ function MarkdownDocument:EditPanel(args)
                 height = 16,
                 fontSize = 12,
                 halign = "right",
+                rmargin = 168,
                 classes = showPreviewSetting:Get() and { "selected" } or {},
                 press = function(element)
                     local newState = not element:HasClass("selected")

--- a/DocumentSystem/MarkdownDocument.lua
+++ b/DocumentSystem/MarkdownDocument.lua
@@ -3093,6 +3093,7 @@ function MarkdownDocument:EditPanel(args)
         borderBox = true,
         lmargin = 8,
         hpad = 16,
+        vpad = 16,
 
         editDocument = function(element, content)
             previewDoc:SetTextContent(content or "")

--- a/DocumentSystem/MarkdownDocument.lua
+++ b/DocumentSystem/MarkdownDocument.lua
@@ -13,6 +13,13 @@ local g_markdownStyle = gui.MarkdownStyle {
     ["##### "] = "<size=120%><b>", ["/##### "] = "</b></size>",
 }
 
+local showPreviewSetting = setting{
+    id = "markdownEditorShowPreview",
+    name = "Show Preview Pane in Markdown Editor",
+    default = true,
+    storage = "preferences",
+}
+
 ---@class RichTag
 ---@field pattern false|string
 RichTag = RegisterGameType("RichTag")

--- a/DocumentSystem/MarkdownDocument.lua
+++ b/DocumentSystem/MarkdownDocument.lua
@@ -3268,20 +3268,8 @@ function MarkdownDocument:EditPanel(args)
         ToolbarButton("U", 16, 28, WrapHandler("__", "__")),
         ToolbarButton("S", 16, 28, WrapHandler("~~", "~~")),
 
-        gui.Dropdown{
-            width = 80, height = 24, idChosen = "",
-            options = headingOptions,
-            change = function(element)
-                if element.idChosen ~= "" then
-                    LineHandler(element.idChosen)()
-                    element.idChosen = ""
-                end
-            end,
-        },
-
-        ToolbarButton("List",    12, 44, LineHandler("* ")),
-        ToolbarButton("Divider", 12, 56, InsertHandler("\n---\n", 5)),
-        ToolbarButton("Link",    12, 40, InsertHandler("[]", 1)),
+        ToolbarButton("Color", 12, 44,
+            WrapHandler("<color=red>", "</color>")),
 
         gui.Dropdown{
             width = 90, height = 24, idChosen = "",
@@ -3299,8 +3287,23 @@ function MarkdownDocument:EditPanel(args)
             end,
         },
 
-        ToolbarButton("Color", 12, 44,
-            WrapHandler("<color=red>", "</color>")),
+        gui.Dropdown{
+            width = 80, height = 24, idChosen = "",
+            options = headingOptions,
+            change = function(element)
+                if element.idChosen ~= "" then
+                    LineHandler(element.idChosen)()
+                    element.idChosen = ""
+                end
+            end,
+        },
+
+        ToolbarButton("List",    12, 44, LineHandler("* ")),
+        ToolbarButton("Divider", 12, 56, InsertHandler("\n---\n", 5)),
+        ToolbarButton("Link",    12, 40, InsertHandler("[]", 1)),
+
+        ToolbarButton("Draw Steel!", 12, 80,
+            InsertHandler('[[//link "Draw Steel!"|Draw Steel!]]')),
 
         gui.Dropdown{
             width = 110, height = 24, idChosen = "",

--- a/DocumentSystem/MarkdownDocument.lua
+++ b/DocumentSystem/MarkdownDocument.lua
@@ -3059,7 +3059,7 @@ function MarkdownDocument:EditPanel(args)
         flow = "vertical",
         borderBox = true,
         lmargin = 8,
-        hpad = 8,
+        hpad = 16,
 
         editDocument = function(element, content)
             previewDoc:SetTextContent(content or "")
@@ -3220,8 +3220,9 @@ function MarkdownDocument:EditPanel(args)
 
     local toolbar = gui.Panel{
         width = "100%",
-        height = 28,
+        height = "auto",
         flow = "horizontal",
+        wrap = true,
         valign = "top",
         halign = "left",
         borderBox = true,
@@ -3299,7 +3300,7 @@ function MarkdownDocument:EditPanel(args)
         toolbar,
         gui.Panel{
             width = "100%",
-            height = "100%-32",
+            height = "100% available",
             editInput,
         },
     }

--- a/DocumentSystem/MarkdownDocument.lua
+++ b/DocumentSystem/MarkdownDocument.lua
@@ -2991,6 +2991,7 @@ function MarkdownDocument:EditPanel(args)
 
     local previewPanel
     previewPanel = gui.Panel{
+        classes = showPreviewSetting:Get() and {} or { "collapsed" },
         width = "50%",
         height = "100%",
         valign = "top",
@@ -3113,6 +3114,13 @@ function MarkdownDocument:EditPanel(args)
         end,
     }
 
+    local editorColumn
+    editorColumn = gui.Panel{
+        width = showPreviewSetting:Get() and "50%" or "100%",
+        height = "100%",
+        editInput,
+    }
+
     resultPanel = gui.Panel {
         classes = { "collapsed" },
         width = "100%",
@@ -3130,17 +3138,32 @@ function MarkdownDocument:EditPanel(args)
             halign = "center",
             valign = "top",
             flow = "horizontal",
-            gui.Panel{
-                width = "50%",
-                height = "100%",
-                editInput,
-            },
+            editorColumn,
             previewPanel,
         },
         gui.Panel {
             width = "100%",
             height = 16,
             markdownReferenceLabel,
+            gui.Button{
+                text = "Preview",
+                width = 70,
+                height = 16,
+                fontSize = 12,
+                halign = "right",
+                classes = showPreviewSetting:Get() and { "selected" } or {},
+                press = function(element)
+                    local newState = not element:HasClass("selected")
+                    element:SetClass("selected", newState)
+                    showPreviewSetting:Set(newState)
+                    previewPanel:SetClass("collapsed", not newState)
+                    editorColumn.selfStyle.width = newState and "50%" or "100%"
+                    if newState then
+                        previewPanel:FireEvent("editDocument",
+                            editInput.text or self:GetTextContent())
+                    end
+                end,
+            },
             charactersUsedLabel,
             savePanel,
         },

--- a/DocumentSystem/MarkdownDocument.lua
+++ b/DocumentSystem/MarkdownDocument.lua
@@ -3208,23 +3208,14 @@ function MarkdownDocument:EditPanel(args)
     local widgetTags = { "dice", "bar", "counter", "checkbox", "macro",
                          "reminder", "timer", "setting" }
 
-    local function TagDropdown(label, tagList)
-        local options = { { id = "", text = label } }
-        for _, t in ipairs(tagList) do
-            options[#options + 1] = { id = t, text = t }
-        end
-        return gui.Dropdown{
-            width = 110,
-            height = 24,
-            idChosen = "",
-            options = options,
-            change = function(element)
-                if element.idChosen ~= "" then
-                    RichTagHandler(element.idChosen)()
-                    element.idChosen = ""
-                end
-            end,
-        }
+    local mediaOptions = { { id = "", text = "Insert Media" } }
+    for _, t in ipairs(mediaTags) do
+        mediaOptions[#mediaOptions + 1] = { id = t, text = t }
+    end
+
+    local widgetOptions = { { id = "", text = "Insert Widget" } }
+    for _, t in ipairs(widgetTags) do
+        widgetOptions[#widgetOptions + 1] = { id = t, text = t }
     end
 
     local toolbar = gui.Panel{
@@ -3276,8 +3267,27 @@ function MarkdownDocument:EditPanel(args)
         ToolbarButton("Color", 12, 44,
             WrapHandler("<color=red>", "</color>")),
 
-        TagDropdown("Insert Media",  mediaTags),
-        TagDropdown("Insert Widget", widgetTags),
+        gui.Dropdown{
+            width = 110, height = 24, idChosen = "",
+            options = mediaOptions,
+            change = function(element)
+                if element.idChosen ~= "" then
+                    RichTagHandler(element.idChosen)()
+                    element.idChosen = ""
+                end
+            end,
+        },
+
+        gui.Dropdown{
+            width = 110, height = 24, idChosen = "",
+            options = widgetOptions,
+            change = function(element)
+                if element.idChosen ~= "" then
+                    RichTagHandler(element.idChosen)()
+                    element.idChosen = ""
+                end
+            end,
+        },
     }
 
     local editorColumn

--- a/DocumentSystem/MarkdownDocument.lua
+++ b/DocumentSystem/MarkdownDocument.lua
@@ -3196,6 +3196,13 @@ function MarkdownDocument:EditPanel(args)
         { id = "##### ", text = "H5" },
     }
 
+    local spoilerOptions = {
+        { id = "",  text = "Spoiler" },
+        { id = "h", text = "Hidden" },
+        { id = "r", text = "Redacted" },
+        { id = "v", text = "Revealed" },
+    }
+
     local toolbar = gui.Panel{
         width = "100%",
         height = 28,
@@ -3225,6 +3232,25 @@ function MarkdownDocument:EditPanel(args)
         ToolbarButton("List",    12, 44, LineHandler("* ")),
         ToolbarButton("Divider", 12, 56, InsertHandler("\n---\n", 5)),
         ToolbarButton("Link",    12, 40, InsertHandler("[]", 1)),
+
+        gui.Dropdown{
+            width = 90, height = 24, idChosen = "",
+            options = spoilerOptions,
+            change = function(element)
+                local id = element.idChosen
+                if id == "h" then
+                    WrapHandler("{", "}")()
+                elseif id == "r" then
+                    WrapHandler("{#", "}")()
+                elseif id == "v" then
+                    WrapHandler("{!", "}")()
+                end
+                element.idChosen = ""
+            end,
+        },
+
+        ToolbarButton("Color", 12, 44,
+            WrapHandler("<color=red>", "</color>")),
     }
 
     local editorColumn

--- a/DocumentSystem/MarkdownDocument.lua
+++ b/DocumentSystem/MarkdownDocument.lua
@@ -2984,6 +2984,31 @@ function MarkdownDocument:EditPanel(args)
         end,
     }
 
+    local previewDoc = MarkdownDocument.new{
+        content = self:GetTextContent(),
+        annotations = self.annotations,
+    }
+
+    local previewPanel
+    previewPanel = gui.Panel{
+        width = "50%",
+        height = "100%",
+        valign = "top",
+        vscroll = true,
+        flow = "vertical",
+        hmargin = 4,
+
+        editDocument = function(element, content)
+            previewDoc:SetTextContent(content or "")
+            element:FireEventTree("refreshDocument", previewDoc)
+        end,
+
+        previewDoc:DisplayPanel{
+            width = "100%",
+            height = "auto",
+        },
+    }
+
     local m_richPanels = {}
 
     local annotationsPanel = gui.Panel {
@@ -3094,7 +3119,12 @@ function MarkdownDocument:EditPanel(args)
             halign = "center",
             valign = "top",
             flow = "horizontal",
-            editInput,
+            gui.Panel{
+                width = "50%",
+                height = "100%",
+                editInput,
+            },
+            previewPanel,
         },
         gui.Panel {
             width = "100%",

--- a/DocumentSystem/MarkdownDocument.lua
+++ b/DocumentSystem/MarkdownDocument.lua
@@ -2999,6 +2999,7 @@ function MarkdownDocument:EditPanel(args)
         flow = "vertical",
         borderBox = true,
         lmargin = 8,
+        hpad = 8,
 
         editDocument = function(element, content)
             previewDoc:SetTextContent(content or "")

--- a/DocumentSystem/MarkdownDocument.lua
+++ b/DocumentSystem/MarkdownDocument.lua
@@ -2963,6 +2963,31 @@ function MarkdownDocument:EditPanel(args)
         input:FireEvent("edit")
     end
 
+    local function WrapHandler(prefix, suffix)
+        return function() InsertAction(editInput, {
+            mode = "wrap", prefix = prefix, suffix = suffix,
+        }) end
+    end
+
+    local function LineHandler(prefix)
+        return function() InsertAction(editInput, {
+            mode = "linePrefix", prefix = prefix,
+        }) end
+    end
+
+    local function InsertHandler(text, caretOffset)
+        return function() InsertAction(editInput, {
+            mode = "insert", text = text, caretOffset = caretOffset,
+        }) end
+    end
+
+    local function RichTagHandler(tagName)
+        return function() InsertAction(editInput, {
+            mode = "insert",
+            text = string.format("[[%s]]\n", tagName),
+        }) end
+    end
+
     editInput = gui.Input {
         id = "editorPanel",
         classes = { "monospace" },
@@ -3151,12 +3176,45 @@ function MarkdownDocument:EditPanel(args)
         end,
     }
 
+    local function ToolbarButton(label, fontSize, width, handler)
+        return gui.Button{
+            text = label,
+            width = width or 28,
+            height = 24,
+            fontSize = fontSize or 14,
+            valign = "center",
+            press = handler,
+        }
+    end
+
+    local toolbar = gui.Panel{
+        width = "100%",
+        height = 28,
+        flow = "horizontal",
+        valign = "top",
+        halign = "left",
+        borderBox = true,
+        hpad = 4,
+        bmargin = 4,
+
+        ToolbarButton("B", 16, 28, WrapHandler("**", "**")),
+        ToolbarButton("I", 16, 28, WrapHandler("*", "*")),
+        ToolbarButton("U", 16, 28, WrapHandler("__", "__")),
+        ToolbarButton("S", 16, 28, WrapHandler("~~", "~~")),
+    }
+
     local editorColumn
     editorColumn = gui.Panel{
         width = showPreviewSetting:Get() and "50%" or "100%",
         height = "100%",
         borderBox = true,
-        editInput,
+        flow = "vertical",
+        toolbar,
+        gui.Panel{
+            width = "100%",
+            height = "100%-32",
+            editInput,
+        },
     }
 
     resultPanel = gui.Panel {

--- a/DocumentSystem/MarkdownDocument.lua
+++ b/DocumentSystem/MarkdownDocument.lua
@@ -2998,6 +2998,7 @@ function MarkdownDocument:EditPanel(args)
         vscroll = true,
         flow = "vertical",
         borderBox = true,
+        lmargin = 8,
 
         editDocument = function(element, content)
             previewDoc:SetTextContent(content or "")

--- a/DocumentSystem/MarkdownDocument.lua
+++ b/DocumentSystem/MarkdownDocument.lua
@@ -2928,6 +2928,41 @@ function MarkdownDocument:EditPanel(args)
         inputElement.popup = popup
     end
 
+    local function InsertAction(input, action)
+        local text = input.text or ""
+        local caret = input.caretPosition or #text
+        local anchor = input.selectionAnchorPosition or caret
+        local selStart = math.min(caret, anchor)
+        local selEnd   = math.max(caret, anchor)
+        local selected = text:sub(selStart + 1, selEnd)
+
+        local newText, newCaret
+
+        if action.mode == "wrap" then
+            local body = selected
+            if body == "" then body = action.placeholder or "" end
+            newText = text:sub(1, selStart)
+                    .. action.prefix .. body .. action.suffix
+                    .. text:sub(selEnd + 1)
+            newCaret = selStart + #action.prefix + #body
+        elseif action.mode == "linePrefix" then
+            local lineStart = selStart
+            while lineStart > 0 and text:sub(lineStart, lineStart) ~= "\n" do
+                lineStart = lineStart - 1
+            end
+            newText = text:sub(1, lineStart) .. action.prefix
+                    .. text:sub(lineStart + 1)
+            newCaret = selStart + #action.prefix
+        else
+            newText = text:sub(1, selStart) .. action.text
+                    .. text:sub(selEnd + 1)
+            newCaret = selStart + (action.caretOffset or #action.text)
+        end
+
+        input:SetTextAndCaret(newCaret, newText)
+        input:FireEvent("edit")
+    end
+
     editInput = gui.Input {
         id = "editorPanel",
         classes = { "monospace" },

--- a/DocumentSystem/MarkdownDocument.lua
+++ b/DocumentSystem/MarkdownDocument.lua
@@ -3372,6 +3372,7 @@ function MarkdownDocument:EditPanel(args)
                     previewPanel:SetClass("collapsed", not newState)
                     editorColumn.selfStyle.width = newState and "50%" or "100%"
                     if newState then
+                        lastSyncedCaret = -1
                         previewPanel:FireEvent("editDocument",
                             editInput.text or self:GetTextContent())
                     end

--- a/DocumentSystem/MarkdownDocument.lua
+++ b/DocumentSystem/MarkdownDocument.lua
@@ -3007,6 +3007,17 @@ function MarkdownDocument:EditPanel(args)
             width = "100%",
             height = "auto",
         },
+
+        gui.Panel{
+            classes = { "previewClickGuard" },
+            width = "100%",
+            height = "100%",
+            floating = true,
+            bgimage = "panels/square.png",
+            bgcolor = "#00000000",
+            click = function() end,
+            rightClick = function() end,
+        },
     }
 
     local m_richPanels = {}

--- a/DocumentSystem/MarkdownDocument.lua
+++ b/DocumentSystem/MarkdownDocument.lua
@@ -2992,7 +2992,7 @@ function MarkdownDocument:EditPanel(args)
     local previewPanel
     previewPanel = gui.Panel{
         classes = showPreviewSetting:Get() and {} or { "collapsed" },
-        width = "50%",
+        width = "50%-16",
         height = "100%",
         valign = "top",
         vscroll = true,

--- a/DocumentSystem/MarkdownDocument.lua
+++ b/DocumentSystem/MarkdownDocument.lua
@@ -2997,7 +2997,7 @@ function MarkdownDocument:EditPanel(args)
         valign = "top",
         vscroll = true,
         flow = "vertical",
-        hmargin = 4,
+        borderBox = true,
 
         editDocument = function(element, content)
             previewDoc:SetTextContent(content or "")
@@ -3118,6 +3118,7 @@ function MarkdownDocument:EditPanel(args)
     editorColumn = gui.Panel{
         width = showPreviewSetting:Get() and "50%" or "100%",
         height = "100%",
+        borderBox = true,
         editInput,
     }
 

--- a/DocumentSystem/MarkdownDocument.lua
+++ b/DocumentSystem/MarkdownDocument.lua
@@ -3362,7 +3362,7 @@ function MarkdownDocument:EditPanel(args)
         gui.Panel {
             width = "100%",
             height = 16,
-            tmargin = 8,
+            tmargin = 12,
             markdownReferenceLabel,
             gui.Button{
                 text = "Preview",

--- a/DocumentSystem/MarkdownDocument.lua
+++ b/DocumentSystem/MarkdownDocument.lua
@@ -3203,6 +3203,30 @@ function MarkdownDocument:EditPanel(args)
         { id = "v", text = "Revealed" },
     }
 
+    local mediaTags  = { "image", "sound", "ability", "scene",
+                         "encounter", "party", "follower" }
+    local widgetTags = { "dice", "bar", "counter", "checkbox", "macro",
+                         "reminder", "timer", "setting" }
+
+    local function TagDropdown(label, tagList)
+        local options = { { id = "", text = label } }
+        for _, t in ipairs(tagList) do
+            options[#options + 1] = { id = t, text = t }
+        end
+        return gui.Dropdown{
+            width = 110,
+            height = 24,
+            idChosen = "",
+            options = options,
+            change = function(element)
+                if element.idChosen ~= "" then
+                    RichTagHandler(element.idChosen)()
+                    element.idChosen = ""
+                end
+            end,
+        }
+    end
+
     local toolbar = gui.Panel{
         width = "100%",
         height = 28,
@@ -3251,6 +3275,9 @@ function MarkdownDocument:EditPanel(args)
 
         ToolbarButton("Color", 12, 44,
             WrapHandler("<color=red>", "</color>")),
+
+        TagDropdown("Insert Media",  mediaTags),
+        TagDropdown("Insert Widget", widgetTags),
     }
 
     local editorColumn


### PR DESCRIPTION
## Summary

Three connected upgrades to the in-app markdown document editor in `DocumentSystem/MarkdownDocument.lua`:

- **Live preview pane.** A side-by-side preview renders the document as you type, debounced ~300ms via the editor's existing `editlag`. Toggled with a "Preview" button in the footer; state persists per user via `setting{}` (defaults on). Reuses `MarkdownDocument:DisplayPanel()` against a transient in-memory `MarkdownDocument`, so the preview shows rich tags (dice, image, ability, encounter, etc.) exactly as readers see them. A transparent floating overlay swallows clicks on the preview so authors can't accidentally fire rich-tag side effects.
- **Formatting toolbar.** A wrapping row of buttons and dropdowns above the editor exposes every supported markdown option without the user having to memorize syntax: **B I U S** (wrap), Color, Spoiler dropdown (hidden/redacted/revealed), Heading dropdown (H1-H5), List, Divider, Link, Draw Steel! shortcut, and two dropdowns covering all 15 rich tags (Insert Media: image/sound/ability/scene/encounter/party/follower; Insert Widget: dice/bar/counter/checkbox/macro/reminder/timer/setting). One shared `InsertAction(input, action)` helper handles three modes (`wrap`, `linePrefix`, `insert`) and powers every button. Uses engine-native `caretPosition`, `selectionAnchorPosition`, and `SetTextAndCaret(...)` for caret-aware insertion.
- **Proportional scroll sync.** The preview pane scrolls to follow the editor caret on both `caretReady` (clicks, arrow keys) and the existing `think` tick (~200ms). Maps `caretLine / totalLines` to the engine's `vscrollPosition` (0 = bottom, 1 = top). A `lastSyncedCaret` upvalue avoids redundant work; toggling the preview pane back on resets state so the next sync fires immediately.

Plus small polish: 8px gutter between columns, `borderBox = true` on both columns so internal padding doesn't push them into each other, scrollbar-width compensation on the preview, vertical/horizontal padding around preview content, footer breathing room, and a fix for the Preview toggle button (and the \"characters remaining\" label) overlapping the existing save panel.

## Test plan

All verification is manual inside DMHub.

- [ ] Open any markdown document. Preview pane is visible on the right by default.
- [ ] Type, select, click toolbar buttons - wrap, line-prefix, and insert actions all behave per the icon (selection wraps, caret lands inside the inserted markers).
- [ ] Heading, Spoiler, Insert Media, Insert Widget dropdowns each open with their full option list. Picking an item inserts the right syntax and snaps the dropdown back to its placeholder label.
- [ ] Toolbar wraps onto a second row when the editor column is narrow.
- [ ] Click a rich-tag widget in the preview (e.g. \`[[dice]]\`) - no chat roll fires. Hover still shows tooltips.
- [ ] Move caret with arrow keys / clicks / Ctrl+End / Ctrl+Home - preview scrolls proportionally to follow.
- [ ] Toggle preview off via footer button: editor expands to full width, no errors. Toggle back on: preview returns and re-syncs to current caret. Setting persists across reopen.
- [ ] Save the document - existing save flow unaffected. Annotations strip below the editor (rich-tag thumbnails) still works.
- [ ] Approach the character limit - "characters remaining" label appears to the left of the Preview button instead of behind the save panel.