### PR TITLE
fix(builder): make _safeFeatureName null-safe for instance entries

### DIFF
--- a/Draw Steel Character Builder/CharacterBuilder.lua
+++ b/Draw Steel Character Builder/CharacterBuilder.lua
@@ -501,13 +501,25 @@ end
 --- @param feature table The feature object
 --- @return string The feature name
 function CharacterBuilder._safeFeatureName(feature)
-    local name = feature:try_get("name")
-    if name then
+    -- Safe against plain instance tables (ongoing-effect / condition instances
+    -- set as entry.feature) that lack a try_get method: use the same accessor
+    -- _safeGet does, and guard a missing/short typeName, so the index build for
+    -- a creature carrying such instances never crashes.
+    if feature == nil then
+        return ""
+    end
+
+    local name = CharacterBuilder._safeGet(feature, "name")
+    if type(name) == "string" and name ~= "" then
         return name
     end
 
     -- Extract type name without "Character" prefix
-    local typeName = feature.typeName:sub(10)  -- Remove "Character"
+    local typeName = CharacterBuilder._safeGet(feature, "typeName")
+    if type(typeName) ~= "string" or #typeName < 10 then
+        return ""
+    end
+    typeName = typeName:sub(10)  -- Remove "Character"
 
     -- Add spaces before capitals (except first char)
     return typeName:sub(1, 1) .. typeName:sub(2):gsub("(%u)", " %1")


### PR DESCRIPTION
## Summary
The TAC / character-panel feature categoriser crashes when building its index for any creature carrying an ongoing-effect or condition instance. `_safeFeatureName` called `try_get` directly on those entries, which are plain tables without that method.

## Changes
- `_safeFeatureName` now reads `name`/`typeName` via the existing `_safeGet` accessor (handles both game objects and plain tables), guards a nil feature and a missing/short `typeName`, and returns `""` as a safe fallback.

## Testing
- Reproduced live in a playtest (`attempt to call a nil value (method 'try_get')` via `pushFeature` -> `categoriserEntrySearchText` -> `BuildIndex` -> `BuildTacIndex`).
- Applied the fix, reloaded Lua, confirmed the index builds without error and real features keep their names.

## Notes for reviewer
- Pre-existing fragility, not tied to any feature work.
- Branch is based on local `main` (1 commit behind `origin/main`'s unrelated roll-dialog fix `4a4b1b2`); the diff is this single function and merges cleanly.