### PR TITLE
fix(abilities): apply purge-effects self-damage for effects, not just conditions

### DIFF
--- a/DMHub Game Rules/AbilityPurgeEffects.lua
+++ b/DMHub Game Rules/AbilityPurgeEffects.lua
@@ -399,9 +399,11 @@ function ActivatedAbilityPurgeEffectsBehavior:Cast(ability, casterToken, targets
                             end
                         end
 
-                        -- damageToSelf: applied once per target when conditions were selected,
-                        -- matching original behaviour (lines 397-400 in CastOnTarget).
-                        if purgedConditionsCount > 0 and self.damageToSelf ~= "" then
+                        -- damageToSelf: applied once per target whenever at least one
+                        -- effect or condition was purged (we are already inside
+                        -- `if #selectedItems > 0`).  Matches the once-per-target behaviour
+                        -- of the conditions-only path in CastOnTarget.
+                        if self.damageToSelf ~= "" then
                             local damage = tonumber(self.damageToSelf)
                             if damage ~= nil and damage > 0 then
                                 data.token.properties:TakeDamage(damage, "Purged condition")


### PR DESCRIPTION
## Summary
The Purge Ongoing Effects behavior (`ActivatedAbilityPurgeEffectsBehavior`) has a `damageToSelf` option used for abilities like "take 10 damage to end one save-ends effect on you." In the unified purge dialog path (`purgeType = one` / `chosen`), the effect was removed correctly but the self-damage was never applied when running in `conditions_and_effects` mode.

## Root cause
The damage was gated on `purgedConditionsCount > 0`. That counter only increments for purged items of type `"condition"`, which is produced exclusively in `mode == "conditions"`. In `conditions_and_effects` mode, purged items are typed `"effect"` or `"conditionOnly"`, so the counter stayed at `0` and the damage block never ran -- even though the effect/condition itself was removed.

## Changes
- `DMHub Game Rules/AbilityPurgeEffects.lua`: gate `damageToSelf` on having purged at least one item instead of `purgedConditionsCount > 0`. The block is already nested inside `if #selectedItems > 0`, so damage now applies once per target whenever anything (condition, effect, or condition-only) is purged. This matches the once-per-target behaviour of the conditions-only path in `CastOnTarget`.

## Testing
- Tested in-game with an "Instant Solo" creature template's End Effect (`mode = conditions_and_effects`, `purgeType = one`, `damageToSelf = 10`): the save-ends effect is now removed AND the creature takes the damage.
- Confirmed damage applies once per target for a single selected effect.

## Notes for reviewer
- Scope is limited to the unified dialog path (`purgeType` `one` / `chosen`). The `purgeType = all` path (which routes through `CastOnTarget`) still applies no self-damage for effects in `conditions_and_effects` mode -- left unchanged here since "take damage to end effects" implies a player choice. Happy to address that separately if wanted.
- `purgedConditionsCount` is still computed and still feeds the `purgedConditions` GoblinScript symbol; only the damage gate changed.