### PR TITLE
fix(rolls): serialize dice-roll dialogs so only one shows at a time

### DIFF
--- a/Draw Steel Core Rules/MCDMCreature.lua
+++ b/Draw Steel Core Rules/MCDMCreature.lua
@@ -3747,6 +3747,14 @@ function creature:GetAfterRollModifiersForPowerRoll(rollType, options)
     return result
 end
 
+--Tracks creatures with a queued user-initiated roll (a characteristic test or a
+--journal power-table test) that is waiting for the roll gate to clear, so repeat
+--clicks do not stack multiple waiters that would displace each other. File-local
+--on purpose: it resets on every Lua reload, so a flag left set by a waiter
+--coroutine killed mid-wait (e.g. an F5/F4 reload) cannot persist -- unlike a
+--_tmp_ field on the creature, which survives reloads and would pin future clicks.
+local g_pendingQueuedRoll = {}
+
 function creature:RollCustomPowerTableTest(title, characteristics, skills, tiers)
     local attrid = nil
     local bestModifier = nil
@@ -3802,24 +3810,55 @@ function creature:RollCustomPowerTableTest(title, characteristics, skills, tiers
         end
     end
 
-    GameHud.instance.rollDialog.data.ShowDialog {
-        title = title,
-        description = title,
-        creature = self,
+    --Respect the global roll gate. This drives the singleton rollDialog
+    --directly, which only serializes against itself, so without this it would
+    --pop on top of an in-flight embedded/standalone roll (e.g. a start-of-turn
+    --damage or prayer roll). We cannot yield in this synchronous UI handler, so
+    --wait for every surface to clear inside a coroutine before showing. The
+    --pending registry stops repeated link clicks from stacking waiters.
+    if g_pendingQueuedRoll[self] then
+        return
+    end
+    g_pendingQueuedRoll[self] = true
 
-        type = rollType,
-        roll = roll,
-        modifiers = modifiers,
+    dmhub.Coroutine(function()
+        --Wait for every roll surface to clear, with a hard cap so a stuck dialog
+        --can never pin this flag (and thus future clicks) forever.
+        local waited = 0
+        while (not mod.unloaded) and CharacterPanel.AnyRollDialogShown() do
+            coroutine.yield(0.05)
+            waited = waited + 1
+            if waited > 600 then break end
+        end
 
-        rollProperties = rollProperties,
-        PopulateCustom = ActivatedAbilityPowerRollBehavior.GetPowerTablePopulateCustom(rollProperties),
+        g_pendingQueuedRoll[self] = nil
 
-        completeRoll = function(rollInfo)
-        end,
+        --Bail without showing if a reload is underway or we hit the cap with a
+        --roll still up (showing now would overlap). The click is dropped and the
+        --user can retry; nothing stays queued.
+        if mod.unloaded or CharacterPanel.AnyRollDialogShown() then
+            return
+        end
 
-        cancelRoll = function()
-        end,
-    }
+        GameHud.instance.rollDialog.data.ShowDialog {
+            title = title,
+            description = title,
+            creature = self,
+
+            type = rollType,
+            roll = roll,
+            modifiers = modifiers,
+
+            rollProperties = rollProperties,
+            PopulateCustom = ActivatedAbilityPowerRollBehavior.GetPowerTablePopulateCustom(rollProperties),
+
+            completeRoll = function(rollInfo)
+            end,
+
+            cancelRoll = function()
+            end,
+        }
+    end)
 end
 
 function creature:ShowCharacteristicRollDialog(attrid)
@@ -3839,35 +3878,13 @@ function creature:ShowCharacteristicRollDialog(attrid)
     local modifiers = self:GetModifiersForPowerRoll(roll, rollType, { attribute = attrid })
 
     local syntheticAbility = ActivatedAbility.Create{ isTest = true, name = title }
-    local token = dmhub.LookupToken(self)
 
-    --Give the test roll a synthetic single-target (the roller itself) so the
-    --post-roll edge/bane -> tier refresh pipeline runs. That pipeline is plumbed
-    --entirely through RecalculateMultiTargets -> "recalculatedMultiTargets" ->
-    --message:UploadProperties, which bails when m_multitargets is nil. Without
-    --this, applying banes/edges after the dice land does not update the displayed
-    --tier (it only works before the roll, where the boons are baked into the
-    --formula). markLineOfSight is intentionally left unset so no targeting-ray
-    --labels are drawn, and CalculateMultiTargets is omitted so this static
-    --single-target array is preserved across recalculations.
+    --Assigned inside the queue coroutine below (after any in-flight roll clears)
+    --so the displacing steps do not run until it is safe. ShowRollDialog closes
+    --over these upvalues, so they are read at call time, not capture time.
+    local token = nil
     local multitargets = nil
-    if token ~= nil then
-        multitargets = {
-            {
-                token = token,
-                boons = 0,
-                banes = 0,
-                modifiers = modifiers,
-                triggers = {},
-            },
-        }
-    end
-
     local displaying = false
-    if token ~= nil then
-        CharacterPanel.UnlockDisplayAbility()
-        displaying = CharacterPanel.DisplayAbility(token, syntheticAbility, nil, {lock = true, renderAsAbility = true})
-    end
 
     local function ShowRollDialog(dialog)
         if dialog == nil or not dialog.valid then
@@ -3933,15 +3950,73 @@ function creature:ShowCharacteristicRollDialog(attrid)
         }
     end
 
