### PR TITLE
feat(goblinscript): add Includes Condition Rider creature symbol

### DIFF
--- a/DMHub Game Rules/Creature.lua
+++ b/DMHub Game Rules/Creature.lua
@@ -7299,6 +7299,13 @@ creature.helpSymbols = {
 		examples = {"OBJ.Count Riders('goblin', 'crafty')"},
 	},
 
+	hasconditionrider = {
+		name = "Has Condition Rider",
+		type = "function",
+		desc = "A function given a condition name and a condition rider name; true if the creature has that condition with that rider attached. The rider name may be omitted to test for any rider on the named condition.",
+		examples = {"OBJ.Has Condition Rider(\"Grabbed\", \"Let's Tussle\")"},
+	},
+
 	level = {
 		name = "Level",
 		type = "number",
@@ -7937,6 +7944,34 @@ creature.lookupSymbols = {
 	countnearbycreatures = countnearbycreatures,
 
     countriders = countriders,
+
+	hasconditionrider = function(c)
+		return function(conditionName, riderName)
+			conditionName = string.lower(conditionName)
+			riderName = riderName ~= nil and string.lower(riderName) or nil
+			local inflicted = c:try_get("inflictedConditions")
+			if inflicted == nil then
+				return false
+			end
+			local conditionsTable = GetTableCached(CharacterCondition.tableName)
+			local ridersTable = GetTableCached(CharacterCondition.ridersTableName)
+			for condid, entry in pairs(inflicted) do
+				local condInfo = conditionsTable[condid]
+				if condInfo ~= nil and string.lower(condInfo.name) == conditionName and entry.riders ~= nil then
+					if riderName == nil then
+						return #entry.riders > 0
+					end
+					for _, riderid in ipairs(entry.riders) do
+						local riderInfo = ridersTable[riderid]
+						if riderInfo ~= nil and string.lower(riderInfo.name) == riderName then
+							return true
+						end
+					end
+				end
+			end
+			return false
+		end
+	end,
 
 	summoned = function(c)
 		local token = dmhub.LookupToken(c)

--- a/DMHub Game Rules/Creature.lua
+++ b/DMHub Game Rules/Creature.lua
@@ -7299,11 +7299,11 @@ creature.helpSymbols = {
 		examples = {"OBJ.Count Riders('goblin', 'crafty')"},
 	},
 
-	hasconditionrider = {
-		name = "Has Condition Rider",
+	includesconditionrider = {
+		name = "Includes Condition Rider",
 		type = "function",
 		desc = "A function given a condition name and a condition rider name; true if the creature has that condition with that rider attached. The rider name may be omitted to test for any rider on the named condition.",
-		examples = {"OBJ.Has Condition Rider(\"Grabbed\", \"Let's Tussle\")"},
+		examples = {"OBJ.Includes Condition Rider(\"Grabbed\", \"Let's Tussle\")"},
 	},
 
 	level = {
@@ -7945,7 +7945,7 @@ creature.lookupSymbols = {
 
     countriders = countriders,
 
-	hasconditionrider = function(c)
+	includesconditionrider = function(c)
 		return function(conditionName, riderName)
 			conditionName = string.lower(conditionName)
 			riderName = riderName ~= nil and string.lower(riderName) or nil


### PR DESCRIPTION
## Summary

Adds a new GoblinScript creature function, **`Has Condition Rider`**, that tests whether a creature has a named condition with a specific condition rider attached.

Previously there was no way in GoblinScript to detect a condition rider. The `Conditions` set only exposes condition names, `Ongoing Effects` only exposes active ongoing-effect names, and condition riders are stored separately on `inflictedConditions[conditionid].riders`. This left filters like Modify Power Rolls unable to distinguish, e.g., a Grabbed condition carrying the **Let's Tussle** rider from a plain Grabbed.

## Usage

```
Target.Has Condition Rider("Grabbed", "Let's Tussle")
```

The rider name may be omitted to test for any rider on the named condition:

```
Target.Has Condition Rider("Grabbed")
```

## Implementation

- Registers the `hasconditionrider` symbol info (name "Has Condition Rider", function type) alongside `Count Riders`.
- Adds the implementation, which walks the creature's `inflictedConditions`, matches the named condition, then matches the named rider against the `conditionRiders` table. Comparisons are case-insensitive, consistent with other condition/effect symbols.