### PR TITLE
fix(editor): refresh stale targeting + feature-name UI on edit

### DIFF
--- a/DMHub Game Rules/CharacterFeature.lua
+++ b/DMHub Game Rules/CharacterFeature.lua
@@ -1073,7 +1073,13 @@ function CharacterFeature:PopupEditor()
 				fontSize = 22,
 				text = "Confirm",
 				click = function(element)
-					contentPanel:FireEvent('modifierRefreshed')
+					-- FireEventTree (not FireEvent): in the themed path the
+					-- caller's 'modifierRefreshed' handler lives on the inner
+					-- scroll panel, not on contentPanel (the outer wrapper), so
+					-- a plain FireEvent on the wrapper never reaches it and edits
+					-- made right before Confirm (e.g. a renamed feature) failed to
+					-- refresh the source list until the sheet was reopened.
+					contentPanel:FireEventTree('modifierRefreshed')
 					resultPanel:DestroySelf()
 				end,
 			},
@@ -1104,7 +1110,14 @@ function CharacterFeature:PopupEditor()
 						self[k] = v
 					end
 
-					contentPanel:FireEvent('refreshModifier')
+					-- Cancel restored the backup above, so notify the source
+					-- list to rebuild from the reverted state. Route through the
+					-- same 'modifierRefreshed' handler as Confirm (FireEventTree
+					-- so it reaches the inner scroll panel in the themed path);
+					-- the handler fires 'refreshModifier' on the notify element.
+					-- Without this, any name the live poll had already pushed to
+					-- the list would persist until the sheet was reopened.
+					contentPanel:FireEventTree('modifierRefreshed')
 
 					resultPanel:DestroySelf()
 				end,

--- a/Draw Steel Ability Editor/AbilityEditor.lua
+++ b/Draw Steel Ability Editor/AbilityEditor.lua
@@ -3235,6 +3235,29 @@ local function _buildTargetingSection(ability, fireChange)
                 ability:SetChosenTargetTypeFromDropdown(element.idChosen)
                 fireChange()
             end,
+            refreshAbility = function(element)
+                -- For triggered abilities the valid target types depend on the
+                -- trigger event / subject, so recompute the options whenever the
+                -- ability changes. Only reassign when the set actually changed --
+                -- for non-triggered abilities the list is static, so this is a
+                -- no-op and avoids churn on every edit. idChosen is refreshed
+                -- unconditionally; assigning it does not re-fire 'change'.
+                local options = ability:GetDisplayedTargetTypeOptions()
+                local current = element.options
+                local changed = current == nil or #current ~= #options
+                if not changed then
+                    for i,opt in ipairs(options) do
+                        if current[i].id ~= opt.id then
+                            changed = true
+                            break
+                        end
+                    end
+                end
+                if changed then
+                    element.options = options
+                end
+                element.idChosen = ability:GetChosenTargetTypeInDropdown()
+            end,
         }
     )
 

--- a/Draw Steel Ability Editor/NewTriggeredAbilityEditor.lua
+++ b/Draw Steel Ability Editor/NewTriggeredAbilityEditor.lua
@@ -754,7 +754,7 @@ end
 -- than miming a dropdown with modal behaviour. TriggeredAbility.Create
 -- always sets a default trigger id ("losehitpoints"), so the field never
 -- needs an empty state.
-local function makeTriggerEventButton(ability, refreshSection)
+local function makeTriggerEventButton(ability, refreshSection, fireChange)
     return gui.Panel{
         width = "auto",
         height = 30,
@@ -801,7 +801,12 @@ local function makeTriggerEventButton(ability, refreshSection)
                 click = function()
                     openTriggerEventPicker(ability.trigger, function(triggerId)
                         ability.trigger = triggerId
+                        -- refreshSection() rebuilds the Trigger section so the
+                        -- event label updates; fireChange() fires refreshAbility
+                        -- tree-wide so the Target Type dropdown in the Setup
+                        -- section recomputes its valid options for the new event.
                         refreshSection()
+                        if fireChange ~= nil then fireChange() end
                     end)
                 end,
             },