-    local embeddedDialog = CharacterPanel.EmbedDialogInAbility()
-    if embeddedDialog ~= nil then
-        dmhub.Schedule(0.05, function()
-            if mod.unloaded then return end
-            ShowRollDialog(embeddedDialog)
-        end)
-    else
-        ShowRollDialog(nil)
+    --This is a synchronous UI handler (a characteristic click), so we cannot
+    --yield here to queue. Run the displacing steps -- DisplayAbility clears the
+    --embedded panel and EmbedDialogInAbility mounts a fresh dialog -- inside a
+    --coroutine that first waits for every roll surface to clear. Without this,
+    --clicking a characteristic mid-roll destroyed the in-flight dialog (e.g. an
+    --ongoing-damage roll) and silently lost its result. The pending registry
+    --stops repeated clicks from stacking multiple queued waiters.
+    if g_pendingQueuedRoll[self] then
+        return
     end
+    g_pendingQueuedRoll[self] = true
+
+    dmhub.Coroutine(function()
+        --Wait for every roll surface to clear, with a hard cap so a stuck dialog
+        --can never pin this flag (and thus future clicks) forever.
+        local waited = 0
+        while (not mod.unloaded) and CharacterPanel.AnyRollDialogShown() do
+            coroutine.yield(0.05)
+            waited = waited + 1
+            if waited > 600 then break end
+        end
+
+        g_pendingQueuedRoll[self] = nil
+
+        --Bail without showing if a reload is underway or we hit the cap with a
+        --roll still up (showing now would displace/overlap). The click is dropped
+        --and the user can retry; nothing stays queued.
+        if mod.unloaded or CharacterPanel.AnyRollDialogShown() then
+            return
+        end
+
+        token = dmhub.LookupToken(self)
+
+        --Give the test roll a synthetic single-target (the roller itself) so the
+        --post-roll edge/bane -> tier refresh pipeline runs. That pipeline is plumbed
+        --entirely through RecalculateMultiTargets -> "recalculatedMultiTargets" ->
+        --message:UploadProperties, which bails when m_multitargets is nil. Without
+        --this, applying banes/edges after the dice land does not update the displayed
+        --tier (it only works before the roll, where the boons are baked into the
+        --formula). markLineOfSight is intentionally left unset so no targeting-ray
+        --labels are drawn, and CalculateMultiTargets is omitted so this static
+        --single-target array is preserved across recalculations.
+        if token ~= nil then
+            multitargets = {
+                {
+                    token = token,
+                    boons = 0,
+                    banes = 0,
+                    modifiers = modifiers,
+                    triggers = {},
+                },
+            }
+
+            CharacterPanel.UnlockDisplayAbility()
+            displaying = CharacterPanel.DisplayAbility(token, syntheticAbility, nil, {lock = true, renderAsAbility = true})
+        end
+
+        local embeddedDialog = CharacterPanel.EmbedDialogInAbility()
+        if embeddedDialog ~= nil then
+            dmhub.Schedule(0.05, function()
+                if mod.unloaded then return end
+                ShowRollDialog(embeddedDialog)
+            end)
+        else
+            ShowRollDialog(nil)
+        end
+    end)
 end
 
 --hitpoints handling overridden. We include handling of minions.

