### PR TITLE
Roll intercept hooks for re-rolls and tables

### DIFF
--- a/DMHub Game Hud/RollOnTableDialog.lua
+++ b/DMHub Game Hud/RollOnTableDialog.lua
@@ -165,6 +165,7 @@ function GameHud.CreateRollOnTableDialog(self)
 		events = {
 			click = function(element)
 				rollDiceButton:SetClass("collapsed", true)
+				m_rolls = {}
 
 				m_hasClose = true
 
@@ -172,9 +173,47 @@ function GameHud.CreateRollOnTableDialog(self)
 				if m_options.creature ~= nil then
 					tokenid = dmhub.LookupTokenId(m_options.creature)
 				end
-                
+
                 m_options.rollProperties.tableRef = m_options.tableRef
                 print("ROLL PROPERTIES:", json(m_options.rollProperties))
+
+				-- Hook for external mods to intercept table rolls
+				if RollDialog.OnBeforeTableRoll then
+					local rollFormula = m_table:CalculateRollInfo().roll
+					local hookResult = RollDialog.OnBeforeTableRoll({
+						roll = rollFormula,
+						description = string.format("Roll on %s", m_table.name),
+						creature = m_options.creature,
+						tokenid = tokenid,
+						properties = m_options.rollProperties,
+						tableRef = m_options.tableRef,
+						tableName = m_table.name,
+						guid = m_guid,
+						completeWithResult = function(total)
+							local syntheticRollInfo = {
+								total = total,
+								boons = 0,
+								banes = 0,
+								rolls = {},
+								properties = m_options.rollProperties,
+							}
+							local rowIndex = m_table:RowIndexFromDiceResult(total)
+							tablePanel:FireEvent("previewRoll", rowIndex)
+							proceedButton:SetClass("collapsed", false)
+							gui.SetFocus(proceedButton)
+							proceedButton.data.onclick = function()
+								if m_options.completeRoll ~= nil then
+									m_options.completeRoll(syntheticRollInfo)
+								end
+								tablePanel:FireEvent("completeRoll", syntheticRollInfo)
+							end
+						end,
+					})
+					if hookResult == "intercept" then
+						chat.PreviewChat{''}
+						return
+					end
+				end
 
 				dmhub.Roll{
 					guid = m_guid,

--- a/Draw Steel UI/DSRollDialog.lua
+++ b/Draw Steel UI/DSRollDialog.lua
@@ -10,6 +10,8 @@ end
 
 RollDialog = {
     OnBeforeRoll = false,
+    OnReroll = false,
+    OnBeforeTableRoll = false,
 }
 
 local g_activeRoll = nil
@@ -2107,24 +2109,40 @@ function GameHud.CreateRollDialog(self)
                 return
             end
 
-            local guid = dmhub.GenerateGuid()
+            local function doRerollAmend(rollFormula)
+                if g_activeRoll == nil then return end
+                local guid = dmhub.GenerateGuid()
+                g_activeRoll = g_activeRoll:Amend {
+                    guid = guid,
+                    roll = tostring(rollFormula),
+                    amendmentRerolls = true,
+                    description = g_activeRollArgs.description .. " -- Re-rolled!",
+                    amendable = g_activeRollArgs.amendable,
+                    tokenid = g_activeRollArgs.tokenid,
+                    silent = g_activeRollArgs.rollIsSilent,
+                    instant = g_activeRollArgs.instant,
+                    creature = g_activeRollArgs.creature,
+                    properties = g_activeRollArgs.properties,
+                    begin = function(rollInfo)
+                        m_rollInfo = rollInfo
+                        resultPanel:FireEventTree("beginRoll", rollInfo, guid)
+                    end,
+                }
+            end
 
-            g_activeRoll = g_activeRoll:Amend {
-                guid = guid,
-                roll = g_activeRollArgs.roll,
-                amendmentRerolls = true,
-                description = g_activeRollArgs.description .. " -- Re-rolled!",
-                amendable = g_activeRollArgs.amendable,
-                tokenid = g_activeRollArgs.tokenid,
-                silent = g_activeRollArgs.rollIsSilent,
-                instant = g_activeRollArgs.instant,
-                creature = g_activeRollArgs.creature,
-                properties = g_activeRollArgs.properties,
-                begin = function(rollInfo)
-                    m_rollInfo = rollInfo
-                    resultPanel:FireEventTree("beginRoll", rollInfo, guid)
-                end,
-            }
+            -- Hook for external mods to intercept re-rolls
+            if RollDialog.OnReroll then
+                local rerollResult = RollDialog.OnReroll({
+                    rollArgs = g_activeRollArgs,
+                    originalRoll = g_activeRollArgs.originalRoll or g_activeRollArgs.roll,
+                    activeRoll = g_activeRoll,
+                    setActiveRoll = function(roll) g_activeRoll = roll end,
+                    amendWithResult = doRerollAmend,
+                })
+                if rerollResult == "intercept" then return end
+            end
+
+            doRerollAmend(g_activeRollArgs.originalRoll or g_activeRollArgs.roll)
         end,
     }
 
@@ -3206,6 +3224,7 @@ function GameHud.CreateRollDialog(self)
                 }
 
                 g_activeRollArgs = rollArgs
+                g_activeRollArgs.originalRoll = rollArgs.roll
 
                 -- Hook for external mods to intercept rolls
                 local hookResult = nil
@@ -3226,6 +3245,13 @@ function GameHud.CreateRollDialog(self)
                         modifiers = modifiersUsed,
                         multitargets = multitargetsUsed,
                         boons = m_boons,
