### PR TITLE
ModifyPowerRoll display: show active modifier effects in ability sidebar

### DIFF
--- a/DMHub Game Rules/Party.lua
+++ b/DMHub Game Rules/Party.lua
@@ -15,6 +15,7 @@ local mod = dmhub.GetModLoading()
 --- @field allyParties nil|table<string, boolean> Set of party ids that are allied with this party.
 Party = RegisterGameType("Party")
 
+Party.id = ""
 Party.name = "New Party"
 Party.details = ""
 Party.tableName = "parties"

--- a/DMHub Game Rules/Party.lua
+++ b/DMHub Game Rules/Party.lua
@@ -15,7 +15,6 @@ local mod = dmhub.GetModLoading()
 --- @field allyParties nil|table<string, boolean> Set of party ids that are allied with this party.
 Party = RegisterGameType("Party")
 
-Party.id = ""
 Party.name = "New Party"
 Party.details = ""
 Party.tableName = "parties"

--- a/Draw Steel Core Rules/MCDMActivatedAbility.lua
+++ b/Draw Steel Core Rules/MCDMActivatedAbility.lua
@@ -690,11 +690,17 @@ function ActivatedAbility:Render(options, params)
             if modifier:try_get("rollRequirement", "none") ~= "none" then
                 return
             end
-            local hint = modifier:HintModifyPowerRolls(modContext, creatureProperties, "ability_power_roll", {
+            -- Check displayCondition first (cheaper gate, avoids evaluating
+            -- activationCondition when the modifier should not be shown at all).
+            local rollOptions = {
                 ability = self,
                 caster = creatureProperties,
                 target = nullTarget,
-            })
+            }
+            if not modifier:ShouldShowInPowerRollDialog(modContext, creatureProperties, "ability_power_roll", rollOptions) then
+                return
+            end
+            local hint = modifier:HintModifyPowerRolls(modContext, creatureProperties, "ability_power_roll", rollOptions)
             if hint == nil or not hint.result then
                 return
             end

--- a/Draw Steel Core Rules/MCDMActivatedAbility.lua
+++ b/Draw Steel Core Rules/MCDMActivatedAbility.lua
@@ -656,11 +656,40 @@ function ActivatedAbility:Render(options, params)
         local rollProperties = RollPropertiesPowerTable.new{
             tiers = normalizedTiers,
         }
+        -- Pre-compute what the ability's tiers contain so note parts can be
+        -- filtered to only show information relevant to this ability.
+        -- hasDamage: any normalized tier contains the word "damage".
+        -- hasPotency: any raw tier contains a potency gate (" < ").
+        -- tiersDamageTypes: set of specific damage type words present in tiers.
+        local tiersAllText = table.concat(normalizedTiers, " "):lower()
+        local hasDamage = tiersAllText:find("damage") ~= nil
+        local hasPotency = false
+        for _, t in ipairs(ptBehavior.tiers) do
+            if t:find(" < ") then hasPotency = true break end
+        end
+        local tiersDamageTypes = {}
+        for damageType in tiersAllText:gmatch("(%a+)%s+damage") do
+            tiersDamageTypes[damageType] = true
+        end
+
         -- A minimal "null target" object: GenerateSymbols returns a non-nil
         -- function from it, which prevents AppendSymbols from substituting any
         -- stale target left in _tmp_symbols from a previous real roll.
         local nullTarget = {lookupSymbols = {}}
         local function tryApply(modifier, modContext)
