### PR TITLE
Add condition+rider rule pattern and invoke-ability prompt improvements

### DIFF
--- a/DMHub Game Rules/AbilityInvokeAbility.lua
+++ b/DMHub Game Rules/AbilityInvokeAbility.lua
@@ -396,7 +396,7 @@ function ActivatedAbilityInvokeAbilityBehavior:Cast(ability, casterToken, target
                         end
 
                         local autoTarget = self:try_get("autoTarget", true)
-                        if autoTarget and not abilityClone:RequiresPromptWhenCast() then
+                        if autoTarget and not abilityClone:RequiresPromptWhenCast() and abilityClone:try_get("promptOverride") == nil then
                             abilityClone.castImmediately = true
                             print("INVOKE:: Auto-target enabled for", abilityClone.name)
                         end
@@ -578,7 +578,7 @@ function ActivatedAbilityInvokeAbilityBehavior.ExecuteInvoke(invokerToken, abili
                 end
             end
 
-            if abilityClone:RequiresPromptWhenCast() then
+            if abilityClone:RequiresPromptWhenCast() or abilityClone:try_get("promptOverride") ~= nil then
                 abilityClone.skippable = true
                 gamehud.actionBarPanel:FireEventTree("invokeAbility", casterToken, abilityClone, symbols, invokerCallback, {instantCast = true, targets = targets})
             else

--- a/Draw Steel Core Rules/MCDMAbilityBehavior.lua
+++ b/Draw Steel Core Rules/MCDMAbilityBehavior.lua
@@ -1131,16 +1131,77 @@ ActivatedAbility.RegisterPowerTableRule{
 local g_gainResourceIndex = nil
 local g_applyConditionIndex = nil
 local g_gainConditionWithRiderIndex = nil
+local g_gainConditionByNameWithRiderIndex = nil
 
 dmhub.RegisterEventHandler("refreshTables", function(keys)
     if mod.unloaded then
         return
     end
 
-	if keys ~= nil and (not keys[CharacterResource.tableName]) then
+	if keys ~= nil and (not keys[CharacterResource.tableName]) and (not keys[CharacterCondition.tableName]) and (not keys[CharacterCondition.ridersTableName]) then
 		return
 	end
 
+
+    -- Pattern: "Weakened Tail Spike (Save Ends)" -- condition name + rider powerTableText + duration
+    g_gainConditionByNameWithRiderIndex = g_gainConditionByNameWithRiderIndex or #g_rulePatterns + 1
+    g_rulePatterns[g_gainConditionByNameWithRiderIndex] = {
+        pattern = "^(?<condition>" .. GetTableNameRegex(CharacterCondition.tableName, "powertable") .. ") (?<rider>" .. GetTableNameRegex(CharacterCondition.ridersTableName, nil, "powerTableText") .. ")\\s+\\((?<duration>eot|eoe|save ends)\\)",
+        execute = function(behavior, ability, casterToken, targetToken, options, match)
+            local duration = string.lower(match.duration)
+            if string.starts_with(duration, "save") then
+                duration = "save"
+            end
+
+            local condName = match.condition
+            local riderName = match.rider
+
+            local conditionid = nil
+            local conditionsTable = dmhub.GetTable(CharacterCondition.tableName)
+            for k, v in unhidden_pairs(conditionsTable) do
+                local vname = regex.ReplaceAll(string.lower(v.name), "[^a-z0-9 ]", "")
+                if vname == condName then
+                    conditionid = k
+                    break
+                end
+            end
+
+            if conditionid == nil then
+                print("Rider:: Could not find condition for '" .. condName .. "'")
+                return
+            end
+
+            local riderid = nil
+            local t = dmhub.GetTable(CharacterCondition.ridersTableName)
+            for key, value in unhidden_pairs(t) do
+                local name = regex.ReplaceAll(string.lower(value["powerTableText"]), "[^a-z0-9 ]", "")
+                if name == string.lower(riderName) then
+                    riderid = key
+                    break
+                end
+            end
+
+            if riderid == nil then
+                print("Rider:: Could not find rider for '" .. riderName .. "'")
+                return
+            end
+
+            targetToken:ModifyProperties {
+                description = "Inflict Condition",
+                execute = function()
+                    targetToken.properties:InflictCondition(conditionid, {
+                        duration = duration,
+                        riders = {riderid},
+                        sourceDescription = string.format("Inflicted by %s's <b>%s</b> ability", creature.GetTokenDescription(casterToken), ability.name),
+                        casterInfo = {
+                            tokenid = casterToken.charid,
+                        },
+                        cast = options.symbols.cast,
+                    })
+                end
+            }
+        end,
+    }
 
     g_gainConditionWithRiderIndex = g_gainConditionWithRiderIndex or #g_rulePatterns + 1
     g_rulePatterns[g_gainConditionWithRiderIndex] = {

--- a/DrawSteelActionBar/DrawSteelActionBar.lua
+++ b/DrawSteelActionBar/DrawSteelActionBar.lua
@@ -4518,7 +4518,7 @@ CreateAbilityController = function()
                 caster = casterToken,
                 section = "target",
             }
-            element:FireEvent("beginCasting", ability, { symbols = symbols })
+            element:FireEvent("beginCasting", ability, { symbols = symbols, targets = options.targets })
 
             --[[
             local spellPanel = GetSpellPanel(nil, nil, ability,
@@ -5973,8 +5973,12 @@ CalculateSpellTargeting = function(forceCast, initialSetup)
 
         g_skipButton:SetClass("collapsed", not g_currentAbility:try_get("skippable", false))
 
-        -- Don't auto-cast on initial setup unless requested
-        if ((not g_currentAbility:CanSelectMoreTargets(g_token, targets, g_currentSymbols)) or forceCast) then --temporarily disabled -David -- and not initialSetup then
+        -- Don't auto-cast on initial setup unless requested.
+        -- When a promptOverride is set (e.g. an invoke-ability prompt), always fall through to the
+        -- confirmation UI so the player can read the prompt and click Confirm, even if all
+        -- targets are already pre-selected via the inherited target list.
+        local hasPromptOverride = g_currentAbility:try_get("promptOverride") ~= nil
+        if ((not g_currentAbility:CanSelectMoreTargets(g_token, targets, g_currentSymbols)) or forceCast) and not hasPromptOverride then --temporarily disabled -David -- and not initialSetup then
             --we can't select more targets, so cast the spell in here.
             g_token.lookAtMouse = false
             if g_castingEmoteSet and g_token.valid then


### PR DESCRIPTION
## Summary

- **New rule pattern for condition + rider** (`MCDMAbilityBehavior.lua`): Power roll rule text of the form \`"Weakened Tail Spike (Save Ends)"\` -- a condition name followed by a rider's \`powerTableText\` followed by a duration -- now matches and correctly calls \`InflictCondition\` with both the condition and rider attached. The \`refreshTables\` guard was also extended to rebuild patterns when \`charConditions\` or \`conditionRiders\` tables change (previously only \`characterResources\` triggered a rebuild).

- **Invoke Ability prompt fixes** (\`AbilityInvokeAbility.lua\`): When a \`promptText\` is configured on an Invoke Ability behavior, the sub-ability no longer silently auto-casts (\`castImmediately\` is suppressed), and the action-bar \`invokeAbility\` event is now fired so the player sees the confirmation dialog.

- **Action bar target pre-selection** (\`DrawSteelActionBar.lua\`): Inherited targets from the originating power roll are now forwarded into \`beginCasting\` so they appear pre-selected when the invoke prompt is shown. \`CalculateSpellTargeting\` is guarded to skip the auto-cast branch when \`promptOverride\` is set, keeping the Confirm button visible even when all targets are already chosen.

## Test plan

- [ ] Fire a monster ability whose power roll tier text contains \`"Condition Rider (Save Ends)"\` (e.g. \`"Weakened Tail Spike (Save Ends)"\`). Verify the condition is applied with the rider attached.
- [ ] Add or edit a condition rider in the compendium. Verify the rule patterns rebuild without requiring a full reload.
- [ ] Trigger an Invoke Ability behavior that has a \`promptText\` set. Verify the confirmation dialog appears with the prompt text and a Confirm button visible immediately (targets pre-highlighted, no extra click required).
- [ ] Confirm that invoke behaviors without a \`promptText\` still auto-cast as before (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)