--- a/Draw Steel UI/DSRequestRollsDialog.lua
+++ b/Draw Steel UI/DSRequestRollsDialog.lua
@@ -421,8 +421,12 @@ function GameHud:RequireRollListenerPanel()
 		monitorGame = "/actionRequests",
 
 		refreshGame = function(element)
-			if self.rollDialog.data.IsShown() then
-				if showingRollId == gamehud.rollDialog.data.rollid then
+			--Defer if ANY roll dialog is on screen, not just the legacy singleton.
+			--Otherwise a table roll (e.g. the Conduit prayer, which routes to the
+			--standalone host) pops on top of an in-flight ability/ongoing-effect
+			--roll shown in the embedded dialog. See CharacterPanel.AnyRollDialogShown.
+			if CharacterPanel.AnyRollDialogShown() then
+				if self.rollDialog.data.IsShown() and showingRollId == gamehud.rollDialog.data.rollid then
 					--we requested the current roll dialog that is shown. See if our reason
 					--for doing so has been canceled, in which case we want to close that dialog.
 					if dmhub.GetPlayerActionRequest(rollRequestId) == nil then
@@ -430,7 +434,7 @@ function GameHud:RequireRollListenerPanel()
 					end
 				end
 
-				--we are currently blocked by the roll dialog. Try again in a little while.
+				--we are currently blocked by a roll dialog. Try again in a little while.
 				element:ScheduleEvent("refreshGame", 0.2)
 
 				return
@@ -1589,6 +1593,19 @@ function GameHud:ShowRollSummaryDialog(actionid, resultTable)
 
 			}
 
