### PR TITLE
Ability Editor: auto-expand More Options when filters present + alignment fixes

### DIFF
--- a/DMHub Game Rules/AbilityFloatText.lua
+++ b/DMHub Game Rules/AbilityFloatText.lua
@@ -68,6 +68,7 @@ function ActivatedAbilityFloatTextBehavior:EditorItems(parentPanel)
         gui.ColorPicker{
             width = 16,
             height = 16,
+            halign = "left",
             value = self.color,
             change = function(element)
                 self.color = element.value

--- a/Draw Steel Ability Editor/AbilityEditor.lua
+++ b/Draw Steel Ability Editor/AbilityEditor.lua
@@ -573,13 +573,14 @@ local function _editorStyles()
             valign = "center",
         },
         -- "More options" CollapseArrow row (Targeting section foldout).
-        -- Text + chevron together, centered in column.
+        -- Text + chevron together, left-aligned to sit flush with the
+        -- other section headers / field rows in the column.
         {
             selectors = {"nae-more-options-row"},
             width = "auto",
             height = "auto",
             flow = "horizontal",
-            halign = "center",
+            halign = "left",
             valign = "center",
             tmargin = 12,
             bmargin = 4,
@@ -3678,9 +3679,16 @@ local function _buildTargetingSection(ability, fireChange)
     --------------------------------------------------------------------------
     -- "More options" CollapseArrow
     --------------------------------------------------------------------------
+    -- Default-expanded when the ability already has ability/reasoned filters
+    -- so authors can see active filter state without hunting for it. Plain
+    -- collapsed default otherwise.
+    local hasFilters =
+        #ability:try_get("abilityFilters", {}) > 0 or
+        #ability:try_get("reasonedFilters", {}) > 0
+
     local moreOptionsContent
     moreOptionsContent = gui.Panel{
-        classes = {"nae-field-subgroup", "collapsed-anim"},
+        classes = {"nae-field-subgroup", cond(hasFilters, nil, "collapsed-anim")},
         flow = "vertical",
         width = "100%",
         height = "auto",
@@ -3709,7 +3717,7 @@ local function _buildTargetingSection(ability, fireChange)
 
     local moreOptionsChevron
     moreOptionsChevron = gui.Panel{
-        classes = {"nae-more-options-chevron", "nae-collapsed"},
+        classes = {"nae-more-options-chevron", cond(hasFilters, nil, "nae-collapsed")},
     }
     children[#children + 1] = gui.Panel{
         classes = {"nae-more-options-row"},

--- a/Draw Steel Ability Editor/NewTriggeredAbilityEditor.lua
+++ b/Draw Steel Ability Editor/NewTriggeredAbilityEditor.lua
@@ -93,16 +93,6 @@ local function buildStyles()
         priority = 3,
         halign = "left",
     }
-    -- The shared "More options" row in the Targeting stack (AbilityEditor.lua
-    -- ~line 563) uses halign="center" by default so the New Ability Editor
-    -- shows it as a centered fold-out. Inside the Triggered Ability Editor
-    -- we want it flush-left like every other Setup-section field row, per
-    -- 2026-04-24 design feedback. Scoped priority beats the base halign.
-    styles[#styles + 1] = {
-        selectors = {"nae-more-options-row"},
-        priority = 3,
-        halign = "left",
-    }
     -- Note: the classic TargetTypeEditor's abilityFilterPanel (DMHub Compendium
     -- ActivatedAbilityEditor.lua line ~1825) has no halign and no class hook,
     -- so its "Add Ability Filter" button still renders centered. Same story


### PR DESCRIPTION
## Summary

- **Auto-expand More Options when filters are present.** In the Ability Editor and Triggered Ability Editor, the Targeting "More options" foldout houses Ability Filters and Reasoned Filters. Today it always defaults to collapsed, so authors who set a filter then re-open the ability have no visible cue that one is active. The foldout now opens already expanded whenever `abilityFilters` or `reasonedFilters` has at least one entry; otherwise the existing collapsed default is preserved. Initial-state only -- the chevron still toggles manually and isn't auto-reopened later.
- **Left-align the "More options" header in both editors.** The shared `nae-more-options-row` style was `halign = "center"`, which made the header drift to the column midline while every other section header / field row sits flush left. Flipping the base rule to `halign = "left"` brings both editors into line. Because the Triggered Ability Editor previously layered a priority-3 override to achieve the same effect, that override is now redundant and was removed.
- **Float Text behaviour: left-align the colour picker.** Inside the modifier-style stacked formPanel (`flow = "vertical"`, `width = "100%"`), the 16x16 `gui.ColorPicker` swatch had no `halign`, so it rendered centered under the left-aligned "Color:" label. Pinning the swatch to `halign = "left"` puts it flush under the header, matching every other label/control pair in the surface.

## Test plan

- [ ] Open an existing ability that already has at least one Ability Filter or Reasoned Filter -- the Targeting "More options" foldout opens expanded with the filter visible.
- [ ] Open an ability with no filters -- the foldout stays collapsed; clicking the header still toggles open and shows the empty filter lists + Add buttons.
- [ ] Same checks in the Triggered Ability Editor (it reuses `AbilityEditor.BuildTargetingSection`).
- [ ] Confirm the "More options" header row in both editors now sits flush-left in line with surrounding section headers.
- [ ] Add a Float Text behaviour to any ability and confirm the colour-picker swatch sits directly under the "Color:" label (left-aligned), not centred.

[Claude session transcript](https://claude.com/share)

🤖 Generated with [Claude Code](https://claude.com/claude-code)