### PR TITLE
fix(combat): drop spurious +unitsPerSquare from Ignore Hidden Within Range checks

### DIFF
--- a/DrawSteelActionBar/DrawSteelActionBar.lua
+++ b/DrawSteelActionBar/DrawSteelActionBar.lua
@@ -5939,7 +5939,7 @@ local function CalculateSpellTargetFocusing(symbols)
                     local bypass = false
                     if ignoreRange > 0 then
                         local dist = g_token:Distance(targetToken)
-                        if dist <= ignoreRange + dmhub.unitsPerSquare then
+                        if dist <= ignoreRange then
                             bypass = true
                         end
                     end

--- a/Monster AI/MonsterAI.lua
+++ b/Monster AI/MonsterAI.lua
@@ -255,7 +255,7 @@ function MonsterAI:FindValidTargetsOfStrike(token, ability, loc, range)
         local canTarget = ability:TargetPassesFilter(token, enemy, {})
         if canTarget and enemy.properties:HasNamedCondition("Hidden") and ability:HasKeyword("Strike") then
             local ignoreRange = token.properties:CalculateNamedCustomAttribute("Ignore Hidden Within Range") or 0
-            if ignoreRange <= 0 or token:Distance(enemy) > ignoreRange + dmhub.unitsPerSquare then
+            if ignoreRange <= 0 or token:Distance(enemy) > ignoreRange then
                 canTarget = false
             end
         end


### PR DESCRIPTION
## Summary
The `Ignore Hidden Within Range` custom attribute is authored in native units -- the same units `token:Distance()` returns -- so its range check needs no conversion. The existing checks added `+ dmhub.unitsPerSquare`, which granted one extra square (a value of `4` actually suppressed the hidden edge / allowed targeting out to 5 squares). This drops the spurious term so the attribute means exactly N squares.

## Changes
- `DrawSteelActionBar.lua`: hidden-creature strike-targeting bypass now uses `dist <= ignoreRange` (was `dist <= ignoreRange + dmhub.unitsPerSquare`).
- `MonsterAI.lua`: monster AI strike-target filter now uses `token:Distance(enemy) > ignoreRange` (was `> ignoreRange + dmhub.unitsPerSquare`).

## Why no unit conversion
`token:Distance()` returns native units and the attribute is authored in native units, so they compare directly. The `+ unitsPerSquare` was an off-by-one: it appears to have been adapted from the standard range idiom `range + unitsPerSquare > dist`, which pairs the extra square with a *strict* `>` to mean inclusive `<=`. Using it with a non-strict `<=` double-counts and adds a real extra square. Confirmed with the lead developer that the term should be removed.

## Testing
- Verified against the live instance: `dmhub.unitsPerSquare = 1`, and `token:Distance()` matches `Loc:DistanceInTiles` (native units), so squares = `Distance() / unitsPerSquare`.
- Traced the matching Modify Power Roll edge (Hiding global rule mod display condition `Distance(target) > target.Ignore Hidden Within Range`) so the targeting block and the edge now agree: within N squares a hidden creature can be struck and is denied its edge; beyond N it keeps the edge.

## Notes for reviewer
The `Line Of Effect Limit` attribute has a similar feet-vs-squares inconsistency between `DrawSteelActionBar.lua:2304` (converts distance to squares) and `DSRuleUtils.lua:15` (compares raw distance). Left untouched here -- flagging as a separate follow-up.