### PR TITLE
Fix Tail Spike invoke-ability prompt: target lock-in and Malice payment

### DIFF
--- a/DMHub Game Rules/AbilityInvokeAbility.lua
+++ b/DMHub Game Rules/AbilityInvokeAbility.lua
@@ -417,7 +417,7 @@ function ActivatedAbilityInvokeAbilityBehavior:Cast(ability, casterToken, target
                         end
 
                         local autoTarget = self:try_get("autoTarget", true)
-                        if autoTarget and not abilityClone:RequiresPromptWhenCast() then
+                        if autoTarget and not abilityClone:RequiresPromptWhenCast() and abilityClone:try_get("promptOverride") == nil then
                             abilityClone.castImmediately = true
                             print("INVOKE:: Auto-target enabled for", abilityClone.name)
                         end
@@ -604,6 +604,16 @@ function ActivatedAbilityInvokeAbilityBehavior.ExecuteInvoke(invokerToken, abili
                 targets = { { token = casterToken } }
             elseif targeting == "inherit" then
                 targets = options.targets or {}
+                --Lock target selection to exactly the inherited targets -- the player
+                --should not be able to swap in different targets for an "inherit"
+                --invoke, since the whole point is to reuse the parent ability's targets.
+                local allowedtargets = {}
+                for _, target in ipairs(targets) do
+                    if target.token ~= nil then
+                        allowedtargets[target.token.charid] = true
+                    end
+                end
+                symbols.allowedtargets = allowedtargets
             elseif targeting == "args" then
                 targets = options.targetArgs or {}
             elseif targeting == "formula" then
@@ -642,7 +652,7 @@ function ActivatedAbilityInvokeAbilityBehavior.ExecuteInvoke(invokerToken, abili
                 end
             end
 
-            if abilityClone:RequiresPromptWhenCast() then
+            if abilityClone:RequiresPromptWhenCast() or abilityClone:try_get("promptOverride") ~= nil then
                 abilityClone.skippable = true
                 gamehud.actionBarPanel:FireEventTree("invokeAbility", casterToken, abilityClone, symbols, invokerCallback, {instantCast = true, targets = targets})
             else

--- a/Draw Steel Core Rules/MCDMAbilityBehavior.lua
+++ b/Draw Steel Core Rules/MCDMAbilityBehavior.lua
@@ -47,7 +47,7 @@ function ActivatedAbilityDrawSteelCommandBehavior:Cast(ability, casterToken, tar
         end
     end
 
-    --ability:CommitToPaying(casterToken, options)
+    ability:CommitToPaying(casterToken, options)
 
     repeat
         if promptWhenResolving and #targets > 0 then

--- a/DrawSteelActionBar/DrawSteelActionBar.lua
+++ b/DrawSteelActionBar/DrawSteelActionBar.lua
@@ -4787,7 +4787,7 @@ CreateAbilityController = function()
                 caster = casterToken,
                 section = "target",
             }
-            element:FireEvent("beginCasting", ability, { symbols = symbols })
+            element:FireEvent("beginCasting", ability, { symbols = symbols, targets = options.targets })
 
             --[[
             local spellPanel = GetSpellPanel(nil, nil, ability,
@@ -6374,8 +6374,13 @@ CalculateSpellTargeting = function(forceCast, initialSetup)
 
         g_skipButton:SetClass("collapsed", not g_currentAbility:try_get("skippable", false))
 
-        -- Don't auto-cast on initial setup unless requested
-        if ((not g_currentAbility:CanSelectMoreTargets(g_token, targets, g_currentSymbols)) or forceCast) then --temporarily disabled -David -- and not initialSetup then
+        -- Don't auto-cast on initial setup unless requested.
+        -- When a promptOverride is set (e.g. an invoke-ability prompt), always fall through to the
+        -- confirmation UI so the player can read the prompt and click Confirm, even if all
+        -- targets are already pre-selected via the inherited target list. An explicit Confirm
+        -- click (forceCast = true) always goes through regardless of promptOverride.
+        local hasPromptOverride = g_currentAbility:try_get("promptOverride") ~= nil
+        if forceCast or ((not g_currentAbility:CanSelectMoreTargets(g_token, targets, g_currentSymbols)) and not hasPromptOverride) then --temporarily disabled -David -- and not initialSetup then
             --we can't select more targets, so cast the spell in here.
             g_token.lookAtMouse = false
             if g_castingEmoteSet and g_token.valid then


### PR DESCRIPTION
## Summary

Follow-up to #99, whose fixes were silently overwritten by later commits touching the same files. Re-applies the original fixes against current main, plus two additional fixes found during live testing on the Manticore's Tail Spike ability.

- **`AbilityInvokeAbility.lua`**: suppress `castImmediately` when `promptOverride` is set so the prompt isn't silently skipped; fire the `invokeAbility` action-bar event whenever `promptOverride` is set (not just when `RequiresPromptWhenCast` is true); restrict target selection to the inherited power-roll targets via `symbols.allowedtargets` so the player can't swap in different targets for an `"inherit"`-targeting invoke (previously the player could freely click any token, which both confused the UX and let a condition rider leak onto unintended targets).

- **`MCDMAbilityBehavior.lua`**: re-enable a commented-out `CommitToPaying` call in `ActivatedAbilityDrawSteelCommandBehavior:Cast`. This was silently breaking resource payment (e.g. Malice) for any invoked sub-ability whose only behavior is a Power Table Effect rule -- confirmed via a live bestiary scan that both Tail Spike (Manticore) and Soul Burn (Hobgoblin Burning Witch) were affected, while abilities using a nested Invoke Ability behavior were unaffected (that behavior type already calls `CommitToPaying` itself). The call is idempotent (guarded by `options.alreadyPaid`/`firedUseAbility`), so this is safe for abilities that already pay via another behavior.

- **`DrawSteelActionBar.lua`**: pass inherited targets into `beginCasting` so `g_targetsChosen` is pre-populated; guard the auto-cast branch in `CalculateSpellTargeting` so a `promptOverride` keeps the Confirm button visible with pre-selected targets instead of auto-casting, while an explicit Confirm click (`forceCast = true`) always goes through regardless.

## Test plan

- [x] Live-tested in DMHub against the Manticore's Tail Spike ability end to end: power roll hits 2 targets, "Spend 1 Malice..." prompt appears with both original targets pre-selected and locked (no manual re-targeting possible), Confirm fires immediately, Malice is deducted, and the Weakened condition + Tail Spike rider apply only to the 2 original targets.
- [ ] Spot-check an ability using a nested Invoke Ability behavior (e.g. Blightblade) to confirm no double-payment regression.
- [ ] Spot-check an invoke behavior without a `promptText` to confirm it still auto-casts as before (no regression).