### PR TITLE
Fix kit bonus subtraction and modifierInfo merge in CombineKits

### DIFF
--- a/Draw Steel Core Rules/MCDMKit.lua
+++ b/Draw Steel Core Rules/MCDMKit.lua
@@ -354,18 +354,26 @@ function Kit.CombineKits(creature, a, b)
 
 	local abilities = {}
 
+	local function subtractKitBonuses(kit, ability)
+        ability = ability:BifurcateIntoMeleeAndRanged(creature)
+        if ability.meleeAndRanged then
+            ApplyBonusesFromKit(kit, ability.meleeVariation, nil, function(a,b) return a - b end)
+            ApplyBonusesFromKit(kit, ability.rangedVariation, nil, function(a,b) return a - b end)
+        else
+            ApplyBonusesFromKit(kit, ability, nil, function(a,b) return a - b end)
+        end
+        return ability
+    end
+
 	for _,abilityRef in ipairs(a:SignatureAbilities()) do
         local ability = abilityRef:MakeTemporaryClone()
-		--Signature abilities that are melee or ranged are bifurcated so correct bonuses are applied to each variation.
-        ability = ability:BifurcateIntoMeleeAndRanged(creature)
-        ApplyBonusesFromKit(a, ability, nil, function(a,b) return a - b end)
+        ability = subtractKitBonuses(a, ability)
 		abilities[#abilities+1] = ability
 	end
 
 	for _,abilityRef in ipairs(b:SignatureAbilities()) do
         local ability = abilityRef:MakeTemporaryClone()
-        ability = ability:BifurcateIntoMeleeAndRanged(creature)
-        ApplyBonusesFromKit(b, ability, nil, function(a,b) return a - b end)
+        ability = subtractKitBonuses(b, ability)
 		abilities[#abilities+1] = ability
 	end
 
@@ -375,7 +383,7 @@ function Kit.CombineKits(creature, a, b)
     elseif b:has_key("modifierInfo") then
         modifierInfo = ClassLevel:CreateNew()
         modifierInfo:MergeFeatures(a.modifierInfo)
-        modifierInfo:MergeFeatures(a.modifierInfo)
+        modifierInfo:MergeFeatures(b.modifierInfo)
     end
 
 	local result = Kit.new{


### PR DESCRIPTION
## Summary

- **Damage subtraction bug**: When `CombineKits` removed each kit's individual bonus from its signature abilities before re-applying the combined bonus, it called `ApplyBonusesFromKit` on the pre-bifurcation wrapper. For abilities with both Melee and Ranged keywords (e.g. Cloak and Dagger's Fade), both bonus types matched and both were subtracted — but after bifurcation only the appropriate one was re-added per variation. This caused a net −1 damage per tier on the melee variation of dual-keyword signature abilities. Fix: bifurcate first, then subtract from each variation separately (matching how the application step already works).

- **`modifierInfo` merge bug**: Copy-paste error at line 378 merged `a.modifierInfo` twice instead of `a.modifierInfo` then `b.modifierInfo`, silently dropping all class features from kit B in the combined kit.

## Test plan

- [ ] Tactician with Cloak and Dagger + Arcane Archer: Fade (Melee) damage should equal base + Might (no inflated or deflated kit bonus)
- [ ] Tactician with two kits where one has features in `modifierInfo`: confirm kit B features appear on the character sheet
- [ ] Single-kit characters: verify signature ability damage is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)