### PR TITLE
Modify Power Roll editor: fix vertical empty space around Adjustments

### DIFF
--- a/Draw Steel Core Rules/MCDModifyPowerRolls.lua
+++ b/Draw Steel Core Rules/MCDModifyPowerRolls.lua
@@ -2058,7 +2058,9 @@ CharacterModifier.TypeInfo.power = {
                 },
 
                 gui.Panel{
-                    classes = {"formLabel"},
+                    width = "auto",
+                    height = "auto",
+                    halign = "left",
                     flow = "vertical",
                     create = function(element)
                         local children = {}


### PR DESCRIPTION
## Summary
- Adjustments wrapper Panel in the Modify Power Roll editor was using `classes = {"formLabel"}`, inheriting label-targeted styling (`width = "100%"`, `valign = "top"`, fontSize, bold) intended for the sibling text label rather than a vertical container of adjustment rows.
- The inherited styling stretched the wrapper and pushed the "Replace Movement" row far below "Adjustments:" with a large empty band in between.
- Swapped the class for explicit `width = "auto"`, `height = "auto"`, `halign = "left"`, matching the wrapper pattern used by the Damage Type panel a few rows above in the same file.

## Test plan
- [ ] Open an ability with a Modify Power Roll behavior in the ability editor.
- [ ] Verify the Adjustments row sits flush under Surges and the "Replace Movement" row sits flush under Adjustments (no large empty bands).
- [ ] Add and remove a couple of adjustment entries to confirm the vertical list rebuilds correctly and the wrapper still hugs its content.