### PR TITLE
feat(combat): add Villain Action strip for Leaders and Solos

### DIFF
--- a/DMHub Game Rules/ActivatedAbility.lua
+++ b/DMHub Game Rules/ActivatedAbility.lua
@@ -2787,6 +2787,31 @@ function ActivatedAbility.CastCoroutine(self, casterToken, targets, options)
 
 	print("CastCoroutine::", self.name, "end behaviors")
 
+	-- Villain Action consumption: any ability marked with the `villainAction`
+	-- field that runs to completion (not aborted) marks itself as used for
+	-- the encounter and spends the per-round VA budget. This fires regardless
+	-- of how the cast was invoked (Villain Action strip, action bar menu,
+	-- /act command, AI), so the strip's state stays accurate.
+	--
+	-- Wrapped in pcall so a transient doc-transaction failure or any other
+	-- runtime issue here can't take down the surrounding cast cleanup
+	-- (which is what frees dmhub.blockTokenSelection, pops the caster
+	-- stack, etc.).
+	if not options.abort then
+		local villainAction = self:try_get("villainAction")
+		if villainAction ~= nil and villainAction ~= "" and casterToken ~= nil and casterToken.valid and VillainActionState ~= nil then
+			local ok, err = pcall(function()
+				VillainActionState.MarkUsed(casterToken.charid, villainAction)
+				if CharacterResource.GetVillainActions() > 0 then
+					CharacterResource.SetVillainActions(0, "Villain Action used")
+				end
+			end)
+			if not ok then
+				print("Villain Action consumption hook failed:", tostring(err))
+			end
+		end
+	end
+
     if restoreTargets ~= nil then
         options.symbols.cast.targets = restoreTargets
     end

--- a/Draw Steel Core Rules/DSResources.lua
+++ b/Draw Steel Core Rules/DSResources.lua
@@ -76,6 +76,63 @@ function CharacterResource.SetVillainActions(amount, note)
     CharacterResource.SetGlobalResource(CharacterResource.villainActionId, amount, note)
 end
 
+-- =====================================================================
+-- VillainActionState: per-encounter tracking of which villain actions
+-- have been consumed. Lives in a shared document so all clients see
+-- the same state in real time. Reset on encounter start (hooked from
+-- InitiativeQueue.Create in MCDMInitiativeQueue.lua).
+--
+-- Keys:
+--   tokenid          - the charid of the Leader/Solo that owns the VA
+--   villainActionKey - the ability's `villainAction` field value
+--                      ("Villain Action 1" | "Villain Action 2" | ...)
+-- =====================================================================
+VillainActionState = {}
+VillainActionState.docId = "dsVillainActions"
+
+mod:RegisterDocumentForCheckpointBackups(VillainActionState.docId)
+
+function VillainActionState.GetDocPath()
+    return mod:GetDocumentPath(VillainActionState.docId)
+end
+
+function VillainActionState.HasUsed(tokenid, villainActionKey)
+    if tokenid == nil or villainActionKey == nil then return false end
+    local doc = mod:GetDocumentSnapshot(VillainActionState.docId)
+    local used = doc.data.used
+    if used == nil then return false end
+    local entry = used[tokenid]
+    if entry == nil then return false end
+    return entry[villainActionKey] == true
+end
+
+function VillainActionState.MarkUsed(tokenid, villainActionKey)
+    if tokenid == nil or villainActionKey == nil then return end
+    local doc = mod:GetDocumentSnapshot(VillainActionState.docId)
+    doc:BeginChange()
+    if doc.data.used == nil then doc.data.used = {} end
+    if doc.data.used[tokenid] == nil then doc.data.used[tokenid] = {} end
+    doc.data.used[tokenid][villainActionKey] = true
+    doc:CompleteChange("Villain Action used: " .. villainActionKey)
+end
+
+function VillainActionState.ClearForToken(tokenid)
+    if tokenid == nil then return end
+    local doc = mod:GetDocumentSnapshot(VillainActionState.docId)
+    if doc.data.used == nil or doc.data.used[tokenid] == nil then return end
+    doc:BeginChange()
+    doc.data.used[tokenid] = nil
+    doc:CompleteChange("Villain Action state cleared for token", {undoable = false})
+end
+
+function VillainActionState.ResetAll()
+    local doc = mod:GetDocumentSnapshot(VillainActionState.docId)
+    if doc.data.used == nil then return end
+    doc:BeginChange()
+    doc.data.used = {}
+    doc:CompleteChange("Villain Action state reset (new encounter)", {undoable = false})
+end
+
 function creature:GetHeroTokens()
     return 0
 end

--- a/Draw Steel Core Rules/MCDMInitiativeBar.lua
+++ b/Draw Steel Core Rules/MCDMInitiativeBar.lua
@@ -1059,10 +1059,11 @@ local g_vaStripStyles = {
     },
     -- Header text: VILLAIN ACTIONS (uppercase) and the creature name in
     -- Title Case. Both use @fgStrong so the subheader stays readable; the