+			--Shown beside the Take Roll button once the DM takes a roll that is
+			--queued behind another dialog (the listener defers while
+			--CharacterPanel.AnyRollDialogShown). Gives the click a visible effect
+			--even though the actual roll prompt is suppressed until the blocking
+			--dialog is resolved.
+			local waitingLabel = gui.Label{
+				classes = {"sizeS", "hidden"},
+				text = "Waiting...",
+				halign = "right",
+				valign = "center",
+				rmargin = 100,
+			}
+
 			panel = gui.Panel{
 				classes = {"resultPanel", "row", cond(rowIndex % 2 == 1, "evenRow", "oddRow")},
 
@@ -1609,6 +1626,8 @@ function GameHud:ShowRollSummaryDialog(actionid, resultTable)
 						local actionInfo = action.info.tokens[k]
 						if actionInfo ~= nil then
 							removeButton:SetClass("hidden", true)
+							--Hide by default; the queued-Take-Roll branch below re-shows it.
+							waitingLabel:SetClass("hidden", true)
 							if actionInfo.status == 'dialog' then
 								if actionInfo.userid ~= nil then
 									element.text = string.format("%s is preparing to roll...", dmhub.GetDisplayName(actionInfo.userid))
@@ -1658,6 +1677,13 @@ function GameHud:ShowRollSummaryDialog(actionid, resultTable)
 								element.text = 'Waiting...'
 								if againButton ~= nil then
 									againButton:FireEvent("takeroll", true)
+								end
+
+								--The DM took this roll (forceuserid is them) but it has
+								--not been shown yet -- it is queued behind another dialog.
+								--Surface that beside the button so the click reads as acted on.
+								if actionInfo.forceuserid == dmhub.loginUserid then
+									waitingLabel:SetClass("hidden", false)
 								end
 							end
 						end
@@ -1735,6 +1761,8 @@ function GameHud:ShowRollSummaryDialog(actionid, resultTable)
 				againButton,
 
 				removeButton,
+
+				waitingLabel,
 			}
 
 			resultsPanels[#resultsPanels+1] = panel

--- a/Timeline/AbilitySidebar.lua
+++ b/Timeline/AbilitySidebar.lua
@@ -1283,6 +1283,94 @@ function CharacterPanel.FindEmbeddedRollDialog()
     return embedded
 end
 
+--True if a roll dialog is currently shown in the standalone roll host (table
+--rolls and other non-ability rolls routed through EmbedDialogStandalone). This
+--host carries no cast-coroutine ownership, so it is safe to wait on without
+--risking a self-deadlock from a cast's own embedded dialog.
+function CharacterPanel.StandaloneRollShown()
+    local hud = rawget(GameHud, "instance")
+    if not hud then
+        return false
+    end
+
+    local host = rawget(hud, "standaloneRollHost")
+    if host == nil or not host.valid then
+        return false
+    end
+
+    for _, child in ipairs(host.children) do
+        if child.valid and child.data ~= nil
+           and child.data.IsShown ~= nil and child.data.IsShown() then
+            return true
+        end
+    end
+
+    return false
+end
+
+--True if the embedded ability dialog is occupied -- either visibly shown, or
+--mid-acquisition: created and stamped with a live cast (castCoroutine) that has
+--not relinquished its roll, but whose ShowDialog has not fired yet.
+--
+--AcquireAbilityRollDialog shows a roll in several steps with yields in between
+--(DisplayAbility -> EmbedDialogInAbility -> yield -> the behavior calls
+--ShowDialog), so there is a window where the dialog exists and is owned but
+--IsShown() is still false. Counting only IsShown() there let a concurrent
+--table-roll request (e.g. the Conduit prayer, fired from the action-request
+--listener) slip into that gap and pop alongside the damage roll -- the
+--player-side overlap. This mirrors the "queue behind it" classification in
+--AcquireAbilityRollDialog so the gap is treated as occupied.
+function CharacterPanel.EmbeddedRollInFlight()
+    local embedded = CharacterPanel.FindEmbeddedRollDialog()
+    if embedded == nil or not embedded.valid or embedded.data == nil then
+        return false
+    end
+
+    if embedded.data.IsShown ~= nil and embedded.data.IsShown() then
+        return true
+    end
+
+    --Not yet shown: occupied only while a live cast still owns an unfinished
+    --roll. A relinquished roll, a dead owner, or an untracked lingering panel
+    --is not in flight and must not block (avoids deadlock on leftovers).
+    local ownerco = embedded.data.castCoroutine
+    if ownerco ~= nil and (not embedded.data.rollRelinquished)
+       and coroutine.IsCoroutineWithIdStillRunning(ownerco) then
+        return true
+    end
+
+    return false
+end
+
+--Single source of truth for "is any dice-roll dialog currently in flight?"
+--There are three independent roll surfaces, and each legacy gate only watched
+--one of them -- which let, e.g., a Conduit prayer table roll (standalone host)
+--pop on top of an ongoing-effect damage roll (embedded ability dialog):
+--  1. the legacy singleton gamehud.rollDialog
+--  2. the embedded ability dialog mounted in abilityDisplay
+--  3. any dialog mounted in the standalone roll host (table rolls)
+function CharacterPanel.AnyRollDialogShown()
+    local hud = rawget(GameHud, "instance")
+    if not hud then
+        return false
+    end
+
+    --1. legacy singleton.
+    local singleton = rawget(hud, "rollDialog")
+    if singleton ~= nil and singleton.valid and singleton.data ~= nil
+       and singleton.data.IsShown ~= nil and singleton.data.IsShown() then
+        return true
+    end
+
+    --2. embedded ability dialog (shown or mid-acquisition).
+    if CharacterPanel.EmbeddedRollInFlight() then
+        return true
+    end
+
+    --3. standalone roll host.
+    return CharacterPanel.StandaloneRollShown()
+end
+
 function CharacterPanel.EmbedDialogInAbility()
     if (not GameHud.instance) or (not GameHud.instance.abilityDisplay) then
         return nil
@@ -1429,6 +1517,21 @@ function CharacterPanel.AcquireAbilityRollDialog(token, ability, symbols, displa
 
     local waited = false
     while true do
+        --Queue behind a roll mounted in the standalone host (table rolls etc.).
+        --It carries no cast-coroutine ownership, so we simply wait for it to
+        --clear. Only do this when we can yield; outside a coroutine we cannot
+        --wait, so fall through (matches the embedded not-in-a-coroutine path).
+        if coid ~= nil and (not mod.unloaded) and CharacterPanel.StandaloneRollShown() then
+            if not waited then
+                waited = true
+                print("AcquireRollDialog:: QUEUE behind standalone roll dialog")
+            end
+            coroutine.yield(0.01)
+            --re-evaluate from the top: the standalone roll may have cleared,
+            --or an embedded dialog may now need classifying.
+            goto continue
+        end
+
         local existing = CharacterPanel.FindEmbeddedRollDialog()
         if existing == nil then
             break
@@ -1479,6 +1582,8 @@ function CharacterPanel.AcquireAbilityRollDialog(token, ability, symbols, displa
             print(string.format("AcquireRollDialog:: QUEUE behind dialog castCoroutine=%s", tostring(ownerco)))
         end
         coroutine.yield(0.01)
+
+        ::continue::
     end
 
     --Clear any stale lock so DisplayAbility's displace guard does not refuse us.


### PR DESCRIPTION
## Summary

Draw Steel has multiple independent dice-roll dialog surfaces, and each legacy gate only watched one of them. So start-of-turn rolls on the same creature could open simultaneously -- most visibly a Conduit prayer table roll popping on top of an ongoing-effect damage roll (e.g. a Manticore's Tail Spike). This introduces a single source of truth across all surfaces and has every roll entry point queue behind an in-flight roll instead of overlapping or displacing it.

The three surfaces:
1. The legacy singleton `gamehud.rollDialog`
2. The embedded ability dialog (ability sidebar) -- damage/power/save/replenish rolls
3. The standalone roll host -- table rolls (the prayer choice)

## Changes

**`Timeline/AbilitySidebar.lua`**
- `CharacterPanel.StandaloneRollShown()` -- is a roll shown in the standalone host?
- `CharacterPanel.EmbeddedRollInFlight()` -- is the embedded ability dialog occupied? Counts it as occupied while shown OR mid-acquisition (created and owned by a live `castCoroutine`, not yet relinquished). Closes the not-yet-shown init window that let a table-roll request slip in on the player's client. Coroutine-aware, so it never blocks on a dead/finished/leftover dialog.
- `CharacterPanel.AnyRollDialogShown()` -- unified predicate over all three surfaces.
- `AcquireAbilityRollDialog` now also queues behind a standalone-host roll (with a `mod.unloaded` guard so a cast can't loop on a stale standalone across a reload).

**`Draw Steel UI/DSRequestRollsDialog.lua`**
- The Request Rolls listener defers on `AnyRollDialogShown()` instead of only the singleton.
- Added a "Waiting..." indicator beside the director's Take Roll button while a taken roll is queued behind another dialog.

**`Draw Steel Core Rules/MCDMCreature.lua`**
- `ShowCharacteristicRollDialog` (tac-panel characteristic test) now queues behind any in-flight roll instead of displacing and silently losing it.
- `RollCustomPowerTableTest` (journal/document inline power-roll links) now respects the gate too.
- Both use a reload-safe file-local pending registry (resets on Lua reload, unlike `_tmp_` fields which survive reloads) with a 30s hard cap, so a waiter killed mid-wait can never pin future clicks.

## Testing

Verified live with a Conduit + Manticore Tail Spike at start of turn:
- Damage roll, prayer table roll, and a manually-clicked characteristic test all sequence one at a time; nothing lost.
- Confirmed on the player client (token assigned to a player; director not taking the roll) and via the journal document power-roll link -- no conflicts.
- Stacked sources (multiple ongoing-damage effects + prayer) resolve in order.
- Robustness checked for escape, ability-failure, crash, and F5/F4 reload -- nothing stays queued behind a dialog that's gone; queues self-heal.

## Notes for reviewer

Two items intentionally left out of scope:
- **Roll ordering** between concurrently-queued rolls is poll-race order, not strict FIFO (e.g. a characteristic test clicked after a queued prayer can resolve first). Accepted by design for now.
- The **Request Rolls panel** (`g_requireRollDialog`) is a single global shared by the request-config UI and the take-roll summary; launching a second roll-request flow (e.g. a director montage test) while one is in flight can clobber it. Pre-existing structural issue, unrelated to dialog collisions -- tracked separately.