### PR TITLE
fix(summon): measure placement range from full token footprint

### DIFF
--- a/DMHub Game Rules/AbilitySummon.lua
+++ b/DMHub Game Rules/AbilitySummon.lua
@@ -805,8 +805,11 @@ end
 function ActivatedAbilitySummonBehavior.PromptPlacementLoc(casterToken, rangeTiles, index, total, isMinion, squadCtx, creatureCtx, ability)
     local SQUAD_CAP = 8
 
-    local origin = casterToken.loc
-    local validLocs = origin:LocsInRadius(rangeTiles)
+    --measure range from the token's full footprint, not just its anchor square.
+    --GetLocsWithinRadius includes every tile the token occupies, so Size 2+ casters
+    --radiate range from all their squares instead of only the bottom-left corner.
+    local validLocs = casterToken:GetLocsWithinRadius(rangeTiles)
+    local occupiedLocs = casterToken:LocsOccupyingWhenAt(casterToken.loc)
 
     local pickedLoc = nil
     local pickedSquadResult = nil
@@ -827,7 +830,15 @@ function ActivatedAbilitySummonBehavior.PromptPlacementLoc(casterToken, rangeTil
     end
 
     local function isInRange(loc)
-        return loc ~= nil and origin:DistanceInTiles(loc) <= rangeTiles
+        if loc == nil then
+            return false
+        end
+        for _,o in ipairs(occupiedLocs) do
+            if o:DistanceInTiles(loc) <= rangeTiles then
+                return true
+            end
+        end
+        return false
     end
 
     local pickerContent


### PR DESCRIPTION
## Summary
The Summon Creatures behavior's manual placement picker measured its range from the caster's anchor tile only (the bottom-left square of the token). For Size 1 casters this is invisible, but Size 2+ casters got a range overlay offset toward that corner instead of radiating from their whole footprint. This fix measures range from every tile the caster occupies.

## Changes
- `PromptPlacementLoc` now builds the valid-loc overlay from `casterToken:GetLocsWithinRadius(rangeTiles)` (footprint-aware) instead of `origin:LocsInRadius(rangeTiles)`.
- The `isInRange` hover check now returns true if the tile is within range of any occupied square (min-distance over `LocsOccupyingWhenAt`), instead of the single anchor tile.

## Testing
- Verified in-game with a Size 3 caster: green range overlay now radiates evenly from all of the token's squares.
- Size 1 casters render identically to before (footprint collapses to the single anchor tile, so the logic is byte-for-byte equivalent).

## Notes for reviewer
Range here is advisory only -- `mappress` never gated placement on `isInRange`, so this is a presentation/overlay fix with no change to placement gating.