### PR TITLE
fix(dramatic-banner): show token name in {name} interpolation

### DIFF
--- a/Draw Steel Ability Behaviors/AbilityDramaticBanner.lua
+++ b/Draw Steel Ability Behaviors/AbilityDramaticBanner.lua
@@ -30,10 +30,15 @@ function ActivatedAbilityDramaticBannerBehavior:Cast(ability, casterToken, targe
         if tok ~= nil and tok.valid then
             -- Title/subtitle support GoblinScript interpolation: any
             -- {formula} is evaluated against the banner token's symbols.
+            -- Override 'name' with the token's display name so {name}
+            -- shows the creature's actual name. The built-in creature
+            -- 'name' symbol returns the monster_type, which is empty for
+            -- hero characters and would render a blank banner.
+            local symbols = tok.properties:LookupSymbol{ name = tok.name }
             DramaticBanner.Show{
                 tokenid = tok.charid,
-                text = StringInterpolateGoblinScript(self.title, tok.properties),
-                subtitle = StringInterpolateGoblinScript(self.subtitle, tok.properties),
+                text = StringInterpolateGoblinScript(self.title, symbols),
+                subtitle = StringInterpolateGoblinScript(self.subtitle, symbols),
             }
             shown = true
         end


### PR DESCRIPTION
## Problem

The Dramatic Banner ability behavior interpolates its title/subtitle text against the target creature's GoblinScript symbols. The built-in creature `name` symbol returns the creature's `monster_type`, which is **empty for hero characters** (its own help text notes it is "Only valid for monsters, not characters").

As a result, a banner such as `{name} steps in and takes their turn.` rendered with a **blank name** whenever it targeted a hero. This is exactly what happens with the Shadow's level 1 *Hesitation is Weakness* triggered ability, whose banner targets the ally who gets to act.

## Fix

In `AbilityDramaticBanner:Cast`, resolve the symbol table once with `name` overridden to the token's display name:

```lua
local symbols = tok.properties:LookupSymbol{ name = tok.name }
```

Now `{name}` resolves to the creature's actual on-map name for both heroes and monsters, while every other GoblinScript symbol still works in the title/subtitle. When a token has no display name set, it gracefully falls back to the built-in symbol (monster_type), so unnamed monsters are unaffected.

## Verification

Tested live in a running DMHub instance against real tokens:

| Token | Old | New |
|---|---|---|
| Rime (hero) | `" steps in..."` (blank) | `"Rime steps in..."` |
| Gnoll Bonesplitter 1 | "Gnoll Bonesplitter steps in..." | "Gnoll Bonesplitter 1 steps in..." |
| Unnamed monster | "Gnoll Wildling steps in..." | "Gnoll Wildling steps in..." (unchanged) |

Banners targeting heroes now show the correct name; monster banners show the specific instance name; unnamed tokens are unaffected.