### PR TITLE
Expose forced-movement distance and melee flag on the Force Moved trigger

### DIFF
--- a/DMHub Game Rules/AbilityRelocateCreature.lua
+++ b/DMHub Game Rules/AbilityRelocateCreature.lua
@@ -368,6 +368,14 @@ function ActivatedAbilityRelocateCreatureBehavior:Cast(ability, casterToken, tar
 
             --make forced movement happen after the movement so they are in the new location.
             if forcemoveEvent ~= nil then
+                --Expose how far the creature was actually moved and whether the forcing
+                --ability had the Melee keyword, so triggered abilities (e.g. the Orc
+                --Chainlock's "Chain Link") can react to melee forced movement and reuse
+                --the distance. path.numSteps is the real distance moved -- it may be less
+                --than requested if the path was blocked. ability is the forced-movement
+                --clone, which InvokeAbility populates with the parent ability's keywords.
+                forcemoveEvent.distance = math.floor((path ~= nil and path.numSteps) or 0)
+                forcemoveEvent.melee = ability.keywords ~= nil and ability.keywords["Melee"] == true
                 casterToken.properties:DispatchEvent("forcemove", forcemoveEvent)
             end
 

--- a/DMHub Game Rules/TriggeredAbility.lua
+++ b/DMHub Game Rules/TriggeredAbility.lua
@@ -124,7 +124,7 @@ TriggeredAbility.TargetTypes = {
 		id = 'attacker',
 		text = 'Creature Attacking Me',
 		condition = function(ability)
-			return ability.trigger == "attacked" or ability.trigger == "hit" or ability.trigger == "losehitpoints" or ability.trigger == "inflictcondition" or ability.trigger == "winded" or ability.trigger == "dying"
+			return ability.trigger == "attacked" or ability.trigger == "hit" or ability.trigger == "losehitpoints" or ability.trigger == "inflictcondition" or ability.trigger == "winded" or ability.trigger == "dying" or ability.trigger == "forcemove"
 		end,
 	},
 	{
@@ -349,10 +349,20 @@ TriggeredAbility.triggers = {
 				type = "creature",
 				desc = "The creature who is causing the forced move to occur. Only valid if Has Attacker is true.",
 			},
-            {
+            vertical = {
                 name = "Vertical",
                 type = "boolean",
                 desc = "True if the forced movement is vertical.",
+            },
+            distance = {
+                name = "Distance",
+                type = "number",
+                desc = "The number of squares the creature was actually force moved.",
+            },
+            melee = {
+                name = "Melee",
+                type = "boolean",
+                desc = "True if the ability that forced the movement had the Melee keyword.",
             },
 		}
     },


### PR DESCRIPTION
## Summary

The **Force Moved** (`forcemove`) triggered-ability event previously exposed only `Type`, `Has Attacker`, and `Attacker`. There was no way for a triggered ability to know **how far** the creature was force moved, or whether the **forcing ability was melee** -- so reactive traits that depend on those facts could not be authored in the ability editor.

This PR enriches the `forcemove` event so both become first-class GoblinScript symbols, and enables targeting the attacker for that trigger.

## Changes

- **`AbilityRelocateCreature.lua`**: when the `forcemove` event fires, attach:
  - `distance` -- the actual squares moved (`path.numSteps`, which reflects a path that was cut short by collisions).
  - `melee` -- whether the forcing ability had the `Melee` keyword (read from the forced-movement clone, which inherits the parent ability's keywords).
- **`TriggeredAbility.lua`**:
  - Register `Distance` and `Melee` symbols on the `forcemove` trigger (and give the existing `Vertical` entry a proper key so it actually resolves).
  - Allow the **Attacker** target type for `forcemove` (runtime already supported `targetType == "attacker"`; this exposes it in the editor's Target Type dropdown).

All changes are additive -- existing `forcemove` triggers are unaffected.

## Motivation

Enables the Orc Chainlock's **Chain Link** trait ("Whenever the chainlock is force moved by a creature's melee ability, the creature is pulled the same distance towards the chainlock") to be built entirely in the ability editor:

- Trigger: Force Moved; Triggers Only When: `Has Attacker and Melee`
- Target Type: Creature Attacking Me (the attacker)
- Behavior: Draw Steel Command rule `pull {Distance}`

## Testing

Not yet hot-reloaded in a running DMHub instance (none was running during development). Changes are additive and syntactically straightforward; recommend an F4 reload + a quick in-game check that the `Distance`/`Melee` symbols appear in the trigger's "Triggers Only When" help and that the Chain Link pull fires correctly.