@@ -828,7 +833,7 @@ local function buildTriggerSection(ability, refreshSection, fireChange)
 
     -- Trigger Event -- categorized picker modal (phase 2).
     children[#children + 1] = fieldRow("Trigger Event",
-        makeTriggerEventButton(ability, refreshSection))
+        makeTriggerEventButton(ability, refreshSection, fireChange))
 
     -- Trigger Subject
     children[#children + 1] = fieldRow("Trigger Subject",
@@ -840,7 +845,10 @@ local function buildTriggerSection(ability, refreshSection, fireChange)
             idChosen = ability:try_get("subject", "self"),
             change = function(element)
                 ability.subject = element.idChosen
+                -- Subject also gates valid target types (e.g. "subject"),
+                -- so refresh the Setup section's Target dropdown tree-wide.
                 refreshSection()
+                if fireChange ~= nil then fireChange() end
             end,
         },
         "Who the editor is listening for the trigger event to occur on.")
@@ -2401,6 +2409,35 @@ local function buildMechanicalView(ability)
         subjectChip = "Never fires"
     end
     addRow("Subject", subjectId, subjectChip)
+
+    -- Target. The set of valid target types is gated by the trigger event
+    -- (and subject) via each TargetTypes entry's condition(). A target picked
+    -- for one event can therefore become invalid after the event is changed,
+    -- silently producing a trigger that targets nothing valid. Surface the
+    -- chosen target and warn (amber) when it is no longer valid for the event.
+    local chosenTargetId = ability:GetChosenTargetTypeInDropdown()
+    local validTargetOptions = ability:GetDisplayedTargetTypeOptions()
+    local targetLabel
+    local targetValid = false
+    for _, opt in ipairs(validTargetOptions) do
+        if opt.id == chosenTargetId then
+            targetLabel = opt.text
+            targetValid = true
+            break
+        end
+    end
+    if not targetValid then
+        -- Not valid for the current event: still describe what is selected by
+        -- scanning the unfiltered target-type list (condition ignored).
+        for _, opt in ipairs(ability.TargetTypes or {}) do
+            if opt.id == chosenTargetId then
+                targetLabel = opt.text
+                break
+            end
+        end
+    end
+    addRow("Target", targetLabel or chosenTargetId or "(unset)",
+        (not targetValid) and { text = "Invalid for event", class = "bgWarning" } or nil)
 
     -- Triggers When (condition). Two failure modes:
     --   * Compile error -- formula is malformed.


### PR DESCRIPTION
## Summary
Fixes two reported bugs where editor UI showed stale state until the
window was closed and reopened. (1) The New Triggered Ability Editor did
not refresh the Target Type options when the trigger event changed,
allowing a trigger to be saved with a target invalid for its event. (2)
Renaming a feature on a character did not update the name in the character
panel until the sheet was reopened.

## Changes
- **Triggered editor:** Target Type dropdown recomputes its valid options
  on `refreshAbility` (no-op when the set is unchanged, so the regular
  Ability Editor is unaffected); the trigger-event and subject callbacks
  now fire `refreshAbility` tree-wide so options update immediately.
- **Triggered editor:** Added a Target row to the "How This Triggers" card
  with a theme-driven warning chip ("Invalid for event") when the chosen
  target is not valid for the current event; it counts toward the card's
  issue rollup.
- **Character sheet:** Confirm/Cancel in the feature editor now use
  `FireEventTree('modifierRefreshed')` so the refresh reaches the handler
  on the inner scroll panel (the themed wrapper was swallowing the plain
  `FireEvent`). Cancel reverts a name the live poll had already pushed.

## Testing
Manually verified in-game (Build 7, F4 reload):
- Triggered editor: changed trigger event with a previously-valid target
  selected; Target options updated immediately and the amber "Invalid for
  event" chip appeared on the now-invalid target.
- Feature rename: confirmed with and without blurring the name field
  first; panel name updated on Confirm. Cancel reverts the change.

## Notes for reviewer
- The Target Type dropdown lives in `AbilityEditor.BuildTargetingSection`,
  shared with the regular Ability Editor. The `refreshAbility` handler only
  reassigns options when the id-set actually changes; for non-triggered
  abilities the option list is static (base `TargetTypes` has no
  `condition`), so it is a verified no-op there.
- Per the "inform, don't enforce" approach, an invalid target is flagged
  with a chip rather than auto-corrected.