### PR TITLE
fix: revert tier badge glyph width to auto

### DIFF
--- a/Draw Steel Core Rules/MCDMActivatedAbility.lua
+++ b/Draw Steel Core Rules/MCDMActivatedAbility.lua
@@ -1325,7 +1325,7 @@ function ActivatedAbility:Render(options, params)
 
                     bgimage = true,
                     bgcolor = "clear",
-                    width = 65,
+                    width = "auto",
                     height = "auto",
                     maxHeight = 22,
                     text = "!",
@@ -1368,7 +1368,7 @@ function ActivatedAbility:Render(options, params)
 
                     bgimage = true,
                     bgcolor = "clear",
-                    width = 65,
+                    width = "auto",
                     height = "auto",
                     maxHeight = 22,
                     text = "@",
@@ -1408,7 +1408,7 @@ function ActivatedAbility:Render(options, params)
 
                     bgimage = true,
                     bgcolor = "clear",
-                    width = 65,
+                    width = "auto",
                     height = "auto",
                     maxHeight = 22,
                     text = "#",


### PR DESCRIPTION
## Summary

- Reverts hardcoded `width = 65` on the three power roll tier badge glyph labels back to `width = "auto"`
- Fixed pixel width breaks font scaling: the badge column stays frozen when font size changes, causing overflow or gaps
- The minor per-glyph misalignment in the `@` (12-16) badge is a DrawSteelGlyphs font design issue and is the lesser evil compared to broken scaling

🤖 Generated with [Claude Code](https://claude.com/claude-code)