### PR TITLE
feat(villain-actions): add right-click reset and use-anyway override

### DIFF
--- a/Draw Steel Core Rules/DSResources.lua
+++ b/Draw Steel Core Rules/DSResources.lua
@@ -116,6 +116,15 @@ function VillainActionState.MarkUsed(tokenid, villainActionKey)
     doc:CompleteChange("Villain Action used: " .. villainActionKey)
 end
 
+function VillainActionState.ClearUsed(tokenid, villainActionKey)
+    if tokenid == nil or villainActionKey == nil then return end
+    local doc = mod:GetDocumentSnapshot(VillainActionState.docId)
+    if doc.data.used == nil or doc.data.used[tokenid] == nil then return end
+    doc:BeginChange()
+    doc.data.used[tokenid][villainActionKey] = nil
+    doc:CompleteChange("Villain Action reset: " .. villainActionKey, {undoable = false})
+end
+
 function VillainActionState.ClearForToken(tokenid)
     if tokenid == nil then return end
     local doc = mod:GetDocumentSnapshot(VillainActionState.docId)

--- a/Draw Steel Core Rules/MCDMInitiativeBar.lua
+++ b/Draw Steel Core Rules/MCDMInitiativeBar.lua
@@ -1307,6 +1307,42 @@ local g_vaStripStyles = {
     },
 }
 
+-- Fire a villain action's ability off-turn: pan to the caster, show the
+-- dramatic banner, then invoke the ability via the action bar after the
+-- banner finishes. Shared by the drawer's normal click (gated) and the
+-- right-click "Use anyway" override (ungated), so both paths run the exact
+-- same cast pipeline.
+local function InvokeVillainAction(token, ability)
+    if token == nil or ability == nil or not token.valid then return end
+
+    -- Pan camera to the caster (fire-and-forget; near-instant).
+    dmhub.CenterOnToken(token.charid, {smooth=true})
+
+    -- Build subtitle from the villainAction field with roman numerals.
+    local subtitle = ability:try_get("villainAction") or ""
+    subtitle = string.gsub(subtitle, "3", "III")
+    subtitle = string.gsub(subtitle, "2", "II")
+    subtitle = string.gsub(subtitle, "1", "I")
+
+    DramaticBanner.Show{
+        tokenid = token.charid,
+        text = ability.name or "",
+        subtitle = subtitle,
+    }
+
+    -- After the banner finishes, invoke the ability off-turn via the action
+    -- bar's invokeAbility event. This pushes the caster onto the action bar's
+    -- caster stack and runs the normal cast pipeline (target selection,
+    -- behaviors) without advancing the initiative queue's currentTurn.
+    local delay = DramaticBanner.TimeUntilDone() + 0.2
+    dmhub.Schedule(delay, function()
+        if mod.unloaded then return end
+        if token == nil or not token.valid then return end
+        if gamehud == nil or gamehud.actionBarPanel == nil then return end
+        gamehud.actionBarPanel:FireEventTree("invokeAbility", token, ability, {}, nil, {})
+    end)
+end
+
 local function CreateVillainActionDrawer(slotKey, slotNumeral)
     local m_token = nil
     local m_ability = nil
@@ -1424,38 +1460,53 @@ local function CreateVillainActionDrawer(slotKey, slotNumeral)
             -- Gate: drawer is unavailable if this VA is already consumed
             -- this encounter, or if the per-round VA budget is spent.
             -- The hover tooltip above explains which gate is blocking.
+            -- Right-click "Use anyway" bypasses both gates (see below).
             if VillainActionState.HasUsed(m_token.charid, slotKey) then return end
             if CharacterResource.GetVillainActions() <= 0 then return end
 
-            -- Pan camera to the caster (fire-and-forget; near-instant).
-            dmhub.CenterOnToken(m_token.charid, {smooth=true})
+            InvokeVillainAction(m_token, m_ability)
+        end,
 
-            -- Build subtitle from the villainAction field with roman numerals.
-            local subtitle = m_ability:try_get("villainAction") or ""
-            subtitle = string.gsub(subtitle, "3", "III")
-            subtitle = string.gsub(subtitle, "2", "II")
-            subtitle = string.gsub(subtitle, "1", "I")
+        -- Right-click override menu (director only). Gives a way out of the
+        -- "already used this encounter" / spent-budget state when a cast
+        -- failed to resolve or needs to be redone, without removing the
+        -- normal gating. "Use anyway" fires regardless of the gates; "Reset"
+        -- un-consumes the slot so the drawer lights up and left-click works
+        -- again (the monitored VillainActionState doc auto-refreshes it).
+        rightClick = function(element)
+            if m_token == nil or m_ability == nil or not m_token.valid then return end
+            if not CanControlInitiative() then return end
 