+                        setActiveRoll = function(roll)
+                            activeRoll = roll
+                            g_activeRoll = roll
+                            if activeRollFn ~= nil then
+                                activeRollFn(roll)
+                            end
+                        end,
                     })
                 end
 

--- a/Timeline/EmbeddedRollDialog.lua
+++ b/Timeline/EmbeddedRollDialog.lua
@@ -3083,24 +3083,40 @@ function GameHud.CreateEmbeddedRollDialog()
                 return
             end
 
-            local guid = dmhub.GenerateGuid()
+            local function doRerollAmend(rollFormula)
+                if g_activeRoll == nil then return end
+                local guid = dmhub.GenerateGuid()
+                g_activeRoll = g_activeRoll:Amend {
+                    guid = guid,
+                    roll = tostring(rollFormula),
+                    amendmentRerolls = true,
+                    description = g_activeRollArgs.description .. " -- Re-rolled!",
+                    amendable = g_activeRollArgs.amendable,
+                    tokenid = g_activeRollArgs.tokenid,
+                    silent = g_activeRollArgs.rollIsSilent,
+                    instant = g_activeRollArgs.instant,
+                    creature = g_activeRollArgs.creature,
+                    properties = g_activeRollArgs.properties,
+                    begin = function(rollInfo)
+                        m_rollInfo = rollInfo
+                        resultPanel:FireEventTree("beginRoll", rollInfo, guid)
+                    end,
+                }
+            end
 
-            g_activeRoll = g_activeRoll:Amend {
-                guid = guid,
-                roll = g_activeRollArgs.roll,
-                amendmentRerolls = true,
-                description = g_activeRollArgs.description .. " -- Re-rolled!",
-                amendable = g_activeRollArgs.amendable,
-                tokenid = g_activeRollArgs.tokenid,
-                silent = g_activeRollArgs.rollIsSilent,
-                instant = g_activeRollArgs.instant,
-                creature = g_activeRollArgs.creature,
-                properties = g_activeRollArgs.properties,
-                begin = function(rollInfo)
-                    m_rollInfo = rollInfo
-                    resultPanel:FireEventTree("beginRoll", rollInfo, guid)
-                end,
-            }
+            -- Hook for external mods to intercept re-rolls
+            if RollDialog.OnReroll then
+                local rerollResult = RollDialog.OnReroll({
+                    rollArgs = g_activeRollArgs,
+                    originalRoll = g_activeRollArgs.originalRoll or g_activeRollArgs.roll,
+                    activeRoll = g_activeRoll,
+                    setActiveRoll = function(roll) g_activeRoll = roll end,
+                    amendWithResult = doRerollAmend,
+                })
+                if rerollResult == "intercept" then return end
+            end
+
+            doRerollAmend(g_activeRollArgs.originalRoll or g_activeRollArgs.roll)
         end,
     }
 
@@ -4520,6 +4536,7 @@ function GameHud.CreateEmbeddedRollDialog()
                 }
 
                 g_activeRollArgs = rollArgs
+                g_activeRollArgs.originalRoll = rollArgs.roll
 
                 -- Hook for external mods to intercept rolls
                 local hookResult = nil
@@ -4540,6 +4557,13 @@ function GameHud.CreateEmbeddedRollDialog()
                         modifiers = modifiersUsed,
                         multitargets = multitargetsUsed,
                         boons = m_boons,
+                        setActiveRoll = function(roll)
+                            activeRoll = roll
+                            g_activeRoll = roll
+                            if activeRollFn ~= nil then
+                                activeRollFn(roll)
+                            end
+                        end,
                     })
                 end
 


### PR DESCRIPTION
## Summary

Adds two optional hook slots on the existing `RollDialog` global so external mods can intercept rolls without forking the dialog code:

- **`RollDialog.OnReroll`** — fires from the re-roll button in `DSRollDialog` and `EmbeddedRollDialog`. Receives `rollArgs`, `originalRoll`, `activeRoll`,
`setActiveRoll()`, and `amendWithResult()`. Returning `"intercept"` short-circuits the normal `:Amend` path.
- **`RollDialog.OnBeforeTableRoll`** — fires from the Roll Dice button in `RollOnTableDialog` before `dmhub.Roll`. Receives the roll formula, description,
creature, tokenid, properties, tableRef, tableName, guid, and a `completeWithResult(total)` callback that drives the table-preview + Accept-Result flow
with a supplied total.

Also adds a `setActiveRoll` callback to the existing `RollDialog.OnBeforeRoll` payload, for symmetry with the new hooks.

## Usage

```lua
RollDialog.OnBeforeTableRoll = function(args)
    -- Mod computes its own result however it likes
    args.completeWithResult(7)
    return "intercept"
end
```

## Backwards compatibility

Both new slots default to `false`. With no handler assigned, behavior is identical to current `main` — the new code paths are skipped entirely.

## Files changed

- `Draw Steel UI/DSRollDialog.lua` (+44 / -18)
- `Timeline/EmbeddedRollDialog.lua` (+42 / -18)
- `DMHub Game Hud/RollOnTableDialog.lua` (+40 / -1)

## Implementation notes

- The re-roll button's inline `:Amend{...}` block was extracted into a local `doRerollAmend(rollFormula)` helper so the OnReroll hook can drive it via the
`amendWithResult` callback.   
- `g_activeRollArgs.originalRoll = rollArgs.roll` is snapshotted before `OnBeforeRoll` can mutate `rollArgs.roll`, so re-rolls always Amend with the
original dice formula rather than a possibly-flattened result.
- `RollOnTableDialog` resets `m_rolls = {}` at the top of the click handler so stale roll state from a prior invocation doesn't leak into an intercepted
roll.