### PR TITLE
Ability editor: fix blank keyword icon preview in Presentation section

### DIFF
--- a/Draw Steel Ability Editor/AbilityEditor.lua
+++ b/Draw Steel Ability Editor/AbilityEditor.lua
@@ -4280,7 +4280,7 @@ local function _buildPresentationSection(ability, fireChange)
         height = 48,
         halign = "left",
         bgimage = ability:GetIcon(),
-        classes = {"bgFgMuted", cond(ability.hasCustomIcon, "collapsed-anim")},
+        classes = {"image", cond(ability.hasCustomIcon, "collapsed-anim")},
         refreshAbility = function(element)
             element.bgimage = ability:GetIcon()
         end,


### PR DESCRIPTION
## Summary
- The Presentation section's keyword-derived icon preview was rendering as a blank square after the recent ThemeEngine pass.
- Root cause: the preview carried the `bgFgMuted` theme class, which sets `bgcolor = @fgMuted` on a `bgimage` panel. The engine treats that as a tint **multiplier**, and the DS keyword icon PNGs (`melee_icon.png`, `ranged_icon.png`, `area_icon.png`, etc.) are full-colour badges rather than white silhouettes -- multiplying them by a mid-grey crushes them to a near-blank square. This is the exact trap called out in `ThemeEngine.md` -> *Icon assets and theme tinting*.
- Fix: swap `bgFgMuted` for the purpose-built `image` class (`panel, image -> bgcolor white`), matching the canonical untinted-icon treatment used by `GetIconDisplay` on the action bar / character sheet. Per the neighbouring `iconEditor` comment, icon-tint state is intentionally not theme-token state.

Single-line change in `Draw Steel Ability Editor/AbilityEditor.lua`.

## Test plan
- [x] In-app: open the Ability Editor -> Presentation tab with **Custom Icon** off -- keyword-derived icon now renders in its native colours (verified in app after `reload_lua`).
- [ ] Toggle **Custom Icon** on/off -- preview collapses/expands correctly, no regression to the custom-icon swatch row.
- [ ] Verify across active color schemes (default / cinnamon / void / forest) -- icon should look identical in each since it is intentionally not theme-tinted.