-            DramaticBanner.Show{
-                tokenid = m_token.charid,
-                text = m_ability.name or "",
-                subtitle = subtitle,
-            }
-
-            -- After the banner finishes, invoke the ability off-turn via
-            -- the action bar's invokeAbility event. This pushes the caster
-            -- onto the action bar's caster stack and runs the normal cast
-            -- pipeline (target selection, behaviors) without advancing the
-            -- initiative queue's currentTurn.
             local token = m_token
             local ability = m_ability
-            local delay = DramaticBanner.TimeUntilDone() + 0.2
-            dmhub.Schedule(delay, function()
-                if mod.unloaded then return end
-                if token == nil or not token.valid then return end
-                if gamehud == nil or gamehud.actionBarPanel == nil then return end
-                gamehud.actionBarPanel:FireEventTree("invokeAbility", token, ability, {}, nil, {})
-            end)
+            local consumed = VillainActionState.HasUsed(token.charid, slotKey)
+
+            element.popup = gui.ContextMenu{
+                entries = {
+                    {
+                        text = "Use anyway",
+                        click = function()
+                            element.popup = nil
+                            InvokeVillainAction(token, ability)
+                        end,
+                    },
+                    {
+                        text = "Reset this Villain Action",
+                        click = function()
+                            element.popup = nil
+                            -- Un-consume the encounter slot...
+                            VillainActionState.ClearUsed(token.charid, slotKey)
+                            -- ...and restore the per-round VA budget if it
+                            -- was spent, so the drawer is fully clickable
+                            -- again via the normal path rather than just lit.
+                            if CharacterResource.GetVillainActions() <= 0 then
+                                CharacterResource.SetVillainActions(1, "Villain Action reset")
+                            end
+                        end,
+                        hidden = not consumed,
+                    },
+                },
+            }
         end,
     }
 end


### PR DESCRIPTION
## Summary
The villain action strip greys out a slot once it has been used this encounter (or once the per-round VA budget is spent) and offers no way back. When a cast fails to resolve or simply needs to be redone, the director is blocked entirely. This adds a director-only right-click override so the gate informs without trapping.

## Changes
- **Right-click context menu on each villain action drawer** (director-only, gated by `CanControlInitiative()`):
  - **Use anyway** - fires the ability regardless of both gates (encounter-used and per-round budget). Always shown.
  - **Reset this Villain Action** - un-consumes the encounter slot *and* restores the per-round VA budget, so the drawer becomes fully clickable again via the normal path. Shown only when the slot is consumed.
- Extracted the cast pipeline (camera pan -> dramatic banner -> off-turn `invokeAbility`) into a shared `InvokeVillainAction` helper so the gated left-click and the ungated override run identical logic.
- Added `VillainActionState.ClearUsed(tokenid, key)` for the per-slot un-consume (mirrors the existing `ClearForToken`/`ResetAll`). The strip already monitors the `dsVillainActions` document, so a reset auto-refreshes the drawer with no extra plumbing.

## Testing
Verified live in DMHub against an encounter with a villain-action owner (Arixx):
- Clean Lua reload, no errors from either file.
- Consumed slot (drawer I, `HasUsed = true`): right-click menu shows both **Use anyway** and **Reset this Villain Action**.
- Non-consumed slot blocked only by spent round budget (drawer II): menu shows **Use anyway** only; Reset correctly hidden.
- Reset round-trip on the real owner: `HasUsed` true -> false and round budget 0 -> 1; restored to original state afterward so the live encounter was unchanged.
- Did not fire a live "Use anyway" cast to avoid mutating the running session; it reuses the proven left-click pipeline verbatim.

## Notes for reviewer
- Design decision (signed off with the lead): **Reset** restores the per-round budget as well as clearing the slot, since the side's one-VA-per-round budget is the second gate and users expect a reset to make the action usable again, not merely re-lit. **Use anyway** bypasses both gates and is the reliable redo path.
- Keeps the project's "inform, don't enforce" model: the gate still greys the slot; the override is an explicit director choice behind right-click.
- No strip-level "reset all" was added in this pass (kept scope minimal); `ClearForToken` already exists if we want it later.