### PR TITLE
Power Roll Preview: Recognise characteristic-bonus damage and compendium tails

### DIFF
--- a/Draw Steel Core Rules/MCDMAbilityBehavior.lua
+++ b/Draw Steel Core Rules/MCDMAbilityBehavior.lua
@@ -373,7 +373,8 @@ local g_rulePatterns = {
     {
         pattern = {"^(?<damage>[0-9 d+-]+)\\s*(?<type>[a-z]+)?\\s?damage(?<mods>(\\s*\\((?:half|no damage)\\))*)",
             "^(?<damage>[0-9]+)\\s+(?<type>[a-z]+)\\s+damage(?<mods>(\\s*\\((?:half|no damage)\\))*)",
-            "^(?<damage>[0-9]+)\\s*\\+\\s*(?<bonus>[a-z, ]+ or [a-z]+ )(?<type>[a-z]+)\\s*damage(?<mods>(\\s*\\((?:half|no damage)\\))*)",
+            "^(?<damage>[0-9]+)\\s*\\+\\s*(?<bonus>[MARIPmarip, ]+ or [MARIPmarip]+)(\\s+(?<type>[a-z]+))?\\s*damage(?<mods>(\\s*\\((?:half|no damage)\\))*)",
+            "^(?<damage>[0-9]+)\\s*\\+\\s*(?<bonus>[MARIPmarip])(?![a-z])(\\s+(?<type>[a-z]+))?\\s*damage(?<mods>(\\s*\\((?:half|no damage)\\))*)",
         },
         execute = ExecuteDamage,
         isdamage = true,
@@ -1641,7 +1642,13 @@ function ActivatedAbilityDrawSteelCommandBehavior.ValidateRule(rule)
 
         local result = string.sub(rule, #bestMatchInfo.all + 1)
         --print("Rule:: validate matched pattern: (" .. bestMatchInfo.all .. "); rule = (" .. rule .. "); result = (" .. result .. ")")
-        return AddGate(result)
+        --Mirror runtime ExecuteCommandInternal: optionally strip a leading separator and revalidate
+        --the tail so subsequent clauses don't show grey when they actually fire at runtime.
+        local matchBody = regex.MatchGroups(result, "^ *[;,] *(?<body>.+)$")
+        if matchBody ~= nil then
+            result = matchBody.body
+        end
+        return AddGate(ActivatedAbilityDrawSteelCommandBehavior.ValidateRule(result))
     end
 
     --built in rule matches. Matched after we check compendium-defined patterns.


### PR DESCRIPTION
## Summary

Closes two cases where the power-roll tier-text preview shows grey for clauses that actually fire at runtime. The validator and runtime now agree on what counts as parsed.

- **Compendium tail recursion in `ValidateRule`**: after a `importerPowerTableEffects` pattern matches, the validator now strips an optional `;`/`,` separator and revalidates the tail, mirroring `ExecuteCommandInternal`. Tier text like `the target gains 5 temporary Stamina; 3 damage` no longer greys the damage clause.
- **Damage pattern coverage**: the multi-attribute bonus pattern's type word is now optional, and a sibling single-attribute pattern was added. Tier text like `2 + R fire damage` and `3 + M or A damage` now parses in the preview without depending on `NormalizeDamageRuleTextForCreature` (which only runs when a caster is bound).
- The bonus character class for the multi-attribute pattern was tightened from `[a-z, ]+` to `[MARIPmarip, ]+` so non-canonical chains like `M or A or I damage` don't smuggle through as a false match.

All changes are in `Draw Steel Core Rules/MCDMAbilityBehavior.lua` and are additive at the regex level: pattern A and B are unchanged, pattern C is more permissive in one dimension (type optional) and more restrictive in another (attr-letter-only class), pattern D is new. The validator's compendium-after path now recurses on the tail in the same way the runtime already does.

## Test plan

Set an ability's implementation status to **Unimplemented** and paste each tier text into a Power Roll tier field. Verify the preview colouring matches the expected column.

### Bug-fix tests (grey before, white after)

- [ ] `The target gains 5 temporary Stamina; 3 damage` — all white
- [ ] `the target has fire weakness 7 (save ends); I<1 frightened (save ends)` — all white
- [ ] `the target is illuminated (save ends), 4 damage` — all white
- [ ] `2 + r fire damage` — all white
- [ ] `3 + m or a damage` — all white
- [ ] `4 + p damage` — all white
- [ ] `The target gains 5 temporary Stamina; 2 + r fire damage` — all white

### Regression tests (should remain white)

- [ ] `3 damage`
- [ ] `2d6 damage`
- [ ] `5 fire damage`
- [ ] `3 damage (half)`
- [ ] `7 + M, A, or I fire damage`
- [ ] `7 + M, A, or I damage`
- [ ] `push 3`
- [ ] `M<2 dazed (save ends)`
- [ ] `6 + a psychic damage; i < weak dazed (save ends)`
- [ ] `the target is illuminated (save ends)`
- [ ] `4 damage; the target is illuminated (save ends)`

### Negative tests (should remain grey)

- [ ] `the wound smolders with regret` — all grey
- [ ] `2 + x fire damage` — grey (`x` not a characteristic)
- [ ] `3 + m and a damage` — grey (`and` not the connector)
- [ ] `5 + m or a or i damage` — grey (three-attr form requires comma style)

### Runtime parity

Cast at least one bug-fix case on a test token and confirm the actual effect fires (e.g. `2 + r fire damage` deals `2 + caster's R-mod` fire damage). White prediction should always match real runtime behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)