### PR TITLE
Fix Trigger GoblinScript field to use ActionResource check

### DIFF
--- a/Draw Steel Core Rules/MCDMActivatedAbility.lua
+++ b/Draw Steel Core Rules/MCDMActivatedAbility.lua
@@ -2768,7 +2768,7 @@ GameSystem.RegisterGoblinScriptField {
     seealso = {},
     examples = {},
     calculate = function(c)
-        return c:has_key("trigger")
+        return c:ActionResource() == "b9bc06dd-80f1-4f33-bc55-25c114e3300c"
     end,
 }
 


### PR DESCRIPTION
## Summary

- The `Trigger` GoblinScript field on `ActivatedAbility` was using `c:has_key("trigger")` to detect trigger abilities, which was returning true for all triggers.
- Changed to check `c:ActionResource() == "b9bc06dd-80f1-4f33-bc55-25c114e3300c"` to correctly identify trigger abilities by their action resource GUID- Now, triggers with no action assigned to them will not trigger bleeding