### PR TITLE
feat(modifiers): add Roll Characteristic GoblinScript symbol to Modify Power Roll

### DIFF
--- a/Draw Steel Core Rules/MCDMAbilityRollBehavior.lua
+++ b/Draw Steel Core Rules/MCDMAbilityRollBehavior.lua
@@ -1760,6 +1760,50 @@ function ActivatedAbilityPowerRollBehavior:GetPowerRollDisplay()
     return string.gsub(roll, "2d10", "<b>Power Roll</b>")
 end
 
+--Resolves the value of the characteristic this power roll uses for `caster`,
+--e.g. 5 for a hero whose roll is "2d10 + Reason" with Reason +5, or the higher
+--of the two for "2d10 + Might or Agility". Returns nil when the roll formula
+--names no characteristic (e.g. a flat "2d10 + 3" monster roll) so callers can
+--leave the GoblinScript symbol absent.
+--- @param caster creature
+--- @return number|nil
+function ActivatedAbilityPowerRollBehavior:GetRollCharacteristicValue(caster)
+    local rollFormula = self:try_get("roll", "")
+    if rollFormula == "" then
+        return nil
+    end
+
+    --Replace the dice term with 0 so evaluating the formula yields just the
+    --bonus. GoblinScript resolves "Might or Agility" to the higher of the two
+    --and "Highest Characteristic" to the highest. If no letters remain after
+    --removing the dice, the bonus is a flat number (no characteristic).
+    local bonusFormula = regex.ReplaceAll(rollFormula, "\\d*d\\d+", "0")
+    if regex.MatchGroups(bonusFormula, "(?<c>[a-zA-Z])") == nil then
+        return nil
+    end
+
+    local value = tonumber(dmhub.EvalGoblinScript(bonusFormula, caster:LookupSymbol(), "Roll Characteristic Value"))
+    if value == nil then
+        return nil
+    end
+
+    return round(value)
+end
+
+--Convenience wrapper: returns the characteristic value used by this ability's
+--power roll, or nil. Skips resistance rolls (they roll the target's defending
+--characteristic, not the caster's attacking one).
+--- @param caster creature
+--- @return number|nil
+function ActivatedAbility:GetRollCharacteristicValue(caster)
+    for _,behavior in ipairs(self.behaviors) do
+        if behavior.typeName == "ActivatedAbilityPowerRollBehavior" and not behavior:try_get("resistanceRoll", false) then
+            return behavior:GetRollCharacteristicValue(caster)
+        end
+    end
+    return nil
+end
+
 function ActivatedAbility:GetPowerRollDisplay()
     for _,behavior in ipairs(self.behaviors) do
         local result = behavior:GetPowerRollDisplay()

--- a/Draw Steel Core Rules/MCDModifyPowerRolls.lua
+++ b/Draw Steel Core Rules/MCDModifyPowerRolls.lua
@@ -35,6 +35,22 @@ local g_powerRollTypes = {
     },
 }
 
+--Resolves the value of the characteristic used for a power roll, or nil when
+--the roll uses no characteristic (so callers leave the GoblinScript symbol
+--absent). Tests and resistance rolls carry the characteristic id directly in
+--options.attribute; ability rolls keep their characteristic in the roll formula
+--(e.g. "2d10 + Reason"), resolved via the ability itself.
+local function ResolveRollCharacteristic(creature, options)
+    local attrid = options.attribute
+    if attrid ~= nil and attrid ~= "none" then
+        return creature:AttributeMod(attrid)
+    end
+    if options.ability ~= nil and options.ability.GetRollCharacteristicValue ~= nil then
+        return options.ability:GetRollCharacteristicValue(creature)
+    end
+    return nil
+end
+
 local function RollTypeMatches(modifier, rollType, options)
     if modifier.rollType == "all" and rollType ~= "enemy_ability_power_roll" then
         return true
@@ -298,11 +314,22 @@ CharacterModifier.TypeInfo.power = {
             }
         end
 
-		local lookupFunction = creature:LookupSymbol(self:AppendSymbols{
+		local powerRollSymbols = self:AppendSymbols{
 			ability = GenerateSymbols(options.ability),
 			target = GenerateSymbols(options.target),
             title = options.title or "",
-		})
+		}
+
+		--Expose the value of the characteristic used for this roll (e.g. 2 for a
+		--Might +2 roll, -1 for an Agility -1 roll). Left absent when the roll uses
+		--no characteristic so a condition can tell "no characteristic" apart from
+		--"characteristic of 0".
+		local rollCharacteristic = ResolveRollCharacteristic(creature, options)
+		if rollCharacteristic ~= nil then
+			powerRollSymbols.rollcharacteristic = rollCharacteristic
+		end
+
+		local lookupFunction = creature:LookupSymbol(powerRollSymbols)
 
         print("POWER ROLL:: OPTIONS:", options)
 
@@ -378,13 +405,22 @@ CharacterModifier.TypeInfo.power = {
         end
 
         if self.displayCondition ~= "" then
-            local lookupFunction = creature:LookupSymbol(self:AppendSymbols{
+            local displaySymbols = self:AppendSymbols{
                 ability = GenerateSymbols(options.ability),
                 target = GenerateSymbols(options.target),
                 caster = GenerateSymbols(options.caster),
                 cast = options.symbols and GenerateSymbols(options.symbols.cast),
                 title = options.title or "",
-            })
+            }
+
+            --See hintPowerRoll: expose the characteristic value used for this
+            --roll, absent when the roll uses no characteristic.
+            local rollCharacteristic = ResolveRollCharacteristic(creature, options)
+            if rollCharacteristic ~= nil then
+                displaySymbols.rollcharacteristic = rollCharacteristic
+            end
+
+            local lookupFunction = creature:LookupSymbol(displaySymbols)
 
             if not GoblinScriptTrue(ExecuteGoblinScript(self.displayCondition, lookupFunction, 0, "Power Roll Activation Condition")) then
                 return false
@@ -1367,6 +1403,11 @@ CharacterModifier.TypeInfo.power = {
                     type = "text",
                     desc = "The title of the roll",
                     examples = "Recall Lore Test to Recall Location of Amulet",
+                }
+                helpSymbols.rollcharacteristic = {
+                    name = "Roll Characteristic",
+                    type = "number",
+                    desc = "The value of the characteristic used for this roll, e.g. 2 for a Might +2 roll. Absent if the roll uses no characteristic.",
                 }
 
                 children[#children+1] = gui.GoblinScriptInput{


### PR DESCRIPTION
## Summary
Adds a new `Roll Characteristic` GoblinScript symbol to the Modify Power Roll
modifier, available in both the activation-condition and display-condition
inputs. It returns the value of the characteristic used for the roll (e.g. 5
for a Reason +5 roll, -1 for an Agility -1 roll), so a modifier can react to
the characteristic across All Our Power Rolls -- abilities, tests, and
resistance rolls alike.

## Changes
- `MCDModifyPowerRolls.lua`: added a `ResolveRollCharacteristic` helper and
  wired it into `hintPowerRoll` (activation condition) and
  `shouldShowInPowerRollDialog` (display condition); injects the
  `rollcharacteristic` symbol only when a characteristic is present.
- `MCDModifyPowerRolls.lua`: documented the symbol in the modifier editor so it
  lists for all roll types.
- `MCDMAbilityRollBehavior.lua`: added `GetRollCharacteristicValue` on the power
  roll behavior (and an `ActivatedAbility` wrapper) to resolve the characteristic
  from the roll formula for ability rolls.

## Behaviour
- Tests / resistance rolls: resolved from the characteristic id (`options.attribute`).
- Ability rolls: resolved from the roll formula -- `2d10 + Reason` -> Reason, and
  `2d10 + Might or Agility` / `Highest Characteristic` resolve to the higher/highest.
- Flat rolls with no characteristic (e.g. monster `2d10 + 3`) leave the symbol
  absent, so a condition can distinguish "no characteristic" from "characteristic of 0".

## Testing
Verified in a running DMHub instance:
- `Afflict a Bountiful Decay` (`2d10 + Reason`, Reason +5) -> `Roll Characteristic` = 5.
- Reason test (+5) and Agility test (-1) via the Tactical Panel resolve the symbol
  and drive a `Roll Characteristic > 0` / `< 0` Modify Power Roll condition correctly.
- Monster flat rolls (`2d10 + 3`) correctly leave the symbol absent.

## Notes for reviewer
The symbol is injected on the pre-roll activation and display paths only (not the
after-roll path). The opposed-test attacker path (`AbilityOpposedPowerRoll.lua`)
does not currently pass `attribute`, so the symbol is absent there -- left out of
scope for this PR.