-    -- case difference does the visual differentiation work.
+    -- case difference does the visual differentiation work. Compact sizes
+    -- for the right-side band placement.
     {
         selectors = {"vaStripHeader"},
-        fontSize = 16,
+        fontSize = 12,
         bold = true,
         color = "@fgStrong",
         uppercase = true,
@@ -1071,16 +1072,16 @@ local g_vaStripStyles = {
     },
     {
         selectors = {"vaStripSeparator"},
-        fontSize = 16,
+        fontSize = 12,
         bold = true,
         color = "@fgStrong",
         width = "auto",
         height = "auto",
-        hmargin = 8,
+        hmargin = 6,
     },
     {
         selectors = {"vaStripSubHeader"},
-        fontSize = 16,
+        fontSize = 12,
         color = "@fgStrong",
         width = "auto",
         height = "auto",
@@ -1105,11 +1106,11 @@ local g_vaStripStyles = {
     -- "cyclable" class is toggled by refresh).
     {
         selectors = {"vaOwnerPortrait"},
-        width = 48,
-        height = 48,
+        width = 40,
+        height = 40,
         halign = "center",
         valign = "center",
-        hmargin = 8,
+        hmargin = 6,
         bgcolor = "white",
         borderColor = "@border",
         borderWidth = 2,
@@ -1121,24 +1122,23 @@ local g_vaStripStyles = {
         transitionTime = 0.1,
     },
 
-    -- Individual drawer: cloned from Styles.ActionBar's actionBarDrawer rule
-    -- so the rendered chrome (beveled corners, raised feel, border contrast)
-    -- is identical. Height bumped to 48 (vs the action bar's ~41) so the
-    -- two-line title+ability-name layout has breathing room.
+    -- Individual drawer: compact variant for the right-side band placement.
+    -- Cloned from Styles.ActionBar's actionBarDrawer chrome (beveled corners,
+    -- raised feel, border contrast) but shrunk toward the monster-card scale.
     {
         selectors = {"vaDrawer"},
-        width = 205,
-        height = 48,
+        width = 132,
+        height = 40,
         halign = "center",
         valign = "bottom",
         bgimage = true,
         bgcolor = "@bg",
         flow = "vertical",
-        cornerRadius = 10,
+        cornerRadius = 8,
         beveledcorners = true,
         borderColor = "@border",
         borderWidth = 2,
-        hmargin = 4,
+        hmargin = 3,
     },
     {
         selectors = {"vaDrawer", "~available"},
@@ -1155,13 +1155,13 @@ local g_vaStripStyles = {
     -- between the drawer's top border and the numeral.
     {
         selectors = {"vaDrawerTitle"},
-        fontSize = 16,
+        fontSize = 13,
         bold = true,
         color = "@fgStrong",
         width = "100%",
-        height = 18,
+        height = 15,
         textAlignment = "center",
-        tmargin = 4,
+        tmargin = 2,
     },
     {
         selectors = {"vaDrawerTitle", "parent:~available"},
@@ -1170,13 +1170,13 @@ local g_vaStripStyles = {
     -- Ability name immediately under the numeral.
     {
         selectors = {"vaDrawerSummary"},
-        fontSize = 12,
+        fontSize = 10,
         bold = true,
         color = "@fg",
         width = "100%",
-        height = 14,
+        height = 12,
         textAlignment = "center",
-        tmargin = -2,
+        tmargin = -1,
     },
     {
         selectors = {"vaDrawerSummary", "parent:~available"},
@@ -1220,17 +1220,19 @@ local g_vaStripStyles = {
     },
 
     -- Flashing nudge: when it's between turns and the director can fire
-    -- a VA, the available drawers' whole surface pulses to @danger (red).
-    -- The pulse is driven by the "on" class toggled on the strip every
+    -- a VA, the available drawers' whole surface pulses to @accent. The
+    -- pulse is driven by the "on" class toggled on the strip every
     -- thinkTime; scoped via the compound selector so non-flashing drawers
-    -- are unaffected.
+    -- are unaffected. (Tokenised rather than a hardcoded red so it tracks
+    -- the active scheme / the in-progress re-theme. Swap @accent -> @bgAlt
+    -- here for a subtler pulse.)
     {
         selectors = {"vaDrawer", "flashing"},
-        borderColor = "@danger",
+        borderColor = "@accent",
     },
     {
         selectors = {"vaDrawer", "flashing", "on"},
-        bgcolor = "@danger",
+        bgcolor = "@accent",
         transitionTime = 0.7,
         easing = "easeInOutSine",
     },
@@ -1447,11 +1449,18 @@ local function CreateVillainActionStrip(self, info)
     return gui.Panel{
         classes = {"villainActionStrip"},
         styles = { ThemeEngine.GetStyles(), ThemeEngine.MergeTokens(g_vaStripStyles) },
+        -- Floating + right-aligned within the choicePanel's 1140-wide space
+        -- so the strip sits in the monster-side band, dropped just below the
+        -- monster cards (which occupy the top ~80px). Floating so it never
+        -- reflows the bar / round tracker. x/y are tuning offsets.
+        floating = true,
         flow = "vertical",
         width = "auto",
         height = "auto",
-        halign = "center",
+        halign = "right",
         valign = "top",
+        x = 0,
+        y = 100,
 
         -- Label row: "VILLAIN ACTIONS - Demon Chorogaunt" or with "(1/2)" suffix when multi.
         gui.Panel{
@@ -1815,16 +1824,17 @@ function GameHud.CreateInitiativeBar(self, info)
 	local addMonsters
 
 	--The parent / top-level initiative bar.
-	-- Strip out the floating + selfStyle from the inner panel; the wrapper
-	-- below owns positioning so the VA strip can stack above it in vertical flow.
-	-- halign='center' kept on the inner so it stays horizontally centred inside
-	-- the wrapper (the wrapper itself is auto-width, hugging widest child).
-	local innerInitiativeBar = gui.Panel({
+	return gui.Panel({
+		floating = true,
+		selfStyle = {
+			valign = 'top',
+			halign = 'center',
+		},
+
 		className = 'initiative-panel',
         height = 200,
         width = 500,
         tmargin = 0,
-        halign = 'center',
 
 		styles = {
 			{
@@ -2096,25 +2106,6 @@ function GameHud.CreateInitiativeBar(self, info)
 			respiteBar,
 		},
 	})
-
-	-- Wrapper: stacks the VillainActionStrip above the initiative bar so the
-	-- bar gets pushed down when a Leader/Solo with villain actions is in
-	-- the encounter, and returns to its original spot otherwise.
-	return gui.Panel{
-		floating = true,
-		selfStyle = {
-			valign = 'top',
-			halign = 'center',
-		},
-		width = "auto",
-		height = "auto",
-		flow = "vertical",
-		halign = "center",
-		valign = "top",
-
-		CreateVillainActionStrip(self, info),
-		innerInitiativeBar,
-	}
 end
 
 function GameHud.CreateInitiativeBarChoicePanel(self, info)
@@ -2574,6 +2565,12 @@ function GameHud.CreateInitiativeBarChoicePanel(self, info)
         drawSteelBubble,
 		monsterContainer,
 		centerContainer,
+
+		-- Villain Action strip: mounted in the choicePanel's 1140-wide
+		-- coordinate space so it right-aligns into the monster-side band,
+		-- below the monster cards. Floating so it never reflows the bar /
+		-- round tracker.
+		CreateVillainActionStrip(self, info),
 
 		refresh = function(element)
 

--- a/Draw Steel Core Rules/MCDMInitiativeBar.lua
+++ b/Draw Steel Core Rules/MCDMInitiativeBar.lua
@@ -1189,6 +1189,28 @@ local g_vaStripStyles = {
         borderColor = "@accent",
         bgcolor = "clear",
     },
+
+    -- Flashing nudge: when it's between turns and the director can fire
+    -- a VA, the available drawers' whole surface pulses to @danger (red).
+    -- The pulse is driven by the "on" class toggled on the strip every
+    -- thinkTime; scoped via the compound selector so non-flashing drawers
+    -- are unaffected.
+    {
+        selectors = {"vaDrawer", "flashing"},
+        borderColor = "@danger",
+    },
+    {
+        selectors = {"vaDrawer", "flashing", "on"},
+        bgcolor = "@danger",
+        transitionTime = 0.7,
+        easing = "easeInOutSine",
+    },
+    {
+        selectors = {"vaDrawer", "flashing", "~on"},
+        bgcolor = "@bg",
+        transitionTime = 0.7,
+        easing = "easeInOutSine",
+    },
 }
 
 local function CreateVillainActionDrawer(slotKey, slotNumeral)
@@ -1283,17 +1305,23 @@ local function CreateVillainActionDrawer(slotKey, slotNumeral)
         hover = function(element)
             if m_token == nil or m_ability == nil or not m_token.valid then return end
 
-            local text
             if VillainActionState.HasUsed(m_token.charid, slotKey) then
-                text = (m_ability.name or "This Villain Action") .. " has already been used this encounter."
+                gui.Tooltip{
+                    text = (m_ability.name or "This Villain Action") .. " has already been used this encounter.",
+                }(element)
             elseif CharacterResource.GetVillainActions() <= 0 then
-                text = "You have already used a Villain Action this round."
+                gui.Tooltip{
+                    text = "You have already used a Villain Action this round.",
+                }(element)
             else
-                -- Chunk 5 will replace this with a full ability preview card.
-                text = m_ability.name or ""
+                -- Full ability preview card for available drawers.
+                local tooltip = CreateAbilityTooltip(m_ability, {token = m_token, width = 480})
+                if tooltip ~= nil then
+                    element.tooltip = tooltip
+                else
+                    gui.Tooltip{text = m_ability.name or ""}(element)
+                end
             end
-
-            gui.Tooltip{text = text}(element)
         end,
 
         click = function(element)
@@ -1380,6 +1408,21 @@ local function CreateVillainActionStrip(self, info)
             element:FireEvent("refresh")
         end,
 
+        -- Track the last active turn-holder so we can suppress the
+        -- "end-of-turn" flash when the just-finished turn was the VA
+        -- owner's own (rules: VAs fire at the end of any *other*
+        -- creature's turn). lastActiveTurnRound records WHICH round that
+        -- capture happened in, so we can suppress flash across the round
+        -- boundary too -- a new round resets the "just-ended-turn"
+        -- relevance. previousCurrentTurn / previousRound let think detect
+        -- transitions and trigger refresh accordingly.
+        data = {
+            lastActiveTurn = nil,
+            lastActiveTurnRound = nil,
+            previousCurrentTurn = nil,
+            previousRound = nil,
+        },
+
         refresh = function(element)
             if not dmhub.isDM then
                 element:SetClass("collapsed", true)
@@ -1401,9 +1444,67 @@ local function CreateVillainActionStrip(self, info)
             element:SetClass("collapsed", false)
             subHeaderLabel.text = owner.name or ""
 
+            -- Flash gating. Pulse only when ALL of:
+            --   - it's between turns (currentTurn == false)
+            --   - the per-round VA budget is unspent
+            --   - a turn actually ended IN THE CURRENT ROUND (not a
+            --     leftover from a previous round, e.g. just after NextRound)
+            --   - the just-finished turn wasn't the VA owner's own
+            --
+            -- currentTurn is an initiative ID, NOT a charid. We compare
+            -- against owner's initiative ID via InitiativeQueue.GetInitiativeId.
+            local q = dmhub.initiativeQueue
+            local currentTurn = q and q.currentTurn
+            local currentRound = q and q.round
+            local betweenTurns = (currentTurn == false)
+            local justFinished = element.data.lastActiveTurn
+            if currentTurn ~= false and currentTurn ~= nil then
+                element.data.lastActiveTurn = currentTurn
+                element.data.lastActiveTurnRound = currentRound
+            end
+            local ownerInitiativeId = InitiativeQueue.GetInitiativeId(owner)
+            local selfTurnJustEnded = (justFinished ~= nil and ownerInitiativeId ~= nil and justFinished == ownerInitiativeId)
+            local turnEndedThisRound = (justFinished ~= nil and element.data.lastActiveTurnRound == currentRound)
+            local budgetAvailable = CharacterResource.GetVillainActions() > 0
+            local stripCanFlash = betweenTurns and budgetAvailable and turnEndedThisRound and (not selfTurnJustEnded)
+
+            -- Per-drawer flash: drawer must also be available (not consumed
+            -- this encounter and the ability slot is actually filled).
+            local function drawerShouldFlash(slot)
+                local ab = vaMap[slot]
+                if ab == nil then return false end
+                if VillainActionState.HasUsed(owner.charid, slot) then return false end
+                return stripCanFlash
+            end
+
+            drawer1:SetClass("flashing", drawerShouldFlash("Villain Action 1"))
+            drawer2:SetClass("flashing", drawerShouldFlash("Villain Action 2"))
+            drawer3:SetClass("flashing", drawerShouldFlash("Villain Action 3"))
+
             drawer1:FireEvent("refreshVA", owner, vaMap["Villain Action 1"])
             drawer2:FireEvent("refreshVA", owner, vaMap["Villain Action 2"])
             drawer3:FireEvent("refreshVA", owner, vaMap["Villain Action 3"])
+        end,
+
+        -- Pulse driver + currentTurn change detector. Every 0.7s:
+        --   1. Toggle the "on" class on the subtree for the brightness pulse
+        --      (only flashing drawers react via the compound selector).
+        --   2. Read currentTurn off the live queue; if it changed since the
+        --      last tick, fire refresh so flash gating + self-suppression
+        --      stay accurate. The shared-doc monitor alone doesn't fire on
+        --      initiative changes, so this poll fills the gap.
+        thinkTime = 0.7,
+        think = function(element)
+            element:SetClassTree("on", not element:HasClass("on"))
+
+            local q = dmhub.initiativeQueue
+            local currentTurn = q and q.currentTurn
+            local currentRound = q and q.round
+            if currentTurn ~= element.data.previousCurrentTurn or currentRound ~= element.data.previousRound then
+                element.data.previousCurrentTurn = currentTurn
+                element.data.previousRound = currentRound
+                element:FireEvent("refresh")
+            end
         end,
 
         create = function(element)

--- a/Draw Steel Core Rules/MCDMInitiativeBar.lua
+++ b/Draw Steel Core Rules/MCDMInitiativeBar.lua
@@ -987,6 +987,383 @@ local function AddInitiativeEntryPanel (element, info, playerControlled)
 	)
 end
 
+-- =====================================================================
+-- Villain Action strip
+-- A director-only horizontal panel that sits above the initiative bar
+-- when an encounter contains a Leader or Solo monster with abilities
+-- whose `villainAction` field is set. Three drawer buttons, one per
+-- VA slot (I / II / III). Buttons grey out when consumed this encounter
+-- (chunk 5 will add per-round budget gating + flash + tooltips).
+-- Click handlers are stubbed in this chunk; chunk 4 wires pan + banner
+-- + off-turn cast.
+-- =====================================================================
+
+-- Return { ["Villain Action 1"] = ability, ... } for a token, or nil.
+local function GetVillainActionAbilities(token)
+    if token == nil or token.properties == nil then return nil end
+    local abilities = token.properties:GetActivatedAbilities()
+    if abilities == nil then return nil end
+    local result
+    for _, ab in ipairs(abilities) do
+        local key = ab:try_get("villainAction")
+        if key ~= nil and key ~= "" then
+            result = result or {}
+            result[key] = ab
+        end
+    end
+    return result
+end
+
+-- Find the first token in the active encounter that owns a villainAction
+-- ability. Multi-creature handling is chunk 6.
+local function FindVillainActionOwnerInEncounter()
+    local q = dmhub.initiativeQueue
+    if q == nil or q.hidden then return nil end
+    if GameHud.instance == nil or GameHud.instance.initiativeInterface == nil then return nil end
+    for initiativeid, _ in pairs(q.entries) do
+        local tokens = GameHud.instance:GetTokensForInitiativeId(GameHud.instance.initiativeInterface, initiativeid)
+        for _, tok in ipairs(tokens or {}) do
+            if GetVillainActionAbilities(tok) ~= nil then
+                return tok
+            end
+        end
+    end
+    return nil
+end
+
+-- Hand-rolled strip + drawers. Visual cues borrow the actionBarDrawer
+-- aesthetic (uppercase title, beveled corners, @border / @disabled
+-- transition for consumed state).
+local g_vaStripStyles = {
+    -- Strip is a transparent layout container; no chrome on the wrapper
+    -- itself. Header label sits above, drawer row sits below.
+    {
+        selectors = {"villainActionStrip"},
+        bgcolor = "clear",
+        vmargin = 4,
+    },
+
+    -- Label row above the drawers. Plain text labels, no panel chrome.
+    {
+        selectors = {"vaStripLabelRow"},
+        flow = "horizontal",
+        width = "auto",
+        height = "auto",
+        halign = "center",
+        valign = "top",
+        bmargin = 4,
+    },
+    -- Header text: VILLAIN ACTIONS (uppercase) and the creature name in
+    -- Title Case. Both use @fgStrong so the subheader stays readable; the
+    -- case difference does the visual differentiation work.
+    {
+        selectors = {"vaStripHeader"},
+        fontSize = 16,
+        bold = true,
+        color = "@fgStrong",
+        uppercase = true,
+        width = "auto",
+        height = "auto",
+    },
+    {
+        selectors = {"vaStripSeparator"},
+        fontSize = 16,
+        bold = true,
+        color = "@fgStrong",
+        width = "auto",
+        height = "auto",
+        hmargin = 8,
+    },
+    {
+        selectors = {"vaStripSubHeader"},
+        fontSize = 16,
+        color = "@fgStrong",
+        width = "auto",
+        height = "auto",
+    },
+
+    -- Drawer row container - horizontal flow, hugs content.
+    {
+        selectors = {"vaDrawerRow"},
+        flow = "horizontal",
+        width = "auto",
+        height = "auto",
+        halign = "center",
+        valign = "top",
+    },
+
+    -- Individual drawer: cloned from Styles.ActionBar's actionBarDrawer rule
+    -- so the rendered chrome (beveled corners, raised feel, border contrast)
+    -- is identical. Height bumped to 48 (vs the action bar's ~41) so the
+    -- two-line title+ability-name layout has breathing room.
+    {
+        selectors = {"vaDrawer"},
+        width = 205,
+        height = 48,
+        halign = "center",
+        valign = "bottom",
+        bgimage = true,
+        bgcolor = "@bg",
+        flow = "vertical",
+        cornerRadius = 10,
+        beveledcorners = true,
+        borderColor = "@border",
+        borderWidth = 2,
+        hmargin = 4,
+    },
+    {
+        selectors = {"vaDrawer", "~available"},
+        borderColor = "@disabled",
+        transitionTime = 0.2,
+    },
+    {
+        selectors = {"vaDrawer", "available", "hover"},
+        brightness = 1.5,
+        transitionTime = 0.1,
+    },
+    -- Roman numeral. Stacked tight with the ability name to keep the
+    -- accent line below clear of the text. tmargin adds breathing room
+    -- between the drawer's top border and the numeral.
+    {
+        selectors = {"vaDrawerTitle"},
+        fontSize = 16,
+        bold = true,
+        color = "@fgStrong",
+        width = "100%",
+        height = 18,
+        textAlignment = "center",
+        tmargin = 4,
+    },
+    {
+        selectors = {"vaDrawerTitle", "parent:~available"},
+        color = "@fgMuted",
+    },
+    -- Ability name immediately under the numeral.
+    {
+        selectors = {"vaDrawerSummary"},
+        fontSize = 12,
+        bold = true,
+        color = "@fg",
+        width = "100%",
+        height = 14,
+        textAlignment = "center",
+        tmargin = -2,
+    },
+    {
+        selectors = {"vaDrawerSummary", "parent:~available"},
+        color = "@fgMuted",
+    },
+
+    -- Filled diamond at the top of the drawer + horizontal accent lines on
+    -- either side that dip around the diamond outline. This is the visual
+    -- that gives the action bar drawer its "raised" look (a bright accent
+    -- line along the top inner edge plus the bevel cut around the diamond).
+    -- All hide when the drawer is ~available.
+    {
+        selectors = {"vaDrawerDiamond"},
+        bgcolor = "@accent",
+        bgimage = true,
+        width = 12,
+        height = 12,
+    },
+    {
+        selectors = {"vaDrawer", "~available"},
+        borderColor = "@disabled",
+    },
+    {
+        selectors = {"vaDrawerDiamond", "~available"},
+        scale = 0,
+        transitionTime = 0.2,
+    },
+    {
+        selectors = {"vaDrawerDiamondAccent", "~available"},
+        scale = { x = 1, y = 0 },
+        transitionTime = 0.2,
+    },
+    {
+        selectors = {"vaDrawerDiamondAccentLine"},
+        bgcolor = "@accent",
+    },
+    {
+        selectors = {"vaDrawerDiamondAccentDot"},
+        borderColor = "@accent",
+        bgcolor = "clear",
+    },
+}
+
+local function CreateVillainActionDrawer(slotKey, slotNumeral)
+    local m_token = nil
+    local m_ability = nil
+
+    local summaryLabel = gui.Label{
+        classes = {"vaDrawerSummary"},
+        text = "",
+    }
+
+    return gui.Panel{
+        classes = {"vaDrawer", "available"},
+
+        -- Floating diamond at the BOTTOM edge - pokes down into open space
+        -- under the strip. Visible when available, hidden when used.
+        gui.Panel{
+            classes = {"vaDrawerDiamond"},
+            floating = true,
+            halign = "center",
+            valign = "bottom",
+            bmargin = -6,
+            rotate = 45,
+        },
+
+        -- Accent strip along the bottom inner edge with a diamond-outline
+        -- notch tracing the upper edge of the floating diamond. Mirrors the
+        -- action bar's top-edge raised treatment, flipped to the bottom.
+        gui.Panel{
+            classes = {"vaDrawerDiamondAccent"},
+            width = "100%-20",
+            height = 6,
+            floating = true,
+            bmargin = 5,
+            halign = "center",
+            valign = "bottom",
+
+            gui.Panel{
+                classes = {"vaDrawerDiamondAccentLine"},
+                width = "50%-6",
+                halign = "left",
+                valign = "bottom",
+                height = 1,
+                bgimage = true,
+            },
+            gui.Panel{
+                classes = {"vaDrawerDiamondAccentLine"},
+                width = "50%-6",
+                halign = "right",
+                valign = "bottom",
+                height = 1,
+                bgimage = true,
+            },
+            -- Border on the bottom + right edges. When the square is
+            -- rotated 45 degrees those edges become the two diagonals
+            -- forming a v shape (chevron pointing down), tracing the
+            -- upper edge of the diamond from above.
+            gui.Panel{
+                classes = {"vaDrawerDiamondAccentDot"},
+                halign = "center",
+                valign = "bottom",
+                y = 5,
+                width = 10,
+                height = 10,
+                rotate = 45,
+                border = { x1 = 0, y1 = 0, x2 = 1, y2 = 1 },
+                bgimage = true,
+            },
+        },
+
+        gui.Label{
+            classes = {"vaDrawerTitle"},
+            text = slotNumeral,
+        },
+        summaryLabel,
+
+        refreshVA = function(element, token, ability)
+            m_token = token
+            m_ability = ability
+            local hasAbility = ability ~= nil
+            element:SetClass("collapsed", not hasAbility)
+            if not hasAbility then return end
+
+            summaryLabel.text = ability.name or ""
+
+            local consumed = VillainActionState.HasUsed(token.charid, slotKey)
+            -- SetClassTree propagates the available/~available state to the
+            -- diamond child so its `~available` style rule fires.
+            element:SetClassTree("available", not consumed)
+        end,
+
+        click = function(element)
+            -- Chunk 4 will replace this with: pan + banner + off-turn cast.
+            print("Villain Action stub press:",
+                slotKey,
+                m_token and m_token.name or "?",
+                m_ability and m_ability.name or "?")
+        end,
+    }
+end
+
+local function CreateVillainActionStrip(self, info)
+    local drawer1 = CreateVillainActionDrawer("Villain Action 1", "I")
+    local drawer2 = CreateVillainActionDrawer("Villain Action 2", "II")
+    local drawer3 = CreateVillainActionDrawer("Villain Action 3", "III")
+
+    local headerLabel = gui.Label{
+        classes = {"vaStripHeader"},
+        text = "VILLAIN ACTIONS",
+    }
+    local subHeaderLabel = gui.Label{
+        classes = {"vaStripSubHeader"},
+        text = "",
+    }
+
+    return gui.Panel{
+        classes = {"villainActionStrip"},
+        styles = { ThemeEngine.GetStyles(), ThemeEngine.MergeTokens(g_vaStripStyles) },
+        flow = "vertical",
+        width = "auto",
+        height = "auto",
+        halign = "center",
+        valign = "top",
+
+        -- Label row: "VILLAIN ACTIONS . Demon Chorogaunt" as plain text.
+        gui.Panel{
+            classes = {"vaStripLabelRow"},
+            headerLabel,
+            gui.Label{ classes = {"vaStripSeparator"}, text = "-" },
+            subHeaderLabel,
+        },
+
+        -- Drawer row: 3 floating drawers side-by-side.
+        gui.Panel{
+            classes = {"vaDrawerRow"},
+            drawer1, drawer2, drawer3,
+        },
+
+        monitorGame = VillainActionState.GetDocPath(),
+        refreshGame = function(element)
+            element:FireEvent("refresh")
+        end,
+
+        refresh = function(element)
+            if not dmhub.isDM then
+                element:SetClass("collapsed", true)
+                return
+            end
+
+            local owner = FindVillainActionOwnerInEncounter()
+            if owner == nil then
+                element:SetClass("collapsed", true)
+                return
+            end
+
+            local vaMap = GetVillainActionAbilities(owner)
+            if vaMap == nil then
+                element:SetClass("collapsed", true)
+                return
+            end
+
+            element:SetClass("collapsed", false)
+            subHeaderLabel.text = owner.name or ""
+
+            drawer1:FireEvent("refreshVA", owner, vaMap["Villain Action 1"])
+            drawer2:FireEvent("refreshVA", owner, vaMap["Villain Action 2"])
+            drawer3:FireEvent("refreshVA", owner, vaMap["Villain Action 3"])
+        end,
+
+        create = function(element)
+            element:FireEvent("refresh")
+        end,
+    }
+end
+
 --Create the initiative bar.
 --   self: the GameHud object
 --   info: the dmhub info object which gives us access to important game information. Some parameters we use here:
@@ -1211,17 +1588,16 @@ function GameHud.CreateInitiativeBar(self, info)
 	local addMonsters
 
 	--The parent / top-level initiative bar.
-	return gui.Panel({
-		floating = true,
-		selfStyle = {
-			valign = 'top',
-			halign = 'center',
-		},
-
+	-- Strip out the floating + selfStyle from the inner panel; the wrapper
+	-- below owns positioning so the VA strip can stack above it in vertical flow.
+	-- halign='center' kept on the inner so it stays horizontally centred inside
+	-- the wrapper (the wrapper itself is auto-width, hugging widest child).
+	local innerInitiativeBar = gui.Panel({
 		className = 'initiative-panel',
         height = 200,
         width = 500,
         tmargin = 0,
+        halign = 'center',
 
 		styles = {
 			{
@@ -1493,6 +1869,25 @@ function GameHud.CreateInitiativeBar(self, info)
 			respiteBar,
 		},
 	})
+
+	-- Wrapper: stacks the VillainActionStrip above the initiative bar so the
+	-- bar gets pushed down when a Leader/Solo with villain actions is in
+	-- the encounter, and returns to its original spot otherwise.
+	return gui.Panel{
+		floating = true,
+		selfStyle = {
+			valign = 'top',
+			halign = 'center',
+		},
+		width = "auto",
+		height = "auto",
+		flow = "vertical",
+		halign = "center",
+		valign = "top",
+
+		CreateVillainActionStrip(self, info),
+		innerInitiativeBar,
+	}
 end
 
 function GameHud.CreateInitiativeBarChoicePanel(self, info)

--- a/Draw Steel Core Rules/MCDMInitiativeBar.lua
+++ b/Draw Steel Core Rules/MCDMInitiativeBar.lua
@@ -989,13 +989,16 @@ end
 
 -- =====================================================================
 -- Villain Action strip
--- A director-only horizontal panel that sits above the initiative bar
--- when an encounter contains a Leader or Solo monster with abilities
--- whose `villainAction` field is set. Three drawer buttons, one per
--- VA slot (I / II / III). Buttons grey out when consumed this encounter
--- (chunk 5 will add per-round budget gating + flash + tooltips).
--- Click handlers are stubbed in this chunk; chunk 4 wires pan + banner
--- + off-turn cast.
+-- A director-only panel that floats in the monster-side band of the
+-- initiative bar when the active encounter contains a Leader or Solo
+-- (or any monster) with abilities whose `villainAction` field is set.
+-- Three drawer buttons, one per VA slot (I / II / III), each showing
+-- the ability name. Drawers grey out when consumed this encounter and
+-- the whole strip is gated by the per-round VA budget. Available drawers
+-- pulse between turns to nudge the director; clicking one pans the camera
+-- to the owner, plays a Dramatic Banner, then casts the ability off-turn.
+-- When more than one VA owner is present the portrait acts as a selector
+-- to cycle between them.
 -- =====================================================================
 
 -- Return { ["Villain Action 1"] = ability, ... } for a token, or nil.
@@ -1411,9 +1414,6 @@ local function CreateVillainActionStrip(self, info)
         text = "",
     }
 
-    -- Owners list refreshed every refresh tick; portrait click reads it.
-    local m_owners = {}
-
     local portraitPanel = gui.Panel{
         classes = {"vaOwnerPortrait"},
         refreshPortrait = function(element, token, isMulti)
@@ -1434,14 +1434,16 @@ local function CreateVillainActionStrip(self, info)
             element:SetClass("cyclable", isMulti)
         end,
         click = function(element)
-            if #m_owners <= 1 then return end
             local strip = element:FindParentWithClass("villainActionStrip")
             if strip == nil then return end
-            strip.data.activeOwnerIndex = (strip.data.activeOwnerIndex % #m_owners) + 1
+            local count = strip.data.ownerCount or 0
+            if count <= 1 then return end
+            strip.data.activeOwnerIndex = (strip.data.activeOwnerIndex % count) + 1
             strip:FireEvent("refresh")
         end,
         hover = function(element)
-            if #m_owners <= 1 then return end
+            local strip = element:FindParentWithClass("villainActionStrip")
+            if strip == nil or (strip.data.ownerCount or 0) <= 1 then return end
             gui.Tooltip{text = "Click to change Villain"}(element)
         end,
     }
@@ -1459,7 +1461,6 @@ local function CreateVillainActionStrip(self, info)
         height = "auto",
         halign = "right",
         valign = "top",
-        x = 0,
         y = 100,
 
         -- Label row: "VILLAIN ACTIONS - Demon Chorogaunt" or with "(1/2)" suffix when multi.
@@ -1483,16 +1484,21 @@ local function CreateVillainActionStrip(self, info)
         end,
 
         -- activeOwnerIndex selects which VA owner the strip currently shows
-        -- when 2+ Leader/Solo with VAs are in the encounter. Click on the
-        -- portrait cycles. lastActiveTurn / lastActiveTurnRound /
-        -- previousCurrentTurn / previousRound power the flash gating; see
-        -- the refresh and think handlers below for the state-machine.
+        -- when 2+ Leader/Solo with VAs are in the encounter (ownerCount is
+        -- the size of that list, read by the portrait selector handlers).
+        -- lastActiveTurn / lastActiveTurnRound / previousCurrentTurn /
+        -- previousRound power the flash gating; anyFlashing lets think skip
+        -- the pulse work when nothing is flashing. See the refresh and think
+        -- handlers below for the state-machine.
         data = {
             activeOwnerIndex = 1,
+            ownerCount = 0,
+            anyFlashing = false,
             lastActiveTurn = nil,
             lastActiveTurnRound = nil,
             previousCurrentTurn = nil,
             previousRound = nil,
+            themeListener = nil,
         },
 
         refresh = function(element)
@@ -1501,20 +1507,23 @@ local function CreateVillainActionStrip(self, info)
                 return
             end
 
-            m_owners = FindAllVillainActionOwnersInEncounter()
-            if #m_owners == 0 then
+            local owners = FindAllVillainActionOwnersInEncounter()
+            element.data.ownerCount = #owners
+            if #owners == 0 then
+                element.data.anyFlashing = false
                 element:SetClass("collapsed", true)
                 return
             end
 
             -- Clamp activeOwnerIndex (creatures may have left the encounter).
-            if element.data.activeOwnerIndex < 1 or element.data.activeOwnerIndex > #m_owners then
+            if element.data.activeOwnerIndex < 1 or element.data.activeOwnerIndex > #owners then
                 element.data.activeOwnerIndex = 1
             end
 
-            local owner = m_owners[element.data.activeOwnerIndex]
+            local owner = owners[element.data.activeOwnerIndex]
             local vaMap = GetVillainActionAbilities(owner)
             if vaMap == nil then
+                element.data.anyFlashing = false
                 element:SetClass("collapsed", true)
                 return
             end
@@ -1523,13 +1532,13 @@ local function CreateVillainActionStrip(self, info)
 
             -- Header text: append "(i/N)" when multiple VA owners exist so
             -- the cycle affordance is discoverable.
-            if #m_owners > 1 then
-                subHeaderLabel.text = string.format("%s (%d/%d)", owner.name or "", element.data.activeOwnerIndex, #m_owners)
+            if #owners > 1 then
+                subHeaderLabel.text = string.format("%s (%d/%d)", owner.name or "", element.data.activeOwnerIndex, #owners)
             else
                 subHeaderLabel.text = owner.name or ""
             end
 
-            portraitPanel:FireEvent("refreshPortrait", owner, #m_owners > 1)
+            portraitPanel:FireEvent("refreshPortrait", owner, #owners > 1)
 
             -- Flash gating. Pulse only when ALL of:
             --   - it's between turns (currentTurn == false)
@@ -1564,9 +1573,14 @@ local function CreateVillainActionStrip(self, info)
                 return stripCanFlash
             end
 
-            drawer1:SetClass("flashing", drawerShouldFlash("Villain Action 1"))
-            drawer2:SetClass("flashing", drawerShouldFlash("Villain Action 2"))
-            drawer3:SetClass("flashing", drawerShouldFlash("Villain Action 3"))
+            local flash1 = drawerShouldFlash("Villain Action 1")
+            local flash2 = drawerShouldFlash("Villain Action 2")
+            local flash3 = drawerShouldFlash("Villain Action 3")
+            element.data.anyFlashing = flash1 or flash2 or flash3
+
+            drawer1:SetClass("flashing", flash1)
+            drawer2:SetClass("flashing", flash2)
+            drawer3:SetClass("flashing", flash3)
 
             drawer1:FireEvent("refreshVA", owner, vaMap["Villain Action 1"])
             drawer2:FireEvent("refreshVA", owner, vaMap["Villain Action 2"])
@@ -1574,15 +1588,17 @@ local function CreateVillainActionStrip(self, info)
         end,
 
         -- Pulse driver + currentTurn change detector. Every 0.7s:
-        --   1. Toggle the "on" class on the subtree for the brightness pulse
-        --      (only flashing drawers react via the compound selector).
-        --   2. Read currentTurn off the live queue; if it changed since the
+        --   1. Read currentTurn off the live queue; if it changed since the
         --      last tick, fire refresh so flash gating + self-suppression
         --      stay accurate. The shared-doc monitor alone doesn't fire on
         --      initiative changes, so this poll fills the gap.
+        --   2. Toggle the "on" class on the subtree for the brightness pulse,
+        --      but only when something is actually flashing (otherwise the
+        --      subtree walk is wasted work).
+        -- Players never have the strip, so bail immediately for them.
         thinkTime = 0.7,
         think = function(element)
-            element:SetClassTree("on", not element:HasClass("on"))
+            if not dmhub.isDM then return end
 
             local q = dmhub.initiativeQueue
             local currentTurn = q and q.currentTurn
@@ -1592,10 +1608,29 @@ local function CreateVillainActionStrip(self, info)
                 element.data.previousRound = currentRound
                 element:FireEvent("refresh")
             end
+
+            if element.data.anyFlashing then
+                element:SetClassTree("on", not element:HasClass("on"))
+            end
         end,
 
         create = function(element)
+            -- Re-resolve themed styles when the user switches theme / scheme
+            -- (MergeTokens captures a one-shot snapshot). Mirrors the action
+            -- bar's live re-theming hookup.
+            element.data.themeListener = ThemeEngine.OnThemeChanged(mod, function()
+                if element.valid then
+                    element.styles = { ThemeEngine.GetStyles(), ThemeEngine.MergeTokens(g_vaStripStyles) }
+                end
+            end)
             element:FireEvent("refresh")
+        end,
+
+        destroy = function(element)
+            if element.data.themeListener ~= nil then
+                element.data.themeListener:Deregister()
+                element.data.themeListener = nil
+            end
         end,
     }
 end

--- a/Draw Steel Core Rules/MCDMInitiativeBar.lua
+++ b/Draw Steel Core Rules/MCDMInitiativeBar.lua
@@ -1014,21 +1014,25 @@ local function GetVillainActionAbilities(token)
     return result
 end
 
--- Find the first token in the active encounter that owns a villainAction
--- ability. Multi-creature handling is chunk 6.
-local function FindVillainActionOwnerInEncounter()
+-- Returns all tokens in the active encounter that own villainAction
+-- abilities. Deduped by charid and sorted by name for stable display.
+local function FindAllVillainActionOwnersInEncounter()
     local q = dmhub.initiativeQueue
-    if q == nil or q.hidden then return nil end
-    if GameHud.instance == nil or GameHud.instance.initiativeInterface == nil then return nil end
+    if q == nil or q.hidden then return {} end
+    if GameHud.instance == nil or GameHud.instance.initiativeInterface == nil then return {} end
+    local result = {}
+    local seen = {}
     for initiativeid, _ in pairs(q.entries) do
         local tokens = GameHud.instance:GetTokensForInitiativeId(GameHud.instance.initiativeInterface, initiativeid)
         for _, tok in ipairs(tokens or {}) do
-            if GetVillainActionAbilities(tok) ~= nil then
-                return tok
+            if tok.valid and not seen[tok.charid] and GetVillainActionAbilities(tok) ~= nil then
+                seen[tok.charid] = true
+                result[#result+1] = tok
             end
         end
     end
-    return nil
+    table.sort(result, function(a, b) return (a.name or "") < (b.name or "") end)
+    return result
 end
 
 -- Hand-rolled strip + drawers. Visual cues borrow the actionBarDrawer
@@ -1090,6 +1094,31 @@ local g_vaStripStyles = {
         height = "auto",
         halign = "center",
         valign = "top",
+    },
+
+    -- Owner portrait. Aligned left of the drawer row at the same height
+    -- as a drawer so the strip reads as one row. bgcolor=white is
+    -- image-tint-neutral so the creature portrait paints at its native
+    -- colours. Border is straight-edged (no corner radius / bevel) so the
+    -- portrait reads as a distinct creature card, not another drawer.
+    -- Clickable when multiple VA owners are in the encounter (the
+    -- "cyclable" class is toggled by refresh).
+    {
+        selectors = {"vaOwnerPortrait"},
+        width = 48,
+        height = 48,
+        halign = "center",
+        valign = "center",
+        hmargin = 8,
+        bgcolor = "white",
+        borderColor = "@border",
+        borderWidth = 2,
+        cornerRadius = 0,
+    },
+    {
+        selectors = {"vaOwnerPortrait", "cyclable", "hover"},
+        brightness = 1.5,
+        transitionTime = 0.1,
     },
 
     -- Individual drawer: cloned from Styles.ActionBar's actionBarDrawer rule
@@ -1380,6 +1409,41 @@ local function CreateVillainActionStrip(self, info)
         text = "",
     }
 
+    -- Owners list refreshed every refresh tick; portrait click reads it.
+    local m_owners = {}
+
+    local portraitPanel = gui.Panel{
+        classes = {"vaOwnerPortrait"},
+        refreshPortrait = function(element, token, isMulti)
+            if token == nil then
+                element.bgimage = nil
+            else
+                -- Match the initiative bar pattern: prefer the creature
+                -- portrait (offTokenPortrait) and crop with the per-aspect
+                -- rect so the framing is correct.
+                local portrait = token.offTokenPortrait
+                element.bgimage = portrait
+                if portrait ~= token.portrait and not token.popoutPortrait then
+                    element.selfStyle.imageRect = nil
+                else
+                    element.selfStyle.imageRect = token:GetPortraitRectForAspect(1.0, portrait)
+                end
+            end
+            element:SetClass("cyclable", isMulti)
+        end,
+        click = function(element)
+            if #m_owners <= 1 then return end
+            local strip = element:FindParentWithClass("villainActionStrip")
+            if strip == nil then return end
+            strip.data.activeOwnerIndex = (strip.data.activeOwnerIndex % #m_owners) + 1
+            strip:FireEvent("refresh")
+        end,
+        hover = function(element)
+            if #m_owners <= 1 then return end
+            gui.Tooltip{text = "Click to change Villain"}(element)
+        end,
+    }
+
     return gui.Panel{
         classes = {"villainActionStrip"},
         styles = { ThemeEngine.GetStyles(), ThemeEngine.MergeTokens(g_vaStripStyles) },
@@ -1389,7 +1453,7 @@ local function CreateVillainActionStrip(self, info)
         halign = "center",
         valign = "top",
 
-        -- Label row: "VILLAIN ACTIONS . Demon Chorogaunt" as plain text.
+        -- Label row: "VILLAIN ACTIONS - Demon Chorogaunt" or with "(1/2)" suffix when multi.
         gui.Panel{
             classes = {"vaStripLabelRow"},
             headerLabel,
@@ -1397,9 +1461,10 @@ local function CreateVillainActionStrip(self, info)
             subHeaderLabel,
         },
 
-        -- Drawer row: 3 floating drawers side-by-side.
+        -- Drawer row: portrait on the left, then the 3 drawers.
         gui.Panel{
             classes = {"vaDrawerRow"},
+            portraitPanel,
             drawer1, drawer2, drawer3,
         },
 
@@ -1408,15 +1473,13 @@ local function CreateVillainActionStrip(self, info)
             element:FireEvent("refresh")
         end,
 
-        -- Track the last active turn-holder so we can suppress the
-        -- "end-of-turn" flash when the just-finished turn was the VA
-        -- owner's own (rules: VAs fire at the end of any *other*
-        -- creature's turn). lastActiveTurnRound records WHICH round that
-        -- capture happened in, so we can suppress flash across the round
-        -- boundary too -- a new round resets the "just-ended-turn"
-        -- relevance. previousCurrentTurn / previousRound let think detect
-        -- transitions and trigger refresh accordingly.
+        -- activeOwnerIndex selects which VA owner the strip currently shows
+        -- when 2+ Leader/Solo with VAs are in the encounter. Click on the
+        -- portrait cycles. lastActiveTurn / lastActiveTurnRound /
+        -- previousCurrentTurn / previousRound power the flash gating; see
+        -- the refresh and think handlers below for the state-machine.
         data = {
+            activeOwnerIndex = 1,
             lastActiveTurn = nil,
             lastActiveTurnRound = nil,
             previousCurrentTurn = nil,
@@ -1429,12 +1492,18 @@ local function CreateVillainActionStrip(self, info)
                 return
             end
 
-            local owner = FindVillainActionOwnerInEncounter()
-            if owner == nil then
+            m_owners = FindAllVillainActionOwnersInEncounter()
+            if #m_owners == 0 then
                 element:SetClass("collapsed", true)
                 return
             end
 
+            -- Clamp activeOwnerIndex (creatures may have left the encounter).
+            if element.data.activeOwnerIndex < 1 or element.data.activeOwnerIndex > #m_owners then
+                element.data.activeOwnerIndex = 1
+            end
+
+            local owner = m_owners[element.data.activeOwnerIndex]
             local vaMap = GetVillainActionAbilities(owner)
             if vaMap == nil then
                 element:SetClass("collapsed", true)
@@ -1442,7 +1511,16 @@ local function CreateVillainActionStrip(self, info)
             end
 
             element:SetClass("collapsed", false)
-            subHeaderLabel.text = owner.name or ""
+
+            -- Header text: append "(i/N)" when multiple VA owners exist so
+            -- the cycle affordance is discoverable.
+            if #m_owners > 1 then
+                subHeaderLabel.text = string.format("%s (%d/%d)", owner.name or "", element.data.activeOwnerIndex, #m_owners)
+            else
+                subHeaderLabel.text = owner.name or ""
+            end
+
+            portraitPanel:FireEvent("refreshPortrait", owner, #m_owners > 1)
 
             -- Flash gating. Pulse only when ALL of:
             --   - it's between turns (currentTurn == false)

--- a/Draw Steel Core Rules/MCDMInitiativeBar.lua
+++ b/Draw Steel Core Rules/MCDMInitiativeBar.lua
@@ -1280,12 +1280,60 @@ local function CreateVillainActionDrawer(slotKey, slotNumeral)
             element:SetClassTree("available", not consumed)
         end,
 
+        hover = function(element)
+            if m_token == nil or m_ability == nil or not m_token.valid then return end
+
+            local text
+            if VillainActionState.HasUsed(m_token.charid, slotKey) then
+                text = (m_ability.name or "This Villain Action") .. " has already been used this encounter."
+            elseif CharacterResource.GetVillainActions() <= 0 then
+                text = "You have already used a Villain Action this round."
+            else
+                -- Chunk 5 will replace this with a full ability preview card.
+                text = m_ability.name or ""
+            end
+
+            gui.Tooltip{text = text}(element)
+        end,
+
         click = function(element)
-            -- Chunk 4 will replace this with: pan + banner + off-turn cast.
-            print("Villain Action stub press:",
-                slotKey,
-                m_token and m_token.name or "?",
-                m_ability and m_ability.name or "?")
+            if m_token == nil or m_ability == nil or not m_token.valid then return end
+
+            -- Gate: drawer is unavailable if this VA is already consumed
+            -- this encounter, or if the per-round VA budget is spent.
+            -- The hover tooltip above explains which gate is blocking.
+            if VillainActionState.HasUsed(m_token.charid, slotKey) then return end
+            if CharacterResource.GetVillainActions() <= 0 then return end
+
+            -- Pan camera to the caster (fire-and-forget; near-instant).
+            dmhub.CenterOnToken(m_token.charid, {smooth=true})
+
+            -- Build subtitle from the villainAction field with roman numerals.
+            local subtitle = m_ability:try_get("villainAction") or ""
+            subtitle = string.gsub(subtitle, "3", "III")
+            subtitle = string.gsub(subtitle, "2", "II")
+            subtitle = string.gsub(subtitle, "1", "I")
+
+            DramaticBanner.Show{
+                tokenid = m_token.charid,
+                text = m_ability.name or "",
+                subtitle = subtitle,
+            }
+
+            -- After the banner finishes, invoke the ability off-turn via
+            -- the action bar's invokeAbility event. This pushes the caster
+            -- onto the action bar's caster stack and runs the normal cast
+            -- pipeline (target selection, behaviors) without advancing the
+            -- initiative queue's currentTurn.
+            local token = m_token
+            local ability = m_ability
+            local delay = DramaticBanner.TimeUntilDone() + 0.2
+            dmhub.Schedule(delay, function()
+                if mod.unloaded then return end
+                if token == nil or not token.valid then return end
+                if gamehud == nil or gamehud.actionBarPanel == nil then return end
+                gamehud.actionBarPanel:FireEventTree("invokeAbility", token, ability, {}, nil, {})
+            end)
         end,
     }
 end

--- a/Draw Steel Core Rules/MCDMInitiativeQueue.lua
+++ b/Draw Steel Core Rules/MCDMInitiativeQueue.lua
@@ -102,6 +102,12 @@ InitiativeQueueEntry.turnsTaken = 0
 --Create a new empty initiative queue. Called when the DM starts initiative.
 function InitiativeQueue.Create()
 	local playersGoFirst = math.random(1, 2) == 1
+
+	-- New encounter -> clear per-encounter villain action consumption.
+	if VillainActionState ~= nil then
+		VillainActionState.ResetAll()
+	end
+
 	return InitiativeQueue.new{
 		guid = dmhub.GenerateGuid(),
         playersGoFirst = playersGoFirst,


### PR DESCRIPTION
## Summary
Adds proper director-facing support for Villain Actions. When a combat encounter contains a Leader or Solo (any monster with `villainAction` abilities), a director-only strip appears in the monster-side band of the initiative bar showing the three villain actions (I/II/III). Clicking one pans the camera to the owner, plays a Dramatic Banner, then casts the ability off-turn without advancing the initiative order.

## Changes
- **Per-encounter state** (`DSResources.lua`): `VillainActionState` tracks which VAs are consumed, in a shared document synced across clients and registered for checkpoint backups. Reset on encounter start.
- **Strip UI** (`MCDMInitiativeBar.lua`): floating, right-aligned in the initiative bar's monster band so the round tracker stays fixed. Drawers reuse the action-bar chrome (beveled corners, diamond, accent line), grey out when consumed, and pulse `@accent` between turns to nudge the director. Portrait acts as an owner-selector when 2+ VA creatures are present.
- **Click flow** (`MCDMInitiativeBar.lua` + `ActivatedAbility.lua`): pan -> banner -> off-turn cast. A consumption hook in `CastCoroutine` marks a VA used on any successful cast path (strip, action bar, /act, AI), keeping strip state accurate, and spends the per-round VA budget.
- **Reset hook** (`MCDMInitiativeQueue.lua`): clears VA state on new encounter.

## Testing
- Verified in-game with the Demon Chorogaunt (Silver) and Arixx (fully implemented) across single- and multi-VA-owner encounters.
- Confirmed: camera pan + banner + off-turn cast (initiative order unchanged); per-encounter consumption greys the drawer; per-round budget gates all three with explanatory tooltips; end-of-turn flash with correct self-suppression and round-boundary suppression; multi-owner portrait cycling preserves per-creature state.
- Confirmed live theme/scheme switching re-themes the strip correctly.
- Director-only (hidden from players).

## Notes for reviewer
- **Placement is provisional.** The strip was moved from above the initiative bar to the monster-side band per playtest feedback (keeps the round tracker stationary). Open to relocating back -- the prior top-placement is in the commit history.
- Drawers are `gui.Panel` (not `gui.Button`) to deliberately match the existing `actionBarDrawer` chrome.
- Flash uses `@accent`; swap to `@bgAlt` in `g_vaStripStyles` for a subtler pulse.