### PR TITLE
Damage Immunity status icon + surface conditional immunities on Winded hover

### DIFF
--- a/DMHub Game Rules/CharacterModifier.lua
+++ b/DMHub Game Rules/CharacterModifier.lua
@@ -1049,6 +1049,25 @@ CharacterModifier.TypeInfo.resistance = {
 		end
 	end,
 
+	fillStatusIcons = function(self, creature, result)
+		if self:try_get("displayIcon", false) and self:has_key("statusIcon") then
+			local hoverText = self.name
+			local description = self:try_get("description", "")
+			if description ~= "" then
+				hoverText = string.format("<b>%s</b>\n%s", self.name, description)
+			end
+			result[#result+1] = {
+				id = self.name,
+				icon = self.statusIcon,
+				hoverText = hoverText,
+				style = {
+					bgcolor = self:try_get("iconColor", "#ffffffff"),
+				},
+				statusIcon = true,
+			}
+		end
+	end,
+
 	createEditor = function(modifier, element)
 		local Refresh
 		local firstRefresh = true
@@ -1351,6 +1370,58 @@ CharacterModifier.TypeInfo.resistance = {
 							Refresh()
 						end
 					end
+				}
+			end
+
+			children[#children+1] = gui.Check{
+				styles = ThemeEngine.GetStyles(),
+				text = "Display Icon When Active",
+				value = modifier:try_get("displayIcon", false),
+				change = function(element)
+					modifier.displayIcon = element.value
+					Refresh()
+				end,
+			}
+
+			if modifier:try_get("displayIcon", false) then
+				children[#children+1] = gui.Panel{
+					width = "auto",
+					height = "auto",
+					flow = "horizontal",
+					gui.IconEditor{
+						library = "ongoingEffects",
+						bgcolor = modifier:try_get("iconColor", "#ffffffff"),
+						margin = 10,
+						width = 48,
+						height = 48,
+						halign = "left",
+						value = modifier:try_get("statusIcon", "none"),
+						change = function(element)
+							modifier.statusIcon = element.value
+							Refresh()
+						end,
+						iconcolor = function(element, color)
+							element.selfStyle.bgcolor = color
+						end,
+					},
+					gui.ColorPicker{
+						value = modifier:try_get("iconColor", "#ffffffff"),
+						hmargin = 8,
+						width = 24,
+						height = 24,
+						halign = "left",
+						valign = "center",
+						borderWidth = 2,
+						borderColor = '#999999ff',
+
+						confirm = function(element)
+							modifier.iconColor = element.value
+							Refresh()
+						end,
+						change = function(element)
+							element.parent.parent:FireEventTree("iconcolor", element.value)
+						end,
+					},
 				}
 			end
 

--- a/Draw Steel UI/DrawSteelTokenHud.lua
+++ b/Draw Steel UI/DrawSteelTokenHud.lua
@@ -40,7 +40,34 @@ TokenUI.RegisterIcon{
 	    return (not creature.minion) and creature.damage_taken >= maxhp/2 and creature.damage_taken < maxhp and dmhub.GetSettingValue("showwoundedicon")
     end,
 
-    hoverText = "Winded",
+    --Computed live on hover. Appends any active *conditional* Damage Immunity
+    --modifiers (those with a filter condition, e.g. "while winded"). This lets
+    --traits like Defiant Anger surface in the winded tooltip without needing
+    --their own token icon, keeping the token uncluttered. Permanent/always-on
+    --immunities (no filter) are excluded so they don't spam this tooltip.
+    --GetActiveModifiers only returns modifiers whose filter currently passes,
+    --so anything listed here is genuinely active right now.
+    hoverText = function(creature)
+        local hoverText = "Winded"
+        local extra = {}
+        for _,modInfo in ipairs(creature:GetActiveModifiers()) do
+            local m = modInfo.mod
+            if m.behavior == "resistance" and m:HasFilter() then
+                local desc = m:try_get("description", "")
+                if desc ~= "" then
+                    extra[#extra+1] = string.format("<b>%s</b>\n%s", m.name, desc)
+                else
+                    extra[#extra+1] = string.format("<b>%s</b>", m.name)
+                end
+            end
+        end
+
+        if #extra > 0 then
+            hoverText = hoverText .. "\n\n" .. table.concat(extra, "\n\n")
+        end
+
+        return hoverText
+    end,
 
     --Only show to those who can't see the health bar.
     showToAll = true,


### PR DESCRIPTION
## Summary

Two related quality-of-life improvements for Draw Steel monster traits that grant conditional damage immunity (e.g. the Ogre Juggernaut's **Defiant Anger**: "while winded, the juggernaut has damage immunity 2").

### `DMHub Game Rules/CharacterModifier.lua`
Adds a **"Display Icon When Active"** option to the **Damage Immunity** (`resistance`) modifier, mirroring the existing **Modify Attribute** behavior:
- New checkbox + icon picker + color picker in the modifier editor.
- New `fillStatusIcons` so the chosen icon renders in the token's status-icon strip while the modifier is active. Its hover tooltip is built from the modifier name and description.

### `Draw Steel UI/DrawSteelTokenHud.lua`
The **Winded** token icon's hover text now appends any active **conditional** damage-immunity modifiers (those with a filter condition, e.g. "while winded"), computed live on hover. This explains to players *why* damage is being reduced, without requiring the trait to display its own token icon -- keeping the token uncluttered. Permanent/always-on immunities (no filter) are excluded so they don't spam the tooltip.

Because both paths read `creature:GetActiveModifiers()`, which only returns modifiers whose filter currently passes, the icon and the appended text appear only while the immunity is genuinely in effect.

## Testing
- Reloaded Lua in DMHub (F4); 42 mods reloaded cleanly.
- Verified the icon appears/clears on the token as the creature crosses the winded threshold.
- Verified the Defiant Anger text appears under the Winded icon's tooltip whether or not "Display Icon When Active" is ticked.