### PR TITLE
Add Duplicate option to journal doc context menu

### DIFF
--- a/DMHub Core Panels/Journal.lua
+++ b/DMHub Core Panels/Journal.lua
@@ -674,6 +674,27 @@ CreateFolderContentsPanel = function(journalPanel, folderid)
                                     end,
                                 },
                                 {
+                                    text = "Duplicate",
+                                    hidden = member.nodeType ~= "custom",
+                                    click = function()
+                                        element.popup = nil
+
+                                        local newDoc = DeepCopy(member)
+                                        newDoc.id = dmhub.GenerateGuid()
+                                        newDoc.description = "Copy of " .. (member.description or "")
+                                        newDoc.updateid = ""
+                                        newDoc.ord = (member.ord or 0) + 0.5
+                                        if not dmhub.isDM then
+                                            newDoc.ownerid = dmhub.loginUserid
+                                        end
+
+                                        newDoc.textStorage = false
+                                        newDoc:SetTextContent(member:GetTextContent())
+
+                                        newDoc:Upload()
+                                    end,
+                                },
+                                {
                                     text = "Delete",
                                     hidden = not member:HaveEditPermissions(),
                                     click = function()


### PR DESCRIPTION
## Summary
- Adds a **Duplicate** entry to the right-click context menu in the Journal panel, between Rename and Delete.
- Only appears for custom documents (`nodeType == "custom"`) — skips PDFs, images, and PDF fragments.
- Creates the copy as `Copy of <original name>`, with a fresh GUID, an `ord` slightly above the original so it sorts adjacent in the list, and a freshly-seeded `textStorage` so edits on the copy do not bleed into the source.
- For non-DM users, the copy is owned by the duplicating user (matches the New Document button's behavior).

## Test plan
- [ ] Right-click a custom doc -> Duplicate -> a "Copy of ..." entry appears immediately next to the original.
- [ ] Open the copy, edit it, and confirm the original is unchanged.
- [ ] Right-click a PDF, image, or PDF fragment -> confirm Duplicate is not in the menu.
- [ ] As a non-DM user, duplicate a doc -> confirm the copy is ownerid'd to the current user.