### PR TITLE
fix(abilities): hide summon-only fields from transform editor

### DIFF
--- a/DMHub Game Rules/AbilitySummon.lua
+++ b/DMHub Game Rules/AbilitySummon.lua
@@ -2001,14 +2001,16 @@ function ActivatedAbilityBehavior:SummonEditor(parentPanel, list, options)
 		end,
 	}
 
-	list[#list+1] = gui.Check{
-		text = "Change Creature Choice While Casting",
-		value = self.changeCreatureWhileCasting,
-        minWidth = 300,
-		change = function(element)
-			self.changeCreatureWhileCasting = element.value
-		end,
-	}
+	if not options.haveTargetCreature then
+		list[#list+1] = gui.Check{
+			text = "Change Creature Choice While Casting",
+			value = self.changeCreatureWhileCasting,
+	        minWidth = 300,
+			change = function(element)
+				self.changeCreatureWhileCasting = element.value
+			end,
+		}
+	end
 
 	list[#list+1] = gui.Check{
 		text = "All creatures the same",
@@ -2037,24 +2039,24 @@ function ActivatedAbilityBehavior:SummonEditor(parentPanel, list, options)
                 self.groupInitiativeWithCaster = element.value
             end,
         }
+
+        list[#list+1] = gui.Check{
+            text = "Summons Share Surges",
+            minWidth = 300,
+            value = self.shareSurgesWithSummoner,
+            change = function(element)
+                self.shareSurgesWithSummoner = element.value
+            end,
+        }
+
+        list[#list+1] = gui.Check{
+            text = "Summons Share Heroic Resource",
+            minWidth = 300,
+            value = self.shareHeroicResourceWithSummoner,
+            change = function(element)
+                self.shareHeroicResourceWithSummoner = element.value
+            end,
+        }
 	end
-
-    list[#list+1] = gui.Check{
-        text = "Summons Share Surges",
-        minWidth = 300,
-        value = self.shareSurgesWithSummoner,
-        change = function(element)
-            self.shareSurgesWithSummoner = element.value
-        end,
-    }
-
-    list[#list+1] = gui.Check{
-        text = "Summons Share Heroic Resource",
-        minWidth = 300,
-        value = self.shareHeroicResourceWithSummoner,
-        change = function(element)
-            self.shareHeroicResourceWithSummoner = element.value
-        end,
-    }
 
 end


### PR DESCRIPTION
## Summary
Adding the Transform Creatures behavior to an ability crashed the editor with
`Attempt to read unknown field changeCreatureWhileCasting` and rendered no
fields. The shared `SummonEditor` rendered three summon-only checkboxes outside
any option gate; the Transform behavior reuses `SummonEditor` but neither
declares nor reads those fields at runtime, so the strict game-type metatable
errored on the read and aborted the editor build.

## Changes
- Gate "Change Creature Choice While Casting" behind `not options.haveTargetCreature` (shown for Summon, hidden for Transform).
- Move "Summons Share Surges" and "Summons Share Heroic Resource" inside the existing `if options.casterControls then` block (only Summon passes `casterControls`).

## Testing
- Verified on a fresh DMHub launch via live Lua: Transform `EditorItems` builds with no error (12 to 9 items, the three checkboxes removed); direct reads of the three fields off the Transform type now error, confirming they are genuinely undeclared and the gating is what prevents the crash.
- Summon `EditorItems` unchanged (14 items, all three controls still present and functional).
- Console clean of `unknown field` errors.
- Manually confirmed in-app: Transform Creatures behavior editor renders correctly with the three checkboxes absent.

## Notes for reviewer
The Transform runtime never consumes `changeCreatureWhileCasting`, `shareSurgesWithSummoner`, or `shareHeroicResourceWithSummoner` (those are read only in `AbilitySummon.lua`), so hiding them from the Transform editor removes misleading no-op controls rather than dropping functionality. Summon behavior is byte-for-byte unchanged in effect.