### PR TITLE
Expose target.Ongoing Effects in modifier conditions; wire modifiers into resistance rolls

### DIFF
--- a/Draw Steel Core Rules/MCDMAbilityRollBehavior.lua
+++ b/Draw Steel Core Rules/MCDMAbilityRollBehavior.lua
@@ -1998,19 +1998,31 @@ function ActivatedAbilityPowerRollBehavior:EditorItems(parentPanel)
                                 element:FireEventOnParents("refreshAbilityPreview")
                             end,
                         },
-                        documentation = {
-                            help = string.format("This GoblinScript determines whether the modifier will apply."),
-                            output = "boolean",
-                            examples = {
-                                {
-                                    script = "Might > 4",
-                                    text = "The modifier will apply if the caster's Might is greater than 4.",
+                        documentation = (function()
+                            local syms = DeepCopy(ActivatedAbility.helpCasting)
+                            syms.target = {
+                                name = "Target",
+                                type = "creature",
+                                desc = "The creature being targeted by this ability roll.",
+                            }
+                            return {
+                                help = string.format("This GoblinScript determines whether the modifier will apply."),
+                                output = "boolean",
+                                examples = {
+                                    {
+                                        script = "Might > 4",
+                                        text = "The modifier will apply if the caster's Might is greater than 4.",
+                                    },
+                                    {
+                                        script = 'target.Ongoing Effects has "Petrified"',
+                                        text = "The modifier will apply if the target has the Petrified ongoing effect.",
+                                    },
                                 },
-                            },
-                            subject = creature.helpSymbols,
-                            subjectDescription = "The creature that is casting the ability.",
-                            symbols = ActivatedAbility.helpCasting,
-                        },
+                                subject = creature.helpSymbols,
+                                subjectDescription = "The creature that is casting the ability.",
+                                symbols = syms,
+                            }
+                        end)(),
                     },
                 }
 
@@ -3055,7 +3067,22 @@ RollCheck.RegisterCustom{
 	GetModifiers = function(check, creature)
         local options = check.options or {}
         options.attribute = check.info.attrid
-        return creature:GetModifiersForPowerRoll(check:GetRoll(creature), "resistance_power_roll" , options)
+        -- Expose the rolling creature as 'target' so activationCondition formulas
+        -- like 'target.Ongoing Effects has "Petrified"' resolve correctly.
+        options.target = creature
+        local result = creature:GetModifiersForPowerRoll(check:GetRoll(creature), "resistance_power_roll", options)
+        local behaviorModifiers = options.behaviorModifiers or {}
+        for _, mod in ipairs(behaviorModifiers) do
+            local modEntry = {mod = mod}
+            local m = mod:DescribeModifyPowerRoll(modEntry, creature, "resistance_power_roll", options)
+            if m ~= nil then
+                m.hint = m.modifier:HintModifyPowerRolls(modEntry, creature, "resistance_power_roll", options)
+                if m.hint ~= nil then
+                    result[#result+1] = m
+                end
+            end
+        end
+        return result
     end,
 	ShowDialog = function(check, dialogOptions)
         dialogOptions.rollProperties = RollPropertiesPowerTable.new{
@@ -3074,6 +3101,23 @@ end
 function ActivatedAbilityPowerRollBehavior:CastResistance(ability, casterToken, targets, options)
     options = options or {}
 	local tokenids = ActivatedAbility.GetTokenIds(targets)
+
+    -- Build ability-level modifiers so conditions like
+    -- 'target.Ongoing Effects has "Petrified"' apply per-target on the resistance roll.
+    local behaviorModifiers = {}
+    for _, modInfo in ipairs(self:try_get("modifiers", {})) do
+        behaviorModifiers[#behaviorModifiers+1] = CharacterModifier.new{
+            behavior = "power",
+            rollType = "resistance_power_roll",
+            activationCondition = modInfo.condition,
+            keywords = {},
+            modtype = modInfo.type,
+            guid = dmhub.GenerateGuid(),
+            name = modInfo.text,
+            description = modInfo.details,
+        }
+    end
+
     local dcaction = ability:RequireSavingThrowsCo(self, casterToken, tokenids, {
         id = "resistance_power_roll",
         rollType = "resistance_power_roll",
@@ -3083,6 +3127,9 @@ function ActivatedAbilityPowerRollBehavior:CastResistance(ability, casterToken, 
         info = {
             attrid = self:ResistanceAttr(),
             tiers = DeepCopy(self.tiers),
+        },
+        dc_options = {
+            behaviorModifiers = behaviorModifiers,
         },
     })
 


### PR DESCRIPTION
## Summary

- **GoblinScript editor**: `target` (type: `creature`) is now included in the documentation symbols for the bane/edge `condition` field on ability-level power roll modifiers. Formulas like `target.Ongoing Effects has "Petrified"` are now recognised and documented in the editor UI, with a worked example.
- **Resistance roll `GetModifiers`**: `options.target` is now set to the rolling creature before evaluating modifiers, so `target.` prefix formulas in `activationCondition` resolve against the correct creature rather than returning nil.
- **`CastResistance`**: Builds `CharacterModifier` objects from the behavior's `modifiers` YAML list and passes them via `dc_options.behaviorModifiers`. Ability-level conditional modifiers are now evaluated per-target on resistance rolls, closing a gap where the `modifiers` list was silently ignored for resistance-type behaviors.

## Why

Needed to implement the Medusa's **Shatter Victims** malice feature (Draw Steel Book Two: Monsters, p. 204). That ability requires enemies with the Petrified ongoing effect to roll their Might test with a double bane. Previously, `target.Ongoing Effects` was not a recognised symbol in the modifier condition editor, and even if authored manually, ability-level modifiers were never wired into resistance rolls at runtime.

## Reviewer notes

- No behaviour change for abilities with an empty `modifiers` list (the common case) — `behaviorModifiers` is an empty table and the new loop is a no-op.
- The `options.target = creature` assignment in `GetModifiers` only affects resistance rolls; existing creature-own modifiers that previously had no `target` in scope will still evaluate correctly since their `activationCondition` formulas won't reference `target.`.
- File changed: `Draw Steel Core Rules/MCDMAbilityRollBehavior.lua`

🤖 Generated with [Claude Code](https://claude.com/claude-code)