### PR TITLE
fix: ability customization icon and button spacing

### DIFF
--- a/DMHub Core UI/DefaultStyles.lua
+++ b/DMHub Core UI/DefaultStyles.lua
@@ -1190,6 +1190,8 @@ ThemeEngine.RegisterTheme{
         {
             selectors = {"panel", "buttonIcon", "parent:customiseAbilityButton"},
             bgimage = "ui-icons/pencil.png",
+        },
+        {
             selectors = {"panel", "buttonIcon", "parent:maximizeButton"},
             bgimage = "panels/hud/down-arrow.png",
         },

--- a/Draw Steel V/DrawSteelChararcterSheet.lua
+++ b/Draw Steel V/DrawSteelChararcterSheet.lua
@@ -553,6 +553,7 @@ local function CreateAbilityPanel()
 
             gui.Button{
                 classes = {"settingsButton"},
+                lmargin  = 8,
                 ability = function(element, ability, c)
                     element:SetClass("hidden", not c:IsActivatedAbilityInnate(ability))
                 end,


### PR DESCRIPTION
## Summary

Fixes display issues with the ability customization feature added in PR #109.

## Changes

- Fix malformed style rule in DefaultStyles.lua that had duplicate `selectors` keys
- Add 8px left margin to the settings button to prevent icon bunching

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)