### PR TITLE
fix(dockable): floating panels broadcast maximize/minimize so child content reveals

### DIFF
--- a/DMHub Core UI/DefaultStyles.lua
+++ b/DMHub Core UI/DefaultStyles.lua
@@ -1187,6 +1187,14 @@ ThemeEngine.RegisterTheme{
             selectors = {"panel", "buttonIcon", "parent:settingsButton"},
             bgimage = "panels/gamescreen/settings.png",
         },
+        {
+            selectors = {"panel", "buttonIcon", "parent:maximizeButton"},
+            bgimage = "panels/hud/down-arrow.png",
+        },
+        {
+            selectors = {"panel", "buttonIcon", "parent:maximizeButton", "parent:maximized"},
+            scale = {x = 1, y = -1},
+        },
         -- pagingArrow: the canonical previous/next paging chevron.
         -- Use `gui.Button{ classes = {"pagingArrow"} }` for the left arrow and
         -- `gui.Button{ classes = {"pagingArrow", "right"} }` for the right

--- a/DMHub Core UI/DockablePanel.lua
+++ b/DMHub Core UI/DockablePanel.lua
@@ -332,6 +332,12 @@ function GameHud:CreateSingleDock(params)
 
             if floating then
                 container:FireEvent("minimizeFloating")
+                -- Mirror the maximize floating path: broadcast minimize so
+                -- child panels re-collapse their content, without the docked
+                -- fitChildren layout work.
+                container:SetClassTree("maximized", false)
+                container:FireEventTree("minimize")
+                element.data.maximizedChild = nil
                 return
             end
 
@@ -374,6 +380,14 @@ function GameHud:CreateSingleDock(params)
 
             if floating then
                 container:FireEvent("maximizeFloating")
+                -- A floating panel has no siblings to collapse and resizes
+                -- itself via maximizeFloating, so skip the dock fitChildren
+                -- work. But still broadcast the maximize event/class the same
+                -- way the docked path does, so child panels that reveal their
+                -- content on maximize (e.g. the audio sound browser) react.
+                container:SetClassTree("maximized", true)
+                container:FireEventTree("maximize")
+                element.data.maximizedChild = child
                 return
             end
 

--- a/DMHub Core UI/Gui.lua
+++ b/DMHub Core UI/Gui.lua
@@ -198,6 +198,7 @@ gui.iconButtonClasses = {
 			actionText = "Delete",
 		},
 	},
+	maximizeButton = {},
 	pagingArrow = {},
 	settingsButton = {},
 }
@@ -4883,24 +4884,18 @@ end
 --- A panel suitable for maximizing a dockable panel.
 --- @return Panel
 function gui.DockablePanelMaximizeButton()
-	return gui.Panel{
-		bgimage = "panels/hud/down-arrow.png",
-		width = 256/8,
-		height = 128/8,
-		bgcolor = "white",
+	-- Themed icon button: the "maximizeButton" kind paints the down-arrow on
+	-- the inner buttonIcon (tinted @fg so it follows the active scheme) and
+	-- the "maximized" class flips it vertically. Hover/press feedback comes
+	-- from the shared iconButton chrome rules. width/height stay inline as
+	-- layout: the arrow art is 2:1, so the button is wider than it is tall.
+	return gui.Button{
+		classes = {"maximizeButton"},
+		width = 32,
+		height = 16,
 		halign = "center",
 		valign = "top",
 		vmargin = 4,
-		styles = {
-			{
-				selectors = {"hover"},
-				brightness = 1.5,
-			},
-			{
-				selectors = {"maximized"},
-				scale = {x = 1, y = -1},
-			},
-		},
 
 		minimize = function(element)
 			element:SetClass("maximized", false)


### PR DESCRIPTION
## Problem
Undock the audio panel, press the maximize arrow -> nothing appears. The
sound-browser section stays collapsed.

## Root cause
The maximize button fires `maximizeChild` up the dock tree. The docked
path broadcasts `FireEventTree("maximize")`, which the audio sound
browser listens for to un-collapse itself (`Audio.lua:1196`). The
**floating** path in `DockablePanel.lua` returned early after
`maximizeFloating` (window resize only), so that broadcast never fired.
`minimizeChild` had the same gap.

## Fix
- `DockablePanel.lua`: floating `maximizeChild`/`minimizeChild` now also
  set the `maximized` class tree, fire the `maximize`/`minimize` event
  tree, and update `maximizedChild` -- mirroring the docked path minus
  the dock-only `fitChildren`/sibling-collapse.

## Drive-by (requested): retheme the maximize button
- `Gui.lua`: `gui.DockablePanelMaximizeButton` is now a themed
  `gui.Button{ classes = {"maximizeButton"} }`; registered the
  `maximizeButton` icon-button kind.
- `DefaultStyles.lua`: kind rules paint `down-arrow.png` (tinted `@fg`,
  vertical flip on `maximized`). Arrow now follows the active theme
  instead of hardcoded white.

Both callsites (`Audio.lua`, `ClipboardPanel.lua`) call with no args --
unchanged. Theme cascade was already present via the dock container
(`DockablePanel.lua:628`).
