### PR TITLE
fix: correct Ignore Hidden Within Range attribute lookup name

### DIFF
--- a/DrawSteelActionBar/DrawSteelActionBar.lua
+++ b/DrawSteelActionBar/DrawSteelActionBar.lua
@@ -5899,7 +5899,7 @@ local function CalculateSpellTargetFocusing(symbols)
                 end
 
                 if canTarget and targetToken.properties:HasNamedCondition("Hidden") and g_currentAbility:HasKeyword("Strike") then
-                    local ignoreRange = g_token.properties:CalculateNamedCustomAttribute("Ignore Hidden at Range") or 0
+                    local ignoreRange = g_token.properties:CalculateNamedCustomAttribute("Ignore Hidden Within Range") or 0
                     local bypass = false
                     if ignoreRange > 0 then
                         local dist = g_token:Distance(targetToken)

--- a/Monster AI/MonsterAI.lua
+++ b/Monster AI/MonsterAI.lua
@@ -254,7 +254,7 @@ function MonsterAI:FindValidTargetsOfStrike(token, ability, loc, range)
         local enemy = self.enemyTokens[i]
         local canTarget = ability:TargetPassesFilter(token, enemy, {})
         if canTarget and enemy.properties:HasNamedCondition("Hidden") and ability:HasKeyword("Strike") then
-            local ignoreRange = token.properties:CalculateNamedCustomAttribute("Ignore Hidden at Range") or 0
+            local ignoreRange = token.properties:CalculateNamedCustomAttribute("Ignore Hidden Within Range") or 0
             if ignoreRange <= 0 or token:Distance(enemy) > ignoreRange + dmhub.unitsPerSquare then
                 canTarget = false
             end


### PR DESCRIPTION
## Summary

- The `Ignore Hidden Within Range` custom attribute was never taking effect because both Lua call sites were looking up `"Ignore Hidden at Range"` (wrong name)
- `CalculateNamedCustomAttribute` does an exact display-name match, so the lookup always returned nil → 0 → the hidden bypass never activated
- Fixed both sites to use the correct name `"Ignore Hidden Within Range"`

## Files changed

- `DrawSteelActionBar/DrawSteelActionBar.lua` — player-facing strike targeting check
- `Monster AI/MonsterAI.lua` — monster AI strike target filtering

## Test plan

- [ ] Set `Ignore Hidden Within Range` to 2 on a creature
- [ ] Place a hidden enemy token within 2 squares — Strike targeting should now be allowed
- [ ] Place a hidden enemy token beyond 2 squares — Strike targeting should still be blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)