### PR TITLE
Add Cast.AnyTargetHas() GoblinScript field

### DIFF
--- a/DMHub Game Rules/ActivatedAbilityCast.lua
+++ b/DMHub Game Rules/ActivatedAbilityCast.lua
@@ -264,6 +264,16 @@ ActivatedAbilityCast.helpSymbols = {
         desc = "The amount of damage dealt by forced movement collisions to creatures targeted by this ability.",
         examples = {"Forced Movement Damage Dealt to Targets > 0"},
     },
+
+    anytargethas = {
+        name = "Any Target Has",
+        type = "function",
+        desc = "Returns true if any target of this ability has the named ongoing effect or condition. An optional second argument restricts the check to conditions applied by a specific creature.",
+        examples = {
+            "Any Target Has(\"Mark\")",
+            "Any Target Has(\"Mark\", Triggerer)",
+        },
+    },
 }
 
 ActivatedAbilityCast.lookupSymbols = {
@@ -321,6 +331,53 @@ ActivatedAbilityCast.lookupSymbols = {
                     for i,t in ipairs(c.targets) do
                         if t.token ~= nil and t.token.charid == tok.charid then
                             return true
+                        end
+                    end
+                end
+            end
+
+            return false
+        end
+    end,
+
+    -- Returns true if any target of this cast has the named ongoing effect or condition.
+    -- An optional second argument (a creature) restricts the check to conditions applied
+    -- by that specific creature, e.g. Cast.AnyTargetHas("Mark", Triggerer).
+    anytargethas = function(c)
+        return function(condname, caster)
+            condname = string.lower(condname)
+
+            -- Coerce GoblinScript creature argument to a properties table
+            if type(caster) == "function" then
+                caster = caster("self")
+            end
+
+            local ongoingEffectsTable = GetTableCached("characterOngoingEffects")
+            local conditionsTable = GetTableCached(CharacterCondition.tableName)
+
+            for _, target in ipairs(c.targets) do
+                if target.token ~= nil and target.token.valid then
+                    local ongoingEffects = target.token.properties:ActiveOngoingEffects()
+                    for _, effectInfo in ipairs(ongoingEffects) do
+                        local ongoingEffectInfo = ongoingEffectsTable[effectInfo.ongoingEffectid]
+                        if ongoingEffectInfo ~= nil then
+                            local cond = conditionsTable[ongoingEffectInfo.condition]
+                            local nameMatches = (cond ~= nil and string.lower(cond.name) == condname)
+                                            or string.lower(ongoingEffectInfo.name) == condname
+                            if nameMatches then
+                                if caster == nil then
+                                    return true
+                                end
+                                -- Check that the caster of this condition matches the provided creature
+                                if effectInfo:try_get("casterInfo") ~= nil then
+                                    local condCasterTok = dmhub.GetTokenById(effectInfo.casterInfo.tokenid)
+                                    local casterTok = dmhub.LookupToken(caster)
+                                    if condCasterTok ~= nil and casterTok ~= nil
+                                       and condCasterTok.charid == casterTok.charid then
+                                        return true
+                                    end
+                                end
+                            end
                         end
                     end
                 end


### PR DESCRIPTION
## Problem

The Tactician's **Mark: Additional Damage** Power Roll Trigger uses a `targetFilter` that is evaluated per-target:

```
Target.Ongoing Effects has "Mark" and Target.ConditionCaster("Mark") = Triggerer
```

When a multi-target ability hits Goblin A (marked) and Goblin B (not marked), only Goblin A passes the filter -- so only Goblin A gets the bonus damage. Goblin B is never added to the trigger list, so `DuplicateTriggerToMultiTargets` (which syncs `multitarget: all` triggers) cannot apply the damage there either.

Per the Draw Steel rules, the trigger should fire whenever **any** target is marked, and the bonus damage should apply to **all** targets of the ability.

## Solution

Add `Cast.AnyTargetHas(conditionName, caster?)` to the GoblinScript vocabulary on `ActivatedAbilityCast`.

```
Cast.AnyTargetHas("Mark")             -- true if any target has "Mark" (any caster)
Cast.AnyTargetHas("Mark", Triggerer)  -- true if any target has "Mark" applied by Triggerer
```

Because all targets of a roll share the same `cast` object, using this in a `targetFilter` returns the same value for every target -- so the trigger either appears for all targets or none. Combined with `multitarget: all`, this achieves the intended behavior.

## Implementation

- Follows the exact patterns of `hastarget` (creature arg coercion via `target("self")` / `dmhub.LookupToken`) and `conditioncaster` (`ActiveOngoingEffects()` iteration, `dmhub.GetTokenById` for caster lookup) -- both already in `ActivatedAbilityCast.lua` / `Creature.lua`.
- Both `helpSymbols` (documentation) and `lookupSymbols` (implementation) entries added.
- The new symbol is general-purpose and reusable for any future ability that needs "any target has X" logic.

## YAML change (gitignored -- apply manually in DMHub)

`compendium/tables/classes/tactician.yaml` -- Mark: Additional Damage modifier:

```yaml
# Before
targetFilter: 'Target.Ongoing Effects has "Mark" and Target.ConditionCaster("Mark") = Triggerer'
target: One creature marked by you

# After
targetFilter: 'Cast.AnyTargetHas("Mark", Triggerer)'
target: All targets of the ability (at least one must be marked by you)
```

## Testing

1. Tactician marks Goblin A; Goblin B is unmarked.
2. Cast a multi-target ability hitting both.
3. **Trigger appears once** (deduped by `multitarget: all`).
4. Using it deals 2 x Reason bonus damage to **both** Goblin A and Goblin B.
5. With no marked targets: trigger does **not** appear.
6. With a single marked target: trigger still fires and applies correctly.

Generated with [Claude Code](https://claude.com/claude-code)