+            -- Skip modifiers whose activation condition references the target.
+            -- Without a real target we cannot evaluate target-relative conditions
+            -- (e.g. High Ground, Hidden, Flanking) and the null-target defaults
+            -- produce false positives.
+            local ac = modifier:try_get("activationCondition", false)
+            if type(ac) == "string" and ac:lower():find("target") then
+                return
+            end
+            -- Skip modifiers with a Roll Requirement (edge, bane, surges, etc.)
+            -- since we have no roll info at display time.
+            if modifier:try_get("rollRequirement", "none") ~= "none" then
+                return
+            end
             local hint = modifier:HintModifyPowerRolls(modContext, creatureProperties, "ability_power_roll", {
                 ability = self,
                 caster = creatureProperties,
@@ -673,21 +702,112 @@ function ActivatedAbility:Render(options, params)
             -- Build a note describing what this modifier does.
             if notes ~= nil then
                 local noteParts = {}
+                local lookupFn = creatureProperties:LookupSymbol(modifier:AppendSymbols{
+                    triggerer = nil,
+                    target = GenerateSymbols(nullTarget),
+                })
                 local damageModifier = modifier:try_get("damageModifier", "")
-                if damageModifier ~= "" then
-                    local lookupFn = creatureProperties:LookupSymbol(modifier:AppendSymbols{
-                        triggerer = nil,
-                        target = GenerateSymbols(nullTarget),
-                    })
+                if damageModifier ~= "" and hasDamage then
                     local dmgVal = safe_toint(dmhub.EvalGoblinScript(damageModifier, lookupFn, "Power Roll Damage display"))
                     if dmgVal ~= nil and dmgVal ~= 0 then
                         dmgVal = round(dmgVal)
-                        noteParts[#noteParts+1] = string.format("%s%d damage", dmgVal > 0 and "+" or "", dmgVal)
+                        local damageModifierType = modifier:try_get("damageModifierType", "none")
+                        if damageModifierType ~= "none" then
+                            noteParts[#noteParts+1] = string.format("%s%d %s damage", dmgVal > 0 and "+" or "", dmgVal, damageModifierType)
+                        else
+                            noteParts[#noteParts+1] = string.format("%s%d damage", dmgVal > 0 and "+" or "", dmgVal)
+                        end
                     end
                 end
-                local potencymod = tonumber(modifier:try_get("potencymod", "none"))
-                if potencymod ~= nil and potencymod ~= 0 then
-                    noteParts[#noteParts+1] = string.format("%s%d potency", potencymod > 0 and "+" or "", potencymod)
+                if hasPotency then
+                    local potencymod = tonumber(modifier:try_get("potencymod", "none"))
+                    if potencymod ~= nil and potencymod ~= 0 then
+                        noteParts[#noteParts+1] = string.format("%s%d potency", potencymod > 0 and "+" or "", potencymod)
+                    end
+                end
+                local damageTypeMappings = modifier:try_get("damageTypeMappings")
+                if damageTypeMappings ~= nil and hasDamage then
+                    if damageTypeMappings["all"] ~= nil then
+                        noteParts[#noteParts+1] = string.format("all damage becomes %s", damageTypeMappings["all"])
+                    else
+                        for k, v in sorted_pairs(damageTypeMappings) do
+                            if tiersDamageTypes[k:lower()] then
+                                noteParts[#noteParts+1] = string.format("%s damage becomes %s", k, v)
+                            end
+                        end
+                    end
+                end
+                local replacePattern = trim(modifier:try_get("replacePattern", ""))
+                local replaceWith = trim(modifier:try_get("replaceText", ""))
+                if replacePattern ~= "" and replaceWith ~= "" then
+                    -- Use tiersAllText (a pre-modification string snapshot) so the
+                    -- search is not defeated by the replacement having already run.
+                    if tiersAllText:find(replacePattern:lower(), 1, true) then
+                        local dest = StringInterpolateGoblinScript(replaceWith, lookupFn)
+                        local t1, t2, t3 = dest:match("^(.-)%s*//%s*(.-)%s*//%s*(.-)%s*$")
+                        local destStr
+                        if t1 ~= nil then
+                            local function ts(t) return trim(t) ~= "" and ('"' .. trim(t) .. '"') or "-" end
+                            destStr = string.format("%s/%s/%s", ts(t1), ts(t2), ts(t3))
+                        else
+                            destStr = '"' .. dest .. '"'
+                        end
+                        noteParts[#noteParts+1] = string.format('"%s" -> %s', replacePattern, destStr)
+                    end
+                end
+                local addText = trim(modifier:try_get("addText", ""))
+                if addText ~= "" then
+                    local interpolated = StringInterpolateGoblinScript(addText, lookupFn)
+                    -- Split "A // B // C" tier notation; fall back to the raw text for N/N/N numeric format.
+                    local t1, t2, t3 = interpolated:match("^(.-)%s*//%s*(.-)%s*//%s*(.-)%s*$")
+                    local tierNote
+                    if t1 ~= nil then
+                        local function tierStr(t) return trim(t) ~= "" and ('"' .. trim(t) .. '"') or "-" end
+                        tierNote = string.format("adds: %s/%s/%s", tierStr(t1), tierStr(t2), tierStr(t3))
+                    else
+                        tierNote = "adds: " .. interpolated
+                    end
+                    noteParts[#noteParts+1] = tierNote
+                end
+                for _, adjustment in ipairs(modifier:try_get("adjustments", {})) do
+                    local adjType = adjustment.type or ""
+                    if adjType ~= "" and tiersAllText:find(adjType, 1, true) then
+                        local adjVal = safe_toint(dmhub.EvalGoblinScript(tostring(adjustment.value or 1), lookupFn, "Adjustment display"))
+                        if adjVal ~= nil and adjVal ~= 0 then
+                            noteParts[#noteParts+1] = string.format("%s%d %s", adjVal > 0 and "+" or "", adjVal, adjType)
+                        end
+                    end
+                end
+                local rfm = modifier:try_get("replaceForcedMovement")
+                if rfm ~= nil and rfm.from ~= nil and rfm.to ~= nil then
+                    if rfm.from == "any" then
+                        local presentTypes = {}
+                        for _, mt in ipairs({"push", "pull", "slide"}) do
+                            if tiersAllText:find(mt, 1, true) then
+                                presentTypes[#presentTypes+1] = mt
+                            end
+                        end
+                        if #presentTypes > 0 then
+                            noteParts[#noteParts+1] = string.format("%s -> %s", table.concat(presentTypes, "/"), rfm.to)
+                        end
+                    elseif tiersAllText:find(rfm.from, 1, true) then
+                        noteParts[#noteParts+1] = string.format("%s -> %s", rfm.from, rfm.to)
+                    end
+                end
+                local modtype = modifier:try_get("modtype", "none")
+                if modtype ~= "none" then
+                    local modTypeInfo = ActivatedAbilityPowerRollBehavior.s_modificationTypesById[modtype]
+                    if modTypeInfo ~= nil and not modTypeInfo.hideText then
+                        local rollModText
+                        if modTypeInfo.mod:match("^[+-]%d+$") then
+                            rollModText = modTypeInfo.mod .. " to roll"
+                        elseif modTypeInfo.mod:match("edge") or modTypeInfo.mod:match("bane") then
+                            rollModText = modTypeInfo.text .. " on roll"
+                        else
+                            rollModText = modTypeInfo.text
+                        end
+                        noteParts[#noteParts+1] = rollModText
+                    end
                 end
                 if #noteParts > 0 then
                     notes[#notes+1] = string.format("%s: %s", modifier.name, table.concat(noteParts, ", "))
@@ -917,11 +1037,15 @@ function ActivatedAbility:Render(options, params)
             end
         end
 
+        local hasDamageDisplay = displayTiers ~= nil and table.concat(displayTiers, " "):lower():find("damage") ~= nil
         for _, entry in ipairs(self:try_get("modificationLog", {})) do
-            tokenDependentChildren[#tokenDependentChildren + 1] = gui.Label {
-                text = entry,
-                classes = { "info" },
-            }
+            -- Skip kit damage notes on abilities that have no rolled damage.
+            if not entry:lower():find("damage") or hasDamageDisplay then
+                tokenDependentChildren[#tokenDependentChildren + 1] = gui.Label {
+                    text = entry,
+                    classes = { "info" },
+                }
+            end
         end
 
         local seenRules = {}

--- a/Draw Steel Core Rules/MCDMActivatedAbility.lua
+++ b/Draw Steel Core Rules/MCDMActivatedAbility.lua
@@ -634,10 +634,88 @@ function ActivatedAbility:Render(options, params)
         end
     end
 
+    -- Apply active Modify Power Roll modifiers to a deep copy of the power-table
+    -- tiers for display purposes. Each tier is fully pre-evaluated first
+    -- (damage expressions, potency markers, GoblinScript) so that the regexes
+    -- inside modifyRollProperties can match plain numeric values. Characteristic
+    -- and potency notes plus one note per applicable modifier are appended to the
+    -- optional `notes` table. Resistance rolls and cases with no token are
+    -- returned unmodified.
+    local function applyModsToTiers(ptBehavior, notes)
+        if creatureProperties == nil or ptBehavior:try_get("resistanceRoll", false) then
+            return ptBehavior.tiers
+        end
+        -- Fully evaluate each tier (damage expressions, potency markers, GoblinScript)
+        -- so that modifyRollProperties regexes can match plain numeric values.
+        -- Characteristic and potency notes are collected into the notes table here;
+        -- the caller's subsequent DisplayRuleTextForCreature pass is then a no-op.
+        local normalizedTiers = {}
+        for i, t in ipairs(ptBehavior.tiers) do
+            normalizedTiers[i] = ActivatedAbilityDrawSteelCommandBehavior.DisplayRuleTextForCreature(creatureProperties, t, notes, true)
+        end
+        local rollProperties = RollPropertiesPowerTable.new{
+            tiers = normalizedTiers,
+        }
+        -- A minimal "null target" object: GenerateSymbols returns a non-nil
+        -- function from it, which prevents AppendSymbols from substituting any
+        -- stale target left in _tmp_symbols from a previous real roll.
+        local nullTarget = {lookupSymbols = {}}
+        local function tryApply(modifier, modContext)
+            local hint = modifier:HintModifyPowerRolls(modContext, creatureProperties, "ability_power_roll", {
+                ability = self,
+                caster = creatureProperties,
+                target = nullTarget,
+            })
+            if hint == nil or not hint.result then
+                return
+            end
+            modifier:ModifyRollProperties(modContext, creatureProperties, rollProperties, nil)
+            -- Build a note describing what this modifier does.
+            if notes ~= nil then
+                local noteParts = {}
+                local damageModifier = modifier:try_get("damageModifier", "")
+                if damageModifier ~= "" then
+                    local lookupFn = creatureProperties:LookupSymbol(modifier:AppendSymbols{
+                        triggerer = nil,
+                        target = GenerateSymbols(nullTarget),
+                    })
+                    local dmgVal = safe_toint(dmhub.EvalGoblinScript(damageModifier, lookupFn, "Power Roll Damage display"))
+                    if dmgVal ~= nil and dmgVal ~= 0 then
+                        dmgVal = round(dmgVal)
+                        noteParts[#noteParts+1] = string.format("%s%d damage", dmgVal > 0 and "+" or "", dmgVal)
+                    end
+                end
+                local potencymod = tonumber(modifier:try_get("potencymod", "none"))
+                if potencymod ~= nil and potencymod ~= 0 then
+                    noteParts[#noteParts+1] = string.format("%s%d potency", potencymod > 0 and "+" or "", potencymod)
+                end
+                if #noteParts > 0 then
+                    notes[#notes+1] = string.format("%s: %s", modifier.name, table.concat(noteParts, ", "))
+                end
+            end
+        end
+        -- Modifiers from features, ongoing effects, auras, etc.
+        for _, mod in ipairs(creatureProperties:GetActiveModifiers()) do
+            tryApply(mod.mod, mod)
+        end
+        -- Modifiers embedded directly in this ability's own behaviors.
+        for _, behavior in ipairs(self.behaviors) do
+            if behavior.typeName == "ActivatedAbilityModifyPowerRollBehavior"
+                    and behavior:IsFiltered(self, params.token, params) == false then
+                local filterCond = trim(behavior.modifier:try_get("filterCondition", ""))
+                if filterCond == "" or dmhub.EvalGoblinScript(filterCond, creatureProperties:LookupSymbol(), "Filter condition for power roll display") then
+                    tryApply(behavior.modifier, {mod = behavior.modifier})
+                end
+            end
+        end
+        return rollProperties.tiers
+    end
+
     local powerRollLabel = nil
     local powerRollTable = nil
 
     local rulesNotes = {}
+    local displayTiers = powerTableBehavior ~= nil and applyModsToTiers(powerTableBehavior, rulesNotes) or nil
 
     if powerTableBehavior ~= nil then
         local c = nil
@@ -689,7 +767,7 @@ function ActivatedAbility:Render(options, params)
 
         local rows = {}
 
-        for i, entry in ipairs(powerTableBehavior.tiers) do
+        for i, entry in ipairs(displayTiers) do
             rows[#rows + 1] = gui.TableRow {
                 width = "100%",
                 height = "auto",
@@ -1078,7 +1156,7 @@ function ActivatedAbility:Render(options, params)
 
                     width = "80%",
                     height = "auto",
-                    text = ActivatedAbilityDrawSteelCommandBehavior.DisplayRuleTextForCreature(creatureProperties, powerTableBehavior.tiers[1], {}, self:try_get("implementation", 1) >= gui.ImplementationStatus.Bronze),
+                    text = ActivatedAbilityDrawSteelCommandBehavior.DisplayRuleTextForCreature(creatureProperties, displayTiers[1], {}, self:try_get("implementation", 1) >= gui.ImplementationStatus.Bronze),
                     fontSize = 16,
                     halign = "left",
                     valign = "center",
@@ -1121,7 +1199,7 @@ function ActivatedAbility:Render(options, params)
 
                     width = "80%",
                     height = "auto",
-                    text = ActivatedAbilityDrawSteelCommandBehavior.DisplayRuleTextForCreature(creatureProperties, powerTableBehavior.tiers[2], {}, self:try_get("implementation", 1) >= gui.ImplementationStatus.Bronze),
+                    text = ActivatedAbilityDrawSteelCommandBehavior.DisplayRuleTextForCreature(creatureProperties, displayTiers[2], {}, self:try_get("implementation", 1) >= gui.ImplementationStatus.Bronze),
                     fontSize = 16,
                     halign = "left",
                     valign = "center",
@@ -1161,7 +1239,7 @@ function ActivatedAbility:Render(options, params)
 
                     width = "80%",
                     height = "auto",
-                    text = ActivatedAbilityDrawSteelCommandBehavior.DisplayRuleTextForCreature(creatureProperties, powerTableBehavior.tiers[3], {}, self:try_get("implementation", 1) >= gui.ImplementationStatus.Bronze),
+                    text = ActivatedAbilityDrawSteelCommandBehavior.DisplayRuleTextForCreature(creatureProperties, displayTiers[3], {}, self:try_get("implementation", 1) >= gui.ImplementationStatus.Bronze),
                     fontSize = 16,
                     halign = "left",
                     valign = "center",

--- a/Draw Steel Core Rules/MCDMActivatedAbility.lua
+++ b/Draw Steel Core Rules/MCDMActivatedAbility.lua
@@ -653,6 +653,11 @@ function ActivatedAbility:Render(options, params)
         for i, t in ipairs(ptBehavior.tiers) do
             normalizedTiers[i] = ActivatedAbilityDrawSteelCommandBehavior.DisplayRuleTextForCreature(creatureProperties, t, notes, true)
         end
+        -- Snapshot pre-modifier tier text for diff highlighting later.
+        local originalTiers = {}
+        for i, t in ipairs(normalizedTiers) do
+            originalTiers[i] = t
+        end
         local rollProperties = RollPropertiesPowerTable.new{
             tiers = normalizedTiers,
         }
@@ -832,6 +837,55 @@ function ActivatedAbility:Render(options, params)
                 if filterCond == "" or dmhub.EvalGoblinScript(filterCond, creatureProperties:LookupSymbol(), "Filter condition for power roll display") then
                     tryApply(behavior.modifier, {mod = behavior.modifier})
                 end
+            end
+        end
+        -- Colorize changed portions of each tier using a character-level diff
+        -- with word-boundary snapping.
+        local accentHex = nil
+        local function isAlnum(b)
+            return (b >= 48 and b <= 57) or (b >= 65 and b <= 90) or (b >= 97 and b <= 122)
+        end
+        for i = 1, #normalizedTiers do
+            local orig = originalTiers[i]
+            local modified = normalizedTiers[i]
+            if orig ~= modified then
+                if accentHex == nil then
+                    accentHex = ThemeEngine.ResolveTokens("@accent")
+                end
+                -- Find first differing character, then snap back to the start
+                -- of the current word so tokens are never split mid-character.
+                -- e.g. "1 damage" -> "11 damage": firstDiff=2, but "1" is
+                -- alphanumeric so we snap back to 1, highlighting the full "11".
+                local firstDiff = 1
+                local minLen = math.min(#orig, #modified)
+                while firstDiff <= minLen and orig:byte(firstDiff) == modified:byte(firstDiff) do
+                    firstDiff = firstDiff + 1
+                end
+                while firstDiff > 1 and isAlnum(modified:byte(firstDiff - 1)) do
+                    firstDiff = firstDiff - 1
+                end
+                -- Only trim a common suffix when there is a substantial shared
+                -- prefix (firstDiff >= 4). Without this, strings that diverge
+                -- early (e.g. "Push 1" -> "slide 2; Shift 1") would have their
+                -- trailing coincidental suffix ("1") excluded from the highlight.
+                local modEnd = #modified
+                if firstDiff >= 4 then
+                    local origEnd = #orig
+                    while origEnd >= firstDiff and modEnd >= firstDiff
+                          and orig:byte(origEnd) == modified:byte(modEnd) do
+                        origEnd = origEnd - 1
+                        modEnd = modEnd - 1
+                    end
+                    -- Snap modEnd forward to end of current word.
+                    while modEnd < #modified and isAlnum(modified:byte(modEnd + 1)) do
+                        modEnd = modEnd + 1
+                    end
+                end
+                normalizedTiers[i] = modified:sub(1, firstDiff - 1)
+                    .. string.format("<color=%s>", accentHex)
+                    .. modified:sub(firstDiff, modEnd)
+                    .. "</color>"
+                    .. modified:sub(modEnd + 1)
             end
         end
         return rollProperties.tiers
@@ -1049,7 +1103,7 @@ function ActivatedAbility:Render(options, params)
             if not entry:lower():find("damage") or hasDamageDisplay then
                 tokenDependentChildren[#tokenDependentChildren + 1] = gui.Label {
                     text = entry,
-                    classes = { "info" },
+                    color = ThemeEngine.ResolveTokens("@accent"),
                 }
             end
         end
@@ -1060,7 +1114,7 @@ function ActivatedAbility:Render(options, params)
                 seenRules[entry] = true
                 tokenDependentChildren[#tokenDependentChildren + 1] = gui.Label {
                     text = entry,
-                    classes = { "info" },
+                    color = ThemeEngine.ResolveTokens("@accent"),
                 }
             end
         end
@@ -1271,7 +1325,7 @@ function ActivatedAbility:Render(options, params)
 
                     bgimage = true,
                     bgcolor = "clear",
-                    width = "auto",
+                    width = 65,
                     height = "auto",
                     maxHeight = 22,
                     text = "!",
@@ -1314,7 +1368,7 @@ function ActivatedAbility:Render(options, params)
 
                     bgimage = true,
                     bgcolor = "clear",
-                    width = "auto",
+                    width = 65,
                     height = "auto",
                     maxHeight = 22,
                     text = "@",
@@ -1354,7 +1408,7 @@ function ActivatedAbility:Render(options, params)
 
                     bgimage = true,
                     bgcolor = "clear",
-                    width = "auto",
+                    width = 65,
                     height = "auto",
                     maxHeight = 22,
                     text = "#",


### PR DESCRIPTION
## Summary

When hovering an ability in the action bar, the sidebar now shows notes describing which active Modify Power Roll modifiers apply to that ability and what they do.

## Changes

### `Draw Steel Core Rules/MCDMActivatedAbility.lua`

Added an `applyModsToTiers` helper inside `Render()` that:
- Pre-evaluates power roll tiers via `DisplayRuleTextForCreature` so modifier regexes match plain values
- Applies each passing modifier's `ModifyRollProperties` to update the displayed tier text
- Collects a note per modifier describing its effect

**Notes generated per modifier:**
- Damage bonus: `+2 damage`, `+1 psychic damage`
- Potency bonus: `+1 potency`
- Damage type mapping: `lightning damage becomes fire`, `all damage becomes fire`
- Add to table: `adds: -/"Slowed"/"Dazed"`
- Replace in table: `"Knockback" -> "slide"`
- Adjustments: `+2 push`
- Replace forced movement: `push -> slide`
- Roll modifier: `+1 to roll`, `Edge on roll`

**Filters to prevent false positives:**
- Skip if `activationCondition` references `"target"` (High Ground, Hidden, Flanking etc. cannot be evaluated without a real target)
- Skip if `rollRequirement != "none"` (edge/bane/surge requirements unknown at display time)
- `ShouldShowInPowerRollDialog` is checked first (evaluates `displayCondition`) before `HintModifyPowerRolls` (evaluates `activationCondition`) -- fixes false positives from modifiers whose `activationCondition` is always-true but `displayCondition` gates on e.g. heroic resources

**Other fixes:**
- Kit damage notes (`modificationLog`) are suppressed on abilities with no rolled damage
- Uses a `tiersAllText` snapshot captured before any modifications so pattern searches are not defeated by in-place tier mutations

🤖 Generated with [Claude Code](https://claude.com/claude-code)