### PR TITLE
feat(monsters): level scaling, villain-action picker, and Make Solo

### DIFF
--- a/DMHub Core Panels/CharacterPanel.lua
+++ b/DMHub Core Panels/CharacterPanel.lua
@@ -2913,7 +2913,22 @@ local function ExtractMonsterCapabilities(props)
                 if okn and okc and type(aname) == "string" and aname ~= ""
                     and MONSTER_ABILITY_CATEGORIES[cat] and not seen[aname] then
                     seen[aname] = true
-                    caps[#caps+1] = { name = aname, categorization = cat }
+                    -- Capture the villain-action slot, implementation status, and
+                    -- whether the ability carries real behaviors during this single
+                    -- scan, so the villain-action picker can reuse the cached index
+                    -- (slot-lock, status dot, behaviors cross-check) without a second
+                    -- GoblinScript pass. Cheap field reads, individually guarded.
+                    local slot, status, hasBehaviors = nil, nil, false
+                    pcall(function() slot = a:try_get("villainAction") end)
+                    pcall(function() status = a:try_get("implementation", 1) end)
+                    pcall(function() hasBehaviors = #a:try_get("behaviors", {}) > 0 end)
+                    caps[#caps+1] = {
+                        name = aname,
+                        categorization = cat,
+                        villainAction = slot,
+                        implementation = status,
+                        hasBehaviors = hasBehaviors,
+                    }
                 end
             end
         end
@@ -2974,6 +2989,10 @@ local function EnsureMonsterAbilityIndex()
                 local mname = monster.name
                 local props = monster.properties
                 if props ~= nil and type(mname) == "string" and mname ~= "" then
+                    -- Monster level, read once per monster (cheap; the villain-action
+                    -- picker surfaces it and searches by it).
+                    local mlevel = nil
+                    pcall(function() mlevel = tonumber(props:CharacterLevel()) end)
                     -- Abilities (deduped) + every named trait, classified once by
                     -- the shared extractor and tagged with the owning monster.
                     for _,cap in ipairs(ExtractMonsterCapabilities(props)) do
@@ -2982,6 +3001,10 @@ local function EnsureMonsterAbilityIndex()
                             categorization = cap.categorization,
                             monsterName = mname,
                             monsterId = monsterid,
+                            level = mlevel,
+                            villainAction = cap.villainAction,
+                            implementation = cap.implementation,
+                            hasBehaviors = cap.hasBehaviors,
                         }
                     end
                 end
@@ -3056,3 +3079,47 @@ Search.RegisterProvider{
         return results
     end,
 }
+
+-- Villain-action picker support (Draw Steel). The picker reuses this cached
+-- bestiary index rather than running its own GoblinScript scan: every villain
+-- action across the bestiary is already classified here with its slot, level,
+-- implementation status, and whether it carries real behaviors. Returns the
+-- index entries matching a slot ("Villain Action 1|2|3"; nil = all slots) plus a
+-- readiness flag, so a caller that opens before the build coroutine finishes can
+-- re-poll instead of showing an empty list.
+function GetBestiaryVillainActions(slot)
+    EnsureMonsterAbilityIndex()
+    local index = g_monsterAbilityIndex
+    if index == nil then
+        return {}, false
+    end
+    local out = {}
+    for _,e in ipairs(index) do
+        if e.categorization == "Villain Action"
+            and (slot == nil or e.villainAction == slot) then
+            out[#out+1] = e
+        end
+    end
+    return out, true
+end
+
+-- Fetch the live ability object behind an index entry, for previewing the real
+-- ability card or duplicating it onto another creature. Re-reads just the one
+-- owning monster's abilities (cheap -- one monster, not the whole bestiary) and
+-- matches by name. Returns nil if the monster or ability can no longer be found.
+function GetBestiaryAbilityObject(monsterId, abilityName)
+    local monster = assets.monsters[monsterId]
+    if monster == nil or monster.properties == nil then
+        return nil
+    end
+    local result = nil
+    pcall(function()
+        for _,a in ipairs(monster.properties:GetActivatedAbilities{}) do
+            if a.name == abilityName then
+                result = a
+                return
+            end
+        end
+    end)
+    return result
+end

--- a/DMHub Game Rules/AbilityPurgeEffects.lua
+++ b/DMHub Game Rules/AbilityPurgeEffects.lua
@@ -169,6 +169,26 @@ ActivatedAbilityPurgeEffectsBehavior.purgeTypeOptions = {
 
 
 
+--Evaluate the damageToSelf field against a creature's properties, returning a
+--roll string. The field accepts a flat number ("5") or a GoblinScript
+--expression ("5 * Echelon"); dmhub.EvalGoblinScript resolves symbols and
+--computes the value, and leaves a plain number unchanged. Returns "" when the
+--field is blank, or the raw field when no creature is available. Callers that
+--need a number apply tonumber() to the result -- a non-numeric result (e.g. a
+--dice expression, which this field has never actually rolled) yields nil there,
+--the same no-op the field had before.
+function ActivatedAbilityPurgeEffectsBehavior:EvalDamageToSelf(creatureProps)
+    local raw = self:try_get("damageToSelf", "")
+    --A plain number (the overwhelmingly common case) needs no evaluation:
+    --return it untouched so flat values are provably unchanged and we skip the
+    --GoblinScript compile entirely. Only a non-numeric expression (e.g.
+    --"5 * Echelon") is evaluated.
+    if raw == "" or tonumber(raw) ~= nil or creatureProps == nil then
+        return raw
+    end
+    return dmhub.EvalGoblinScript(raw, creatureProps:LookupSymbol{}, "Purge effects damage to self")
+end
+
 function ActivatedAbilityPurgeEffectsBehavior:Cast(ability, casterToken, targets, options)
     if #targets == 0 then
         return
@@ -404,7 +424,7 @@ function ActivatedAbilityPurgeEffectsBehavior:Cast(ability, casterToken, targets
                         -- `if #selectedItems > 0`).  Matches the once-per-target behaviour
                         -- of the conditions-only path in CastOnTarget.
                         if self.damageToSelf ~= "" then
-                            local damage = tonumber(self.damageToSelf)
+                            local damage = tonumber(self:EvalDamageToSelf(data.token.properties))
                             if damage ~= nil and damage > 0 then
                                 data.token.properties:TakeDamage(damage, "Purged condition")
                             end
@@ -584,7 +604,7 @@ function ActivatedAbilityPurgeEffectsBehavior:CastOnTarget(casterToken, targetTo
                         result[#result+1] = condid
                     end
 
-                    local damage = tonumber(self.damageToSelf)
+                    local damage = tonumber(self:EvalDamageToSelf(targetCreature))
                     if damage ~= nil and damage > 0 then
                         targetCreature:TakeDamage(damage, "Purged condition")
                     end
@@ -1203,7 +1223,7 @@ function ActivatedAbilityPurgeEffectsBehavior:ShowPurgeDialog(targetDataList, ab
     }
 
     -- Damage-to-self warning: shown in red when a positive damage value is set.
-    local damageNum = tonumber(self:try_get("damageToSelf", ""))
+    local damageNum = tonumber(self:EvalDamageToSelf(casterToken and casterToken.properties or nil))
     if damageNum ~= nil and damageNum > 0 then
         local damageText
         if self.purgeType == "one" then
@@ -1966,6 +1986,9 @@ function ActivatedAbilityPurgeEffectsBehavior:ShowConditionsSelection(casterToke
 
 	local conditionsTable = dmhub.GetTable(CharacterCondition.tableName) or {}
 
+    -- Evaluate the self-damage once (GoblinScript-aware) for the option labels.
+    local damageToSelfShown = self:EvalDamageToSelf(casterToken and casterToken.properties or nil)
+
     for i,condid in ipairs(conditionsList) do
         local conditionInfo = conditionsTable[condid]
         if conditionInfo ~= nil then
@@ -1977,8 +2000,8 @@ function ActivatedAbilityPurgeEffectsBehavior:ShowConditionsSelection(casterToke
                 text = conditionInfo.name,
             }
 
-            if self.damageToSelf ~= "" then
-                option.text = option.text .. " <color=#ff0000>(Receive " .. self.damageToSelf .. " damage)"
+            if damageToSelfShown ~= "" then
+                option.text = option.text .. " <color=#ff0000>(Receive " .. damageToSelfShown .. " damage)"
             end
 
             args.options[#args.options+1] = option

--- a/Draw Steel Core Rules/MCDMAbilityBehavior.lua
+++ b/Draw Steel Core Rules/MCDMAbilityBehavior.lua
@@ -1521,7 +1521,7 @@ function ActivatedAbilityDrawSteelCommandBehavior:ExecuteCommandInternal(ability
         if type(gateMatch.gate) == "string" then
             gate = casterToken.properties:CalculatePotencyValue(gateMatch.gate)
         else
-            gate = tonumber(gateMatch.gate) + casterToken.properties:CalculateNamedCustomAttribute("Potency Bonus")
+            gate = tonumber(gateMatch.gate) + casterToken.properties:CalculateNamedCustomAttribute("Potency Bonus") + casterToken.properties:ScaledPotencyGateBonus()
         end
 
 
@@ -2015,9 +2015,13 @@ function ActivatedAbilityDrawSteelCommandBehavior.DisplayRuleTextForCreature(cas
         rule = regex.ReplaceAll(rule, "(if the target has )?(?<attr>[MARIP]) < \\[?average\\]?", string.format("<color=#ff4444><uppercase>${attr}</uppercase> < %d</color>", potencyAverage))
         rule = regex.ReplaceAll(rule, "(if the target has )?(?<attr>[MARIP]) < \\[?strong\\]?", string.format("<color=#ff4444><uppercase>${attr}</uppercase> < %d</color>", potencyStrong))
 
-        --Add potency bonus when numeric gate is used
-        local potencyBonus = caster:CalculateNamedCustomAttribute("Potency Bonus")
-        if starting == rule and potencyBonus > 0 then
+        --Add potency bonus (plus any level-scaling literal-gate shift) when a
+        --numeric gate is used. The ~= 0 guard (was > 0) lets a negative shift --
+        --i.e. scaling a monster DOWN -- rewrite the gate too, matching what the
+        --resolution save-check already does, so the shown gate never disagrees
+        --with the actual save.
+        local potencyBonus = caster:CalculateNamedCustomAttribute("Potency Bonus") + caster:ScaledPotencyGateBonus()
+        if starting == rule and potencyBonus ~= 0 then
             rule = string.gsub(rule, "([MARIPmarip])%s*<%s*(%-?%d+)", function(attr, gate)
                 local adjustedGate = tonumber(gate) + potencyBonus
                 return string.format("<color=#ff4444><uppercase>%s</uppercase> < %d</color>", string.upper(attr), adjustedGate)

--- a/Draw Steel Core Rules/MCDMAbilityRollBehavior.lua
+++ b/Draw Steel Core Rules/MCDMAbilityRollBehavior.lua
@@ -1266,6 +1266,10 @@ function ActivatedAbilityPowerRollBehavior:Cast(ability, casterToken, targets, o
         tiers = tiers,
     }
 
+    --Bake in this creature's monster level-scaling tier-damage bonuses before
+    --any ResetMods, so they become the persistent baseTiers.
+    rollProperties:ApplyCreatureTierDamage(caster, ability)
+
     for _,token in ipairs(dmhub.allTokens) do
         for _,mod in ipairs(token.properties:GetActiveModifiers()) do
             for _,target in ipairs(multitargets) do
@@ -2415,6 +2419,60 @@ function RollPropertiesPowerTable:ModifyDamageWithType(damage, damageType)
                 -- Just put damage at the front
                 self.tiers[i] = string.format("%s; %s", extraDamage, tier)
             end
+        end
+    end
+end
+
+--Add `amount` to the first damage number in a single tier string, mirroring the
+--regex rewrite in ModifyDamage but for one tier (so per-tier deltas can differ).
+--Returns the tier unchanged if it contains no damage number.
+local function AddDamageToTierText(tier, amount)
+    local match = regex.MatchGroups(tier, "(?<damage>\\d+)\\s+(\\+\\s*\\d+d\\d+\\s+)?([a-zA-Z]+\\s+)?damage", {indexes = true})
+    if match == nil then
+        return tier
+    end
+
+    local index = match.damage.index
+    local length = match.damage.length
+    local before = string.sub(tier, 1, index-1)
+    local after = string.sub(tier, index+length)
+    local damageValue = max(0, round(round(tonumber(match.damage.value)) + amount))
+    return string.format("%s%d%s", before, damageValue, after)
+end
+
+--Apply this creature's monster level-scaling tier-damage bonuses to a freshly
+--constructed ability power-roll table. Reads the Tier 1/2/3 Damage Bonus custom
+--attributes (added to the matching tier of every power roll) and, for strikes,
+--the Strike Damage Bonus (the highest-characteristic delta, added to every
+--tier). See .claude/monster-level-scaling.md and MCDMMonsterScaling.
+--
+--Call this once, right after constructing the table for an ABILITY DAMAGE roll
+--and before any ResetMods, so the scaled numbers become the persistent
+--baseTiers and situational modifiers stack on top. Only the two ability-damage
+--sites call it; opposed / resistance / characteristic rolls must NOT be scaled.
+--@param caster Creature
+--@param ability ActivatedAbility
+function RollPropertiesPowerTable:ApplyCreatureTierDamage(caster, ability)
+    if caster == nil then
+        return
+    end
+
+    local perTier = {
+        caster:CalculateNamedCustomAttribute("Tier 1 Damage Bonus") or 0,
+        caster:CalculateNamedCustomAttribute("Tier 2 Damage Bonus") or 0,
+        caster:CalculateNamedCustomAttribute("Tier 3 Damage Bonus") or 0,
+    }
+
+    if ability ~= nil and ability:HasKeyword("Strike") then
+        local strikeBonus = caster:CalculateNamedCustomAttribute("Strike Damage Bonus") or 0
+        for i=1,3 do
+            perTier[i] = perTier[i] + strikeBonus
+        end
+    end
+
+    for i=1,math.min(#self.tiers, 3) do
+        if perTier[i] ~= 0 then
+            self.tiers[i] = AddDamageToTierText(self.tiers[i], perTier[i])
         end
     end
 end

--- a/Draw Steel Core Rules/MCDMActivatedAbility.lua
+++ b/Draw Steel Core Rules/MCDMActivatedAbility.lua
@@ -653,14 +653,19 @@ function ActivatedAbility:Render(options, params)
         for i, t in ipairs(ptBehavior.tiers) do
             normalizedTiers[i] = ActivatedAbilityDrawSteelCommandBehavior.DisplayRuleTextForCreature(creatureProperties, t, notes, true)
         end
+        local rollProperties = RollPropertiesPowerTable.new{
+            tiers = normalizedTiers,
+        }
+        -- Bake in this creature's monster level-scaling tier-damage bonuses
+        -- (rollProperties.tiers is the same table as normalizedTiers). Done
+        -- BEFORE the snapshot so the scaled numbers are the baseline and only
+        -- situational Modify Power Roll changes get diff-highlighted below.
+        rollProperties:ApplyCreatureTierDamage(creatureProperties, self)
         -- Snapshot pre-modifier tier text for diff highlighting later.
         local originalTiers = {}
         for i, t in ipairs(normalizedTiers) do
             originalTiers[i] = t
         end
-        local rollProperties = RollPropertiesPowerTable.new{
-            tiers = normalizedTiers,
-        }
         -- Pre-compute what the ability's tiers contain so note parts can be
         -- filtered to only show information relevant to this ability.
         -- hasDamage: any normalized tier contains the word "damage".

--- a/Draw Steel Core Rules/MCDMCreature.lua
+++ b/Draw Steel Core Rules/MCDMCreature.lua
@@ -1485,6 +1485,14 @@ function creature:CalculatePotencyValueSelf(potency)
     return potencyValue + potencyBonus
 end
 
+--The amount to shift an ability's *literal* potency gate (e.g. "M < 3") for this
+--creature. Only level-scaled monsters carry a shift (see
+--monster:ScaledPotencyGateBonus); every other creature -- heroes included --
+--returns 0, so non-scaled potency gates are completely unaffected.
+function creature:ScaledPotencyGateBonus()
+    return 0
+end
+
 creature.RegisterSymbol {
     symbol = "recoveriesavailabletospend",
     lookup = function(c)

--- a/Draw Steel Core Rules/MCDMCreature.lua
+++ b/Draw Steel Core Rules/MCDMCreature.lua
@@ -2173,6 +2173,19 @@ function creature:Echelon()
     return math.min(4, math.ceil(self:CharacterLevel() / 3))
 end
 
+creature.RegisterSymbol {
+    symbol = "echelon",
+    lookup = function(c)
+        return c:Echelon()
+    end,
+    help = {
+        name = "Echelon",
+        type = "number",
+        desc = "The creature's echelon, derived from its level: 1 (levels 1-3), 2 (4-6), 3 (7-9), 4 (10 and up). Useful for scaling values that step up once per echelon, e.g. a solo's End Effect damage of 5 * Echelon.",
+        seealso = { "Level" },
+    }
+}
+
 function creature:Keywords()
     return {}
 end

--- a/Draw Steel Core Rules/MCDMMonster.lua
+++ b/Draw Steel Core Rules/MCDMMonster.lua
@@ -1229,6 +1229,30 @@ function monster:Potency()
     return highest
 end
 
+--A level-scaled monster's *literal* ability potency gates (e.g. "M < 3") are
+--frozen text baked in at the authored level; unlike the Potencies line and
+--weak/average/strong gates (which recompute from monster:Potency()), they never
+--track the characteristic. So they must be nudged explicitly by the same potency
+--delta the Adjust Level modal previews. Returns 0 when unscaled (zero shift), and
+--mirrors the summoner redirect that Potency()/CalculatePotencyValue use. Both the
+--display pass and the resolution save-check add this, so the shown gate and the
+--actual save always agree. Computed live (no stored modifier) so it cannot stale.
+function monster:ScaledPotencyGateBonus()
+    local summonerToken = self:GetPotencySummonerToken()
+    if summonerToken ~= nil then
+        return summonerToken.properties:ScaledPotencyGateBonus()
+    end
+    if not self:HasLevelAdjustment() then
+        return 0
+    end
+    local org, role = self:ScalingOrgRole()
+    local deltas = MCDMMonsterScaling.ComputeDeltas(org, role, self:GetScalingBaseLevel(), round(tonumber(self.cr) or 0))
+    if deltas == nil then
+        return 0
+    end
+    return deltas.potency or 0
+end
+
 --==============================================================
 -- Monster level scaling: the generated "Level Adjustment" feature.
 --
@@ -1288,11 +1312,14 @@ function MCDMMonsterScaling.BuildAdjustmentFeature(deltas, charScale)
 
     local charBump = (charScale ~= nil and charScale.bump) or 0
 
-    -- No Potency Bonus modifier: potency follows the characteristic via the
-    -- engine (monster:Potency() = highest characteristic, +1 at echelon-4
-    -- leader/solo), and scaling already raises both the characteristic and the
-    -- level, so potency recomputes correctly on its own. Adding a Potency Bonus
-    -- here would double-count the echelon-4 divergence.
+    -- No Potency Bonus modifier: the computed potency (the Potencies line and
+    -- weak/average/strong gates) follows the characteristic via the engine
+    -- (monster:Potency() = highest characteristic, +1 at echelon-4 leader/solo),
+    -- and scaling already raises both the characteristic and the level, so it
+    -- recomputes on its own; a Potency Bonus here would double-count it. The one
+    -- thing that does NOT recompute is a *literal* potency gate baked into ability
+    -- text (e.g. "M < 3") -- that is nudged separately by monster:ScaledPotencyGateBonus
+    -- at the two gate sites in MCDMAbilityBehavior, not by a modifier here.
     local specs = {
         { key = "ev",         attribute = "ev",                  value = deltas.ev },
         { key = "hitpoints",  attribute = "hitpoints",           value = deltas.stamina },

--- a/Draw Steel Core Rules/MCDMMonster.lua
+++ b/Draw Steel Core Rules/MCDMMonster.lua
@@ -1230,6 +1230,7 @@ local g_adjustModGuids = {
     t2         = "ad13299a-108b-47d3-ac21-c1eda5abda26",
     t3         = "c79b4266-f7c8-49f4-ac52-0a4def6b63b8",
     strike     = "ea86292d-b78d-47ce-9081-14533f341598",
+    characteristic = "1f7c4d6e-2b9a-4f08-bb51-6e0a9d2c8b34",
 }
 
 --Resolve a custom attribute's GUID (the key an attribute modifier targets) by
@@ -1247,21 +1248,39 @@ end
 --(see MCDMMonsterScaling.ComputeDeltas). Every entry is a plain add-operation
 --Modify Attribute modifier; zero deltas are skipped. Returns nil if there is
 --nothing to add.
-function MCDMMonsterScaling.BuildAdjustmentFeature(deltas)
+--
+--charScale (optional) = { attr = <characteristic attribute id>, bump = <delta> }
+--actually raises the creature's highest characteristic so the sheet reflects it
+--and abilities that roll "2d10 + Highest Characteristic" scale. Because the
+--engine ties Potency() to HighestCharacteristic(), the characteristic bump
+--already moves potency by `bump`; the Potency Bonus attribute therefore carries
+--only the REMAINDER (the echelon-4 leader/solo divergence where potency outpaces
+--the +5-capped characteristic). Strike damage moves by the same `bump` (the
+--characteristic part of a strike's per-tier damage); the static tier text is not
+--re-derived from the characteristic, so there is no double count.
+function MCDMMonsterScaling.BuildAdjustmentFeature(deltas, charScale)
     if deltas == nil then
         return nil
     end
+
+    local charBump = (charScale ~= nil and charScale.bump) or 0
 
     local specs = {
         { key = "ev",         attribute = "ev",                  value = deltas.ev },
         { key = "hitpoints",  attribute = "hitpoints",           value = deltas.stamina },
         { key = "freeStrike", attribute = "Free Strike Bonus",   value = deltas.freeStrike, custom = true },
-        { key = "potency",    attribute = "Potency Bonus",       value = deltas.potency,    custom = true },
+        { key = "potency",    attribute = "Potency Bonus",       value = (deltas.potency or 0) - charBump, custom = true },
         { key = "t1",         attribute = "Tier 1 Damage Bonus", value = deltas.t1,         custom = true },
         { key = "t2",         attribute = "Tier 2 Damage Bonus", value = deltas.t2,         custom = true },
         { key = "t3",         attribute = "Tier 3 Damage Bonus", value = deltas.t3,         custom = true },
-        { key = "strike",     attribute = "Strike Damage Bonus", value = deltas.strike,     custom = true },
+        { key = "strike",     attribute = "Strike Damage Bonus", value = charBump,          custom = true },
     }
+
+    --Raise the actual highest characteristic (skipped when there is no echelon
+    --change, or no attribute to target).
+    if charScale ~= nil and charScale.attr ~= nil and charBump ~= 0 then
+        specs[#specs+1] = { key = "characteristic", attribute = charScale.attr, value = charBump }
+    end
 
     local modifiers = {}
     for _,spec in ipairs(specs) do
@@ -1353,7 +1372,31 @@ creature.RegisterFeatureCalculation{
         end
 
         local org, role = MCDMMonsterScaling.ParseOrgRole(c:try_get("role", ""), c:try_get("minion", false))
-        local feature = MCDMMonsterScaling.BuildAdjustmentFeature(MCDMMonsterScaling.ComputeDeltas(org, role, base, target))
+        local deltas = MCDMMonsterScaling.ComputeDeltas(org, role, base, target)
+
+        -- Resolve the characteristic bump. Read the highest characteristic from
+        -- the raw stored attributes (GetBaseAttribute -- no modifier pipeline, so
+        -- no recursion during this calculation), apply the formula characteristic
+        -- delta (deltas.strike), and clamp the result to the +5 power-roll cap so
+        -- a hand-tuned monster authored above the curve cannot exceed it.
+        local charScale = nil
+        if deltas ~= nil then
+            local highestAttr, highestVal = nil, nil
+            for _, attrid in ipairs(creature.attributeIds) do
+                local v = 0
+                pcall(function() v = c:GetBaseAttribute(attrid).baseValue or 0 end)
+                if highestVal == nil or v > highestVal then
+                    highestVal = v
+                    highestAttr = attrid
+                end
+            end
+            if highestAttr ~= nil then
+                local newHighest = math.min(5, (highestVal or 0) + (deltas.strike or 0))
+                charScale = { attr = highestAttr, bump = newHighest - (highestVal or 0) }
+            end
+        end
+
+        local feature = MCDMMonsterScaling.BuildAdjustmentFeature(deltas, charScale)
         if feature ~= nil then
             result[#result+1] = feature
         end

--- a/Draw Steel Core Rules/MCDMMonster.lua
+++ b/Draw Steel Core Rules/MCDMMonster.lua
@@ -1205,6 +1205,30 @@ function monster:ScalingOrgRole()
     return MCDMMonsterScaling.ParseOrgRole(self:try_get("role", ""), self.minion)
 end
 
+--Potency for monsters. The base creature:Potency() returns the highest
+--characteristic, which is correct for every monster EXCEPT echelon-4
+--leaders/solos: the MCDM monster-math sheet caps the characteristic (power
+--roll) at +5 but lets potency reach 6 at that echelon. Detect that one case by
+--organization + echelon and lift potency by 1, but only when the characteristic
+--is actually at the +5 cap, so a hand-tuned monster with a sub-cap characteristic
+--still gets potency = its highest characteristic. Computed live from level/org,
+--so any new L10/L11 leader or solo gets the right result with no per-monster data.
+function monster:Potency()
+    local summonerToken = self:GetPotencySummonerToken()
+    if summonerToken ~= nil then
+        return summonerToken.properties:Potency()
+    end
+
+    local highest = self:HighestCharacteristic()
+    local org = self:ScalingOrgRole()
+    if (org == "leader" or org == "solo")
+        and MCDMMonsterScaling.Echelon(round(tonumber(self.cr) or 0)) == 4
+        and highest >= 5 then
+        return highest + 1
+    end
+    return highest
+end
+
 --==============================================================
 -- Monster level scaling: the generated "Level Adjustment" feature.
 --
@@ -1251,13 +1275,12 @@ end
 --
 --charScale (optional) = { attr = <characteristic attribute id>, bump = <delta> }
 --actually raises the creature's highest characteristic so the sheet reflects it
---and abilities that roll "2d10 + Highest Characteristic" scale. Because the
---engine ties Potency() to HighestCharacteristic(), the characteristic bump
---already moves potency by `bump`; the Potency Bonus attribute therefore carries
---only the REMAINDER (the echelon-4 leader/solo divergence where potency outpaces
---the +5-capped characteristic). Strike damage moves by the same `bump` (the
---characteristic part of a strike's per-tier damage); the static tier text is not
---re-derived from the characteristic, so there is no double count.
+--and abilities that roll "2d10 + Highest Characteristic" scale. Potency needs no
+--modifier of its own: the engine ties monster:Potency() to the highest
+--characteristic (plus the echelon-4 leader/solo +1), so the characteristic bump
+--and the level change move potency correctly on their own. Strike damage moves
+--by the same `bump` (the characteristic part of a strike's per-tier damage); the
+--static tier text is not re-derived from the characteristic, so no double count.
 function MCDMMonsterScaling.BuildAdjustmentFeature(deltas, charScale)
     if deltas == nil then
         return nil
@@ -1265,11 +1288,15 @@ function MCDMMonsterScaling.BuildAdjustmentFeature(deltas, charScale)
 
     local charBump = (charScale ~= nil and charScale.bump) or 0
 
+    -- No Potency Bonus modifier: potency follows the characteristic via the
+    -- engine (monster:Potency() = highest characteristic, +1 at echelon-4
+    -- leader/solo), and scaling already raises both the characteristic and the
+    -- level, so potency recomputes correctly on its own. Adding a Potency Bonus
+    -- here would double-count the echelon-4 divergence.
     local specs = {
         { key = "ev",         attribute = "ev",                  value = deltas.ev },
         { key = "hitpoints",  attribute = "hitpoints",           value = deltas.stamina },
         { key = "freeStrike", attribute = "Free Strike Bonus",   value = deltas.freeStrike, custom = true },
-        { key = "potency",    attribute = "Potency Bonus",       value = (deltas.potency or 0) - charBump, custom = true },
         { key = "t1",         attribute = "Tier 1 Damage Bonus", value = deltas.t1,         custom = true },
         { key = "t2",         attribute = "Tier 2 Damage Bonus", value = deltas.t2,         custom = true },
         { key = "t3",         attribute = "Tier 3 Damage Bonus", value = deltas.t3,         custom = true },

--- a/Draw Steel Core Rules/MCDMMonster.lua
+++ b/Draw Steel Core Rules/MCDMMonster.lua
@@ -1409,6 +1409,118 @@ function monster:ClearLevelAdjustment()
     end
 end
 
+--==============================================================
+-- Solo conversion: the "Make Solo" button lifecycle.
+--
+-- A non-solo monster can be promoted to a Solo in one action: its organization
+-- is set to Solo (the role word is dropped -- Solos have no role) and the
+-- "Instant Solo" creature template is applied for the stat math (EV x3, Stamina
+-- x2.5, extra turns/action, end effect). The conversion is fully reversible: the
+-- prior role string and minion flag are remembered so Revert restores them
+-- exactly, then the template is removed.
+--
+-- creature.role is the single source of truth for organization (Organization()
+-- regex-parses its first word), so the org->Solo flip is a plain string write. A
+-- template MODIFIER cannot write a string field, which is why this lives on a
+-- code actor (the button) rather than in the template itself.
+--
+-- Mutates creature properties -- callers outside the character sheet must wrap
+-- these in token:ModifyProperties.
+--==============================================================
+local INSTANT_SOLO_TEMPLATE_ID = "231c3a1e-1292-4751-bc23-238b26531e61"
+
+--True if this monster was promoted to Solo by the Make Solo button (as opposed
+--to being authored as a Solo). Only a button conversion is revertible.
+function monster:HasSoloConversion()
+    return self:try_get("soloConversionPriorRole") ~= nil
+end
+
+--Promote this monster to a Solo: remember the prior role/minion, set the
+--organization to Solo (dropping the role word), and apply the Instant Solo
+--template. No-op if already converted.
+function monster:MakeSolo()
+    if self:HasSoloConversion() then
+        return
+    end
+
+    self.soloConversionPriorRole = self:try_get("role", "")
+    self.soloConversionPriorMinion = self:try_get("minion", false)
+
+    --Snapshot the villain actions the creature already has, so Revert removes
+    --only the ones added during the solo conversion and leaves any the creature
+    --owned beforehand (e.g. a Leader's native villain actions) intact.
+    local priorVillainActions = {}
+    for _, a in ipairs(self:try_get("innateActivatedAbilities", {})) do
+        if a.categorization == "Villain Action" then
+            priorVillainActions[#priorVillainActions + 1] = a.guid
+        end
+    end
+    self.soloConversionPriorVillainActions = priorVillainActions
+
+    self.role = "Solo"
+    self.minion = false
+
+    --Apply the Instant Solo template, guarding against a stray duplicate.
+    local templates = self:try_get("creatureTemplates")
+    local hasTemplate = false
+    if templates ~= nil then
+        for _, id in ipairs(templates) do
+            if id == INSTANT_SOLO_TEMPLATE_ID then
+                hasTemplate = true
+                break
+            end
+        end
+    end
+    if not hasTemplate then
+        self:AddTemplate(INSTANT_SOLO_TEMPLATE_ID)
+    end
+end
+
+--Revert a Make Solo conversion: restore the prior role/minion and remove the
+--Instant Solo template. No-op if not converted.
+function monster:RevertSolo()
+    if not self:HasSoloConversion() then
+        return
+    end
+
+    self.role = self:try_get("soloConversionPriorRole", "")
+    self.minion = self:try_get("soloConversionPriorMinion", false)
+
+    --Remove the Instant Solo template we added (RemoveTemplate is index-based,
+    --so locate it first; iterate in reverse so the index stays valid).
+    local templates = self:try_get("creatureTemplates")
+    if templates ~= nil then
+        for i = #templates, 1, -1 do
+            if templates[i] == INSTANT_SOLO_TEMPLATE_ID then
+                self:RemoveTemplate(i)
+                break
+            end
+        end
+    end
+
+    --Remove villain actions added during the solo conversion: any villain
+    --action whose guid is not in the pre-conversion snapshot. This restores the
+    --creature's original villain-action set (none for an Elite, the native ones
+    --for a Leader) rather than leaving solo-only actions behind.
+    local priorVillainActions = {}
+    for _, guid in ipairs(self:try_get("soloConversionPriorVillainActions", {})) do
+        priorVillainActions[guid] = true
+    end
+    local villainActionsToRemove = {}
+    for _, a in ipairs(self:try_get("innateActivatedAbilities", {})) do
+        if a.categorization == "Villain Action" and not priorVillainActions[a.guid] then
+            villainActionsToRemove[#villainActionsToRemove + 1] = a
+        end
+    end
+    for _, a in ipairs(villainActionsToRemove) do
+        self:RemoveInnateActivatedAbility(a)
+    end
+
+    self.soloConversionPriorRole = nil
+    self.soloConversionPriorMinion = nil
+    self.soloConversionPriorVillainActions = nil
+end
+
 creature.RegisterFeatureCalculation{
     id = "monsterLevelScaling",
     FillFeatures = function(c, result)

--- a/Draw Steel Core Rules/MCDMMonster.lua
+++ b/Draw Steel Core Rules/MCDMMonster.lua
@@ -976,3 +976,231 @@ function monster:Role()
 
     return nil
 end
+
+--==============================================================
+-- Monster level scaling: lookup tables + math foundation.
+--
+-- Data ported (EVALUATED values) from the Monsters sheet of
+-- "Draw Steel Maker Pro.xlsx" -- the authoritative source for this math.
+-- Designer-confirmed rulings and the full design live in
+-- .claude/monster-level-scaling.md. These functions are pure (no creature
+-- mutation, no UI); the feature builder and the damage hook consume them.
+--==============================================================
+
+MCDMMonsterScaling = {}
+
+MCDMMonsterScaling.minLevel = 1
+MCDMMonsterScaling.maxLevel = 11
+
+--Indexed by [org][level] for levels 1-11. stamina holds the three stamina
+--tiers (low/med/high); normal/dps hold the three power-roll tiers {t1,t2,t3}.
+--Leader/Solo rows only populate High stamina and DPS damage (others are nil),
+--matching the sheet.
+local g_scaleTable = {
+    minion = {
+        [1] = {ev=3, stamina={low=3, med=4, high=5}, normal={1, 2, 3}, dps={2, 4, 5}},
+        [2] = {ev=4, stamina={low=4, med=5, high=7}, normal={2, 3, 5}, dps={3, 4, 6}},
+        [3] = {ev=5, stamina={low=5, med=7, high=8}, normal={2, 4, 5}, dps={3, 5, 6}},
+        [4] = {ev=6, stamina={low=7, med=8, high=9}, normal={2, 4, 6}, dps={3, 5, 7}},
+        [5] = {ev=7, stamina={low=8, med=9, high=10}, normal={3, 5, 6}, dps={3, 6, 7}},
+        [6] = {ev=8, stamina={low=9, med=10, high=12}, normal={3, 5, 7}, dps={4, 6, 8}},
+        [7] = {ev=9, stamina={low=10, med=12, high=13}, normal={3, 6, 7}, dps={4, 7, 8}},
+        [8] = {ev=10, stamina={low=12, med=13, high=14}, normal={3, 6, 8}, dps={4, 7, 9}},
+        [9] = {ev=11, stamina={low=13, med=14, high=15}, normal={4, 6, 8}, dps={5, 7, 9}},
+        [10] = {ev=12, stamina={low=14, med=15, high=17}, normal={4, 7, 9}, dps={5, 8, 10}},
+        [11] = {ev=13, stamina={low=14, med=15, high=18}, normal={5, 7, 9}, dps={5, 8, 10}},
+    },
+    horde = {
+        [1] = {ev=3, stamina={low=10, med=15, high=20}, normal={1, 2, 3}, dps={2, 4, 5}},
+        [2] = {ev=4, stamina={low=15, med=20, high=25}, normal={2, 3, 5}, dps={3, 4, 6}},
+        [3] = {ev=5, stamina={low=20, med=25, high=30}, normal={2, 4, 5}, dps={3, 5, 6}},
+        [4] = {ev=6, stamina={low=25, med=30, high=35}, normal={2, 4, 6}, dps={3, 5, 7}},
+        [5] = {ev=7, stamina={low=30, med=35, high=40}, normal={3, 5, 6}, dps={3, 6, 7}},
+        [6] = {ev=8, stamina={low=35, med=40, high=45}, normal={3, 5, 7}, dps={4, 6, 8}},
+        [7] = {ev=9, stamina={low=40, med=45, high=50}, normal={3, 6, 7}, dps={4, 7, 8}},
+        [8] = {ev=10, stamina={low=45, med=50, high=55}, normal={3, 6, 8}, dps={4, 7, 9}},
+        [9] = {ev=11, stamina={low=50, med=55, high=60}, normal={4, 6, 8}, dps={5, 7, 9}},
+        [10] = {ev=12, stamina={low=55, med=60, high=65}, normal={4, 7, 9}, dps={5, 8, 10}},
+        [11] = {ev=13, stamina={low=55, med=60, high=70}, normal={5, 7, 9}, dps={5, 8, 10}},
+    },
+    platoon = {
+        [1] = {ev=6, stamina={low=20, med=30, high=40}, normal={3, 5, 7}, dps={4, 7, 10}},
+        [2] = {ev=8, stamina={low=30, med=40, high=50}, normal={4, 7, 10}, dps={5, 8, 11}},
+        [3] = {ev=10, stamina={low=40, med=50, high=60}, normal={5, 8, 11}, dps={5, 9, 12}},
+        [4] = {ev=12, stamina={low=50, med=60, high=70}, normal={5, 9, 12}, dps={6, 10, 13}},
+        [5] = {ev=14, stamina={low=60, med=70, high=80}, normal={6, 10, 13}, dps={6, 11, 14}},
+        [6] = {ev=16, stamina={low=70, med=80, high=90}, normal={6, 11, 14}, dps={7, 12, 15}},
+        [7] = {ev=18, stamina={low=80, med=90, high=100}, normal={7, 12, 15}, dps={7, 13, 16}},
+        [8] = {ev=20, stamina={low=90, med=100, high=110}, normal={7, 13, 16}, dps={8, 13, 17}},
+        [9] = {ev=22, stamina={low=100, med=110, high=120}, normal={8, 13, 17}, dps={9, 14, 18}},
+        [10] = {ev=24, stamina={low=110, med=120, high=130}, normal={9, 14, 18}, dps={10, 15, 19}},
+        [11] = {ev=26, stamina={low=110, med=120, high=140}, normal={10, 15, 19}, dps={10, 16, 20}},
+    },
+    leader = {
+        [1] = {ev=12, stamina={low=nil, med=nil, high=80}, normal=nil, dps={4, 7, 10}},
+        [2] = {ev=16, stamina={low=nil, med=nil, high=100}, normal=nil, dps={5, 8, 11}},
+        [3] = {ev=20, stamina={low=nil, med=nil, high=120}, normal=nil, dps={5, 9, 12}},
+        [4] = {ev=24, stamina={low=nil, med=nil, high=140}, normal=nil, dps={6, 10, 13}},
+        [5] = {ev=28, stamina={low=nil, med=nil, high=160}, normal=nil, dps={6, 11, 14}},
+        [6] = {ev=32, stamina={low=nil, med=nil, high=180}, normal=nil, dps={7, 12, 15}},
+        [7] = {ev=36, stamina={low=nil, med=nil, high=200}, normal=nil, dps={7, 13, 16}},
+        [8] = {ev=40, stamina={low=nil, med=nil, high=220}, normal=nil, dps={8, 13, 17}},
+        [9] = {ev=44, stamina={low=nil, med=nil, high=240}, normal=nil, dps={9, 14, 18}},
+        [10] = {ev=48, stamina={low=nil, med=nil, high=260}, normal=nil, dps={10, 15, 19}},
+        [11] = {ev=52, stamina={low=nil, med=nil, high=280}, normal=nil, dps={10, 16, 20}},
+    },
+    elite = {
+        [1] = {ev=12, stamina={low=40, med=60, high=80}, normal={4, 7, 10}, dps={5, 8, 11}},
+        [2] = {ev=16, stamina={low=60, med=80, high=100}, normal={5, 8, 11}, dps={5, 9, 12}},
+        [3] = {ev=20, stamina={low=80, med=100, high=120}, normal={5, 9, 12}, dps={6, 10, 13}},
+        [4] = {ev=24, stamina={low=100, med=120, high=140}, normal={6, 10, 13}, dps={6, 11, 14}},
+        [5] = {ev=28, stamina={low=120, med=140, high=160}, normal={6, 11, 14}, dps={7, 12, 15}},
+        [6] = {ev=32, stamina={low=140, med=160, high=180}, normal={7, 12, 15}, dps={7, 13, 16}},
+        [7] = {ev=36, stamina={low=160, med=180, high=200}, normal={7, 13, 16}, dps={8, 13, 17}},
+        [8] = {ev=40, stamina={low=180, med=200, high=220}, normal={8, 13, 17}, dps={9, 14, 18}},
+        [9] = {ev=44, stamina={low=200, med=220, high=240}, normal={9, 14, 18}, dps={10, 15, 19}},
+        [10] = {ev=48, stamina={low=220, med=240, high=260}, normal={10, 15, 19}, dps={10, 16, 20}},
+        [11] = {ev=52, stamina={low=220, med=240, high=280}, normal={10, 16, 20}, dps={11, 17, 21}},
+    },
+    solo = {
+        [1] = {ev=36, stamina={low=nil, med=nil, high=200}, normal=nil, dps={5, 8, 11}},
+        [2] = {ev=48, stamina={low=nil, med=nil, high=250}, normal=nil, dps={5, 9, 12}},
+        [3] = {ev=60, stamina={low=nil, med=nil, high=300}, normal=nil, dps={6, 10, 13}},
+        [4] = {ev=72, stamina={low=nil, med=nil, high=350}, normal=nil, dps={6, 11, 14}},
+        [5] = {ev=84, stamina={low=nil, med=nil, high=400}, normal=nil, dps={7, 12, 15}},
+        [6] = {ev=96, stamina={low=nil, med=nil, high=450}, normal=nil, dps={7, 13, 16}},
+        [7] = {ev=108, stamina={low=nil, med=nil, high=500}, normal=nil, dps={8, 13, 17}},
+        [8] = {ev=120, stamina={low=nil, med=nil, high=550}, normal=nil, dps={9, 14, 18}},
+        [9] = {ev=132, stamina={low=nil, med=nil, high=600}, normal=nil, dps={10, 15, 19}},
+        [10] = {ev=144, stamina={low=nil, med=nil, high=650}, normal=nil, dps={10, 16, 20}},
+        [11] = {ev=156, stamina={low=nil, med=nil, high=700}, normal=nil, dps={11, 17, 21}},
+    },
+}
+
+--Role -> stamina tier and damage type, from the sheet's MonsterIndex.
+local g_roleStaminaTier = {
+    controller = "low", hexer = "low", artillery = "low",
+    harrier = "med", mount = "med", support = "med", ambusher = "med",
+    defender = "high", brute = "high",
+}
+local g_roleDamageType = {
+    controller = "normal", hexer = "normal", harrier = "normal",
+    mount = "normal", support = "normal", defender = "normal",
+    artillery = "dps", ambusher = "dps", brute = "dps",
+}
+
+local g_organizationSet = {
+    minion = true, horde = true, platoon = true,
+    elite = true, leader = true, solo = true,
+}
+local g_roleSet = {
+    controller = true, hexer = true, artillery = true, harrier = true,
+    mount = true, support = true, ambusher = true, defender = true, brute = true,
+}
+
+--Echelon for a level: 1 (L1-3), 2 (L4-6), 3 (L7-9), 4 (L10-11).
+function MCDMMonsterScaling.Echelon(level)
+    if level <= 3 then return 1
+    elseif level <= 6 then return 2
+    elseif level <= 9 then return 3
+    else return 4 end
+end
+
+--Highest characteristic / power-roll bonus: caps at +5.
+function MCDMMonsterScaling.HighestCharacteristic(level, isLeaderSolo)
+    return math.min(5, MCDMMonsterScaling.Echelon(level) + (isLeaderSolo and 2 or 1))
+end
+
+--Strong-tier potency: caps at 6, and is NOT derived from the (capped)
+--characteristic. They diverge for leader/solo at echelon 4 (char +5, potency 6).
+function MCDMMonsterScaling.PotencyStrong(level, isLeaderSolo)
+    return math.min(6, MCDMMonsterScaling.Echelon(level) + (isLeaderSolo and 2 or 1))
+end
+
+--Parse a monster "role" string (which encodes organization and role, e.g.
+--"Elite Brute", "Minion Harrier", "Leader", or just "Harrier") into
+--(organization, role), both lowercase. Word order is tolerated. With no
+--organization keyword the standard organization is Platoon. minionFlag (the
+--engine's creature.minion) forces minion. role may be nil (e.g. bare "Leader").
+function MCDMMonsterScaling.ParseOrgRole(roleString, minionFlag)
+    local org, role
+    for word in string.gmatch(string.lower(roleString or ""), "%a+") do
+        if g_organizationSet[word] then
+            org = word
+        elseif g_roleSet[word] then
+            role = word
+        end
+    end
+    if minionFlag then org = "minion" end
+    if org == nil then org = "platoon" end
+    return org, role
+end
+
+--Stamina tier to read for an (org, role). Leader/Solo always read High.
+function MCDMMonsterScaling.StaminaTier(org, role)
+    if org == "leader" or org == "solo" then return "high" end
+    return g_roleStaminaTier[role] or "med"
+end
+
+--Damage type to read for an (org, role). Leader/Solo always read DPS.
+function MCDMMonsterScaling.DamageType(org, role)
+    if org == "leader" or org == "solo" then return "dps" end
+    return g_roleDamageType[role] or "normal"
+end
+
+--Raw table row for an (org, level), or nil if out of range / unknown org.
+function MCDMMonsterScaling.RowFor(org, level)
+    local orgTbl = g_scaleTable[org]
+    if orgTbl == nil then return nil end
+    return orgTbl[level]
+end
+
+--Per-stat deltas to apply when scaling from baseLevel to targetLevel for an
+--(org, role). Deltas are added on top of the creature's authored stats (the
+--delta-from-base model), so bespoke / hand-tuned stat blocks keep their offset.
+--Returns nil if the org is unknown or either level is out of the 1-11 range.
+--Fields:
+--  ev             EV delta (creature 'ev' attribute)
+--  stamina        Stamina delta (creature 'hitpoints')
+--  t1/t2/t3       Per-tier table-damage deltas (Tier N Damage Bonus)
+--  freeStrike     Free-strike delta = T1 table delta (no characteristic)
+--  characteristic Highest-characteristic / power-roll delta (capped at +5)
+--  potency        Potency delta (own value, capped at 6; Potency Bonus)
+--  strike         Strike Damage Bonus delta = characteristic delta
+function MCDMMonsterScaling.ComputeDeltas(org, role, baseLevel, targetLevel)
+    local b = MCDMMonsterScaling.RowFor(org, baseLevel)
+    local t = MCDMMonsterScaling.RowFor(org, targetLevel)
+    if b == nil or t == nil then return nil end
+
+    local isLeaderSolo = (org == "leader" or org == "solo")
+    local tier = MCDMMonsterScaling.StaminaTier(org, role)
+    local dtype = MCDMMonsterScaling.DamageType(org, role)
+    local bDmg, tDmg = b[dtype], t[dtype]
+
+    local function tierDelta(i)
+        if bDmg == nil or tDmg == nil then return 0 end
+        return (tDmg[i] or 0) - (bDmg[i] or 0)
+    end
+
+    local charBase = MCDMMonsterScaling.HighestCharacteristic(baseLevel, isLeaderSolo)
+    local charTarget = MCDMMonsterScaling.HighestCharacteristic(targetLevel, isLeaderSolo)
+    local potBase = MCDMMonsterScaling.PotencyStrong(baseLevel, isLeaderSolo)
+    local potTarget = MCDMMonsterScaling.PotencyStrong(targetLevel, isLeaderSolo)
+
+    return {
+        ev = t.ev - b.ev,
+        stamina = (t.stamina[tier] or 0) - (b.stamina[tier] or 0),
+        t1 = tierDelta(1),
+        t2 = tierDelta(2),
+        t3 = tierDelta(3),
+        freeStrike = tierDelta(1),
+        characteristic = charTarget - charBase,
+        potency = potTarget - potBase,
+        strike = charTarget - charBase,
+    }
+end
+
+--Convenience: parse this monster's organization and role from its data.
+function monster:ScalingOrgRole()
+    return MCDMMonsterScaling.ParseOrgRole(self:try_get("role", ""), self.minion)
+end

--- a/Draw Steel Core Rules/MCDMMonster.lua
+++ b/Draw Steel Core Rules/MCDMMonster.lua
@@ -1204,3 +1204,158 @@ end
 function monster:ScalingOrgRole()
     return MCDMMonsterScaling.ParseOrgRole(self:try_get("role", ""), self.minion)
 end
+
+--==============================================================
+-- Monster level scaling: the generated "Level Adjustment" feature.
+--
+-- The only persistent state is the authored base level (scalingBaseLevel);
+-- creature.cr holds the current (target) level. A feature carrying the
+-- base->target stat deltas is regenerated on every modifier calculation via
+-- RegisterFeatureCalculation, so rescaling just changes cr and restoring just
+-- clears scalingBaseLevel -- no stored modifiers to go stale.
+--==============================================================
+
+local g_adjustFeatureName = "Level Adjustment"
+
+--Stable guids for the generated feature and its modifiers. The feature is
+--regenerated (never persisted) per calculation and is only ever alive inside a
+--single creature's modifier list, so these need only be internally distinct.
+local g_adjustFeatureGuid = "c3079d4d-f5a8-48a9-8c6e-b4357209b4a9"
+local g_adjustModGuids = {
+    ev         = "3228246a-90ed-4759-8629-9a967641f6fa",
+    hitpoints  = "64069561-1cbb-47b6-bd01-de9a7a9ce467",
+    freeStrike = "3852aca2-a776-4744-9f67-a92f48210c80",
+    potency    = "831861c3-4d74-4fd1-af15-df1094b2c910",
+    t1         = "5557dadd-a1a1-4338-94e4-f2ffb41470ef",
+    t2         = "ad13299a-108b-47d3-ac21-c1eda5abda26",
+    t3         = "c79b4266-f7c8-49f4-ac52-0a4def6b63b8",
+    strike     = "ea86292d-b78d-47ce-9081-14533f341598",
+}
+
+--Resolve a custom attribute's GUID (the key an attribute modifier targets) by
+--name, so this survives a compendium re-import that changes the GUIDs.
+local function ScalingCustomAttrId(name)
+    local sym = string.lower(name:gsub("%s+", ""))
+    local attr = CustomAttribute.attributeInfoByLookupSymbol[sym]
+    if attr == nil then
+        return nil
+    end
+    return attr.id
+end
+
+--Build the generated "Level Adjustment" CharacterFeature from a deltas table
+--(see MCDMMonsterScaling.ComputeDeltas). Every entry is a plain add-operation
+--Modify Attribute modifier; zero deltas are skipped. Returns nil if there is
+--nothing to add.
+function MCDMMonsterScaling.BuildAdjustmentFeature(deltas)
+    if deltas == nil then
+        return nil
+    end
+
+    local specs = {
+        { key = "ev",         attribute = "ev",                  value = deltas.ev },
+        { key = "hitpoints",  attribute = "hitpoints",           value = deltas.stamina },
+        { key = "freeStrike", attribute = "Free Strike Bonus",   value = deltas.freeStrike, custom = true },
+        { key = "potency",    attribute = "Potency Bonus",       value = deltas.potency,    custom = true },
+        { key = "t1",         attribute = "Tier 1 Damage Bonus", value = deltas.t1,         custom = true },
+        { key = "t2",         attribute = "Tier 2 Damage Bonus", value = deltas.t2,         custom = true },
+        { key = "t3",         attribute = "Tier 3 Damage Bonus", value = deltas.t3,         custom = true },
+        { key = "strike",     attribute = "Strike Damage Bonus", value = deltas.strike,     custom = true },
+    }
+
+    local modifiers = {}
+    for _,spec in ipairs(specs) do
+        local value = spec.value or 0
+        if value ~= 0 then
+            local attribute = spec.attribute
+            if spec.custom then
+                attribute = ScalingCustomAttrId(spec.attribute)
+            end
+            if attribute ~= nil then
+                modifiers[#modifiers+1] = CharacterModifier.new{
+                    guid = g_adjustModGuids[spec.key],
+                    sourceguid = g_adjustFeatureGuid,
+                    name = g_adjustFeatureName,
+                    source = g_adjustFeatureName,
+                    description = "",
+                    behavior = "attribute",
+                    operation = "add",
+                    attribute = attribute,
+                    value = value,
+                }
+            end
+        end
+    end
+
+    if #modifiers == 0 then
+        return nil
+    end
+
+    return CharacterFeature.Create{
+        guid = g_adjustFeatureGuid,
+        name = g_adjustFeatureName,
+        source = g_adjustFeatureName,
+        modifiers = modifiers,
+    }
+end
+
+--The authored (base) level: the stored value if scaled, else the current cr.
+function monster:GetScalingBaseLevel()
+    return round(tonumber(self:try_get("scalingBaseLevel", self.cr)) or 0)
+end
+
+--True if a level adjustment is currently in effect.
+function monster:HasLevelAdjustment()
+    local base = self:try_get("scalingBaseLevel")
+    return base ~= nil and round(tonumber(base) or 0) ~= round(tonumber(self.cr) or 0)
+end
+
+--Scale this monster to targetLevel (clamped to 1-11). Stores the authored base
+--level on first use; clears the adjustment if targetLevel returns to base.
+--Mutates creature properties -- callers outside the character sheet must wrap
+--this in token:ModifyProperties.
+function monster:SetLevelAdjustment(targetLevel)
+    targetLevel = round(tonumber(targetLevel) or 0)
+    targetLevel = math.max(MCDMMonsterScaling.minLevel, math.min(MCDMMonsterScaling.maxLevel, targetLevel))
+
+    local base = self:GetScalingBaseLevel()
+    if targetLevel == base then
+        self:ClearLevelAdjustment()
+        return
+    end
+
+    self.scalingBaseLevel = base
+    self.cr = targetLevel
+end
+
+--Remove the level adjustment, restoring the monster to its authored level.
+function monster:ClearLevelAdjustment()
+    if self:has_key("scalingBaseLevel") then
+        self.cr = self:GetScalingBaseLevel()
+        self.scalingBaseLevel = nil
+    end
+end
+
+creature.RegisterFeatureCalculation{
+    id = "monsterLevelScaling",
+    FillFeatures = function(c, result)
+        if not c:IsMonster() then
+            return
+        end
+        local base = c:try_get("scalingBaseLevel")
+        if base == nil then
+            return
+        end
+        base = round(tonumber(base) or 0)
+        local target = round(tonumber(c.cr) or base)
+        if target == base then
+            return
+        end
+
+        local org, role = MCDMMonsterScaling.ParseOrgRole(c:try_get("role", ""), c:try_get("minion", false))
+        local feature = MCDMMonsterScaling.BuildAdjustmentFeature(MCDMMonsterScaling.ComputeDeltas(org, role, base, target))
+        if feature ~= nil then
+            result[#result+1] = feature
+        end
+    end,
+}

--- a/Draw Steel V/DrawSteelChararcterSheet.lua
+++ b/Draw Steel V/DrawSteelChararcterSheet.lua
@@ -2564,9 +2564,9 @@ local function ShowAdjustLevelDialog(token)
 
         if footerLabel ~= nil and footerLabel.valid then
             if targetLevel == baseLevel then
-                footerLabel.text = "At the base level. No feature is added."
+                footerLabel.text = "At the base level. No adjustment is applied."
             else
-                footerLabel.text = "This adjustment adds a feature to the creature. Delete the feature or click the Reset button below to restore the creature to its original level."
+                footerLabel.text = "Click Reset to restore the creature to its original level."
             end
         end
     end

--- a/Draw Steel V/DrawSteelChararcterSheet.lua
+++ b/Draw Steel V/DrawSteelChararcterSheet.lua
@@ -11,6 +11,21 @@ local g_abilityActionSortOrder = {
     [g_villainActionId] = 1,
 }
 
+-- Villain-action slot vocabulary, shared by the sheet's Villain Actions slots
+-- (CreateAbilityListPanel, earlier in the file) and the picker modal
+-- (ShowVillainActionPicker, far below). The picker is launched for one slot at a
+-- time and only offers candidates authored for that same slot (slot-locked).
+local g_villainSlotMeta = {
+    ["Villain Action 1"] = { label = "Opener",        roman = "I" },
+    ["Villain Action 2"] = { label = "Crowd Control",  roman = "II" },
+    ["Villain Action 3"] = { label = "Showstopper",    roman = "III" },
+}
+local g_villainSlotOrder = { "Villain Action 1", "Villain Action 2", "Villain Action 3" }
+
+-- Forward-declared: defined far below, but referenced by the sheet's Villain
+-- Actions empty-slot Add affordances (CreateAbilityListPanel) which build earlier.
+local ShowVillainActionPicker
+
 --Transient highlight for a capability revealed from search (Phase B). The
 --reveal flashes the accent on instantly, HOLDS it, then fades out over
 --SEARCH_REVEAL_FADE (the rule's transitionTime, eased) with a dark gap before
@@ -801,6 +816,54 @@ local function CreateAbilityListPanel()
         return actionid
     end
 
+    -- Villain Actions empty-slot Add affordances. Solos and leaders are expected
+    -- to field three villain actions (Opener / Crowd Control / Showstopper); when a
+    -- slot is unfilled this surfaces an Add row that launches the picker for that
+    -- slot. Built once; refreshToken toggles each row by which slots are filled and
+    -- whether the group is shown + expanded. Normal monster-building (a non-solo,
+    -- non-leader creature with no villain actions) never sees these.
+    local m_villainSlotRows = {}
+    local m_villainSlotsPanel
+    do
+        local rows = {}
+        for _, slotId in ipairs(g_villainSlotOrder) do
+            local capturedSlot = slotId
+            local slotMeta = g_villainSlotMeta[slotId]
+            local row = gui.Panel{
+                classes = { "villainSlotAdd", "hoverable", "collapsed" },
+                width = "100%",
+                height = 32,
+                flow = "horizontal",
+                valign = "center",
+                borderBox = true,
+                hpad = 12,
+                click = function(element)
+                    local token = CharacterSheet.instance ~= nil
+                        and CharacterSheet.instance.data.info.token or nil
+                    if token ~= nil and ShowVillainActionPicker ~= nil then
+                        ShowVillainActionPicker(token, capturedSlot)
+                    end
+                end,
+                gui.Label{
+                    classes = { "villainSlotAddLabel" },
+                    width = "auto", height = "auto",
+                    valign = "center",
+                    text = string.format("+  Add %s", slotMeta.label),
+                },
+            }
+            m_villainSlotRows[slotId] = row
+            rows[#rows + 1] = row
+        end
+        m_villainSlotsPanel = gui.Panel{
+            classes = { "collapsed" },
+            width = "100%",
+            height = "auto",
+            flow = "vertical",
+            data = { ord = g_villainActionId },
+            children = rows,
+        }
+    end
+
     local function buildActionMenuStyles()
         return ThemeEngine.MergeTokens{
             Styles.ActionMenu,
@@ -819,6 +882,13 @@ local function CreateAbilityListPanel()
             { selectors = {"abilityTitle"},     color = "@fgStrong" },
             { selectors = {"abilityInfoLabel"}, color = "@fgMuted" },
 
+            -- Villain Actions empty-slot Add rows.
+            { selectors = {"villainSlotAdd"},
+              bgcolor = "@bg", borderColor = "@border", borderWidth = 1 },
+            { selectors = {"villainSlotAdd", "hover"},
+              bgcolor = "@bgAlt", borderColor = "@accent" },
+            { selectors = {"villainSlotAddLabel"}, color = "@fgMuted", fontSize = 14 },
+
             SEARCH_REVEAL_RULE,
         }
     end
@@ -829,6 +899,7 @@ local function CreateAbilityListPanel()
         m_triggersLabel,
         m_otherActionsLabel,
         m_villainActionsLabel,
+        m_villainSlotsPanel,
         styles = buildActionMenuStyles(),
         width = "100%-12",
         height = "auto",
@@ -845,14 +916,29 @@ local function CreateAbilityListPanel()
             local abilities = c:GetActivatedAbilities {} -- characterSheet = true }
             local children = {}
 
+            -- Which villain-action slots are already filled, and whether the
+            -- creature is a solo or leader (the orgs expected to have villain
+            -- actions). The Villain Actions group -- and its empty-slot Add rows --
+            -- show when the creature has villain actions OR is a solo/leader, so
+            -- normal monster-building never surfaces them.
             local hasVillainActions = false
+            local slotFilled = {}
             for _, ability in ipairs(abilities) do
                 if IsVillainAction(ability) then
                     hasVillainActions = true
-                    break
+                    local slot = ability:try_get("villainAction")
+                    if slot ~= nil then
+                        slotFilled[slot] = true
+                    end
                 end
             end
-            m_villainActionsLabel:SetClass("collapsed", not hasVillainActions)
+            local isSoloOrLeader = false
+            pcall(function()
+                local org = c:ScalingOrgRole()
+                isSoloOrLeader = (org == "solo" or org == "leader")
+            end)
+            local showVillainGroup = hasVillainActions or isSoloOrLeader
+            m_villainActionsLabel:SetClass("collapsed", not showVillainGroup)
 
             local showAbilities = {}
             if not m_mainActionsLabel:HasClass("collapseSet") then
@@ -867,7 +953,8 @@ local function CreateAbilityListPanel()
                 showAbilities["other"] = true
             end
 
-            if hasVillainActions and not m_villainActionsLabel:HasClass("collapseSet") then
+            local villainExpanded = showVillainGroup and not m_villainActionsLabel:HasClass("collapseSet")
+            if villainExpanded then
                 showAbilities[g_villainActionId] = true
             end
 
@@ -950,6 +1037,20 @@ local function CreateAbilityListPanel()
             for _, heading in ipairs(headings) do
                 children[#children + 1] = heading
             end
+
+            -- Villain Actions empty-slot Add rows: surface each unfilled slot, but
+            -- only when the group is shown and expanded. Appended after the villain
+            -- header / villain abilities (villain actions sort last).
+            local anyEmptySlot = false
+            for _, slotId in ipairs(g_villainSlotOrder) do
+                local emptySlot = villainExpanded and not slotFilled[slotId]
+                m_villainSlotRows[slotId]:SetClass("collapsed", not emptySlot)
+                if emptySlot then
+                    anyEmptySlot = true
+                end
+            end
+            m_villainSlotsPanel:SetClass("collapsed", not anyEmptySlot)
+            children[#children + 1] = m_villainSlotsPanel
 
             for i = #abilities + 1, #m_abilityPanels do
                 m_abilityPanels[i]:SetClass("collapsed", true)
@@ -2916,14 +3017,6 @@ local function ShowAdjustLevelDialog(token)
     gui.ShowModal(dialog)
 end
 
--- Villain-action slot vocabulary. The picker is launched for one slot at a time
--- and only offers candidates authored for that same slot (slot-locked).
-local g_villainSlotMeta = {
-    ["Villain Action 1"] = { label = "Opener",        roman = "I" },
-    ["Villain Action 2"] = { label = "Crowd Control",  roman = "II" },
-    ["Villain Action 3"] = { label = "Showstopper",    roman = "III" },
-}
-
 -- Maps an implementation-status value (gui.ImplementationStatus) to the status
 -- modifier class for the canonical colored dot (DefaultStyles spellImplementationIcon).
 local g_implDotClass = {
@@ -2942,7 +3035,8 @@ local g_implDotClass = {
 -- New Villain Action" arrive in the next pass. Reuses the cached bestiary
 -- ability index (GetBestiaryVillainActions / GetBestiaryAbilityObject) so it
 -- shares the bestiary's single GoblinScript scan rather than re-scanning.
-local function ShowVillainActionPicker(token, slot)
+-- Assigns the forward-declared local (see top of file).
+function ShowVillainActionPicker(token, slot)
     if token == nil or token.properties == nil then
         return
     end

--- a/Draw Steel V/DrawSteelChararcterSheet.lua
+++ b/Draw Steel V/DrawSteelChararcterSheet.lua
@@ -2924,6 +2924,16 @@ local g_villainSlotMeta = {
     ["Villain Action 3"] = { label = "Showstopper",    roman = "III" },
 }
 
+-- Maps an implementation-status value (gui.ImplementationStatus) to the status
+-- modifier class for the canonical colored dot (DefaultStyles spellImplementationIcon).
+local g_implDotClass = {
+    [0] = "wontimplement",
+    [1] = "unimplemented",
+    [2] = "bronze",
+    [3] = "silver",
+    [4] = "gold",
+}
+
 -- Browse every villain action across the bestiary in a given slot, preview the
 -- real ability card, and duplicate one onto this creature. CHUNK 2 (modal core):
 -- slot-locked alphabetical list + real CreateAbilityTooltip preview + "Add to
@@ -2946,10 +2956,44 @@ local function ShowVillainActionPicker(token, slot)
     local dialog
     local listPanel
     local previewPanel
+    local verdictLabel
     local addButton
     local selectedEntry = nil
 
+    -- Filter state. allEntries is the slot's full candidate set (stored once the
+    -- bestiary index is ready); the visible list is derived from it by the search
+    -- needle and the cross-check toggle.
+    local allEntries = {}
+    local searchNeedle = ""
+    -- "Exclude Narrative and Unimplemented" cross-checks the status field (which
+    -- the importer over-marks) against the structural signal: keep only entries
+    -- that are Bronze+ AND carry real behaviors. Default off -- inform, do not
+    -- enforce; the director opts in.
+    local excludeUnimplemented = false
+
+    -- The status field is unreliable on its own (the importer over-marks Silver),
+    -- so the verdict cross-checks it against whether the ability carries real
+    -- behaviors: "<Status> - mechanics verified" when it auto-resolves, or
+    -- "<Status> - no mechanics (text only)" when it is director-adjudicated.
+    local function UpdateVerdict()
+        if verdictLabel == nil or not verdictLabel.valid then
+            return
+        end
+        if selectedEntry == nil then
+            verdictLabel:SetClass("collapsed", true)
+            return
+        end
+        local status = selectedEntry.implementation or 1
+        local statusName = gui.ImplementationStatusValues[status] or "Unknown"
+        local verdict = cond(selectedEntry.hasBehaviors,
+            "mechanics verified", "no mechanics (text only)")
+        verdictLabel.text = string.format("%s - %s", statusName, verdict)
+        verdictLabel.classes = { "sizeXs", "bold", "implStatus" .. tostring(status) }
+        verdictLabel:SetClass("collapsed", false)
+    end
+
     local function RefreshPreview()
+        UpdateVerdict()
         if previewPanel == nil or not previewPanel.valid then
             return
         end
@@ -3003,12 +3047,14 @@ local function ShowVillainActionPicker(token, slot)
             if entry.level ~= nil then
                 subText = string.format("%s - Level %d", subText, entry.level)
             end
+            local status = entry.implementation or 1
+            local dotClass = g_implDotClass[status] or "unimplemented"
             local row
             row = gui.Panel{
                 classes = { "row", cond(i % 2 == 0, "evenRow", "oddRow"), "hoverable" },
                 width = "100%",
                 height = "auto",
-                flow = "vertical",
+                flow = "horizontal",
                 borderBox = true,
                 hpad = 10,
                 vpad = 6,
@@ -3024,32 +3070,72 @@ local function ShowVillainActionPicker(token, slot)
                     end
                     RefreshPreview()
                 end,
-                gui.Label{
-                    classes = { "tableLabel", "bold" },
-                    text = capturedEntry.name,
-                    width = "100%", height = "auto",
-                    halign = "left", textWrap = true,
+                -- Per-row implementation-status dot (the canonical colored dot
+                -- used on compendium entries; scheme-consistent implStatus tokens).
+                gui.Panel{
+                    classes = { "spellImplementationIcon", dotClass },
+                    halign = "left",
+                    valign = "center",
                 },
-                gui.Label{
-                    classes = { "sizeXs" },
-                    text = subText,
-                    width = "100%", height = "auto",
-                    halign = "left", textWrap = true,
+                gui.Panel{
+                    width = "100%-24", height = "auto", flow = "vertical",
+                    halign = "left", valign = "center",
+                    gui.Label{
+                        classes = { "tableLabel", "bold" },
+                        text = capturedEntry.name,
+                        width = "100%", height = "auto",
+                        halign = "left", textWrap = true,
+                    },
+                    gui.Label{
+                        classes = { "sizeXs" },
+                        text = subText,
+                        width = "100%", height = "auto",
+                        halign = "left", textWrap = true,
+                    },
                 },
             }
             rows[#rows + 1] = row
         end
         if #rows == 0 then
+            local emptyText = cond(#allEntries == 0,
+                "No villain actions found for this slot.",
+                "No villain actions match your search and filter.")
             rows = {
                 gui.Label{
                     classes = { "sizeS" },
-                    text = "No villain actions found for this slot.",
+                    text = emptyText,
                     width = "100%", height = "auto",
                     halign = "center", textAlignment = "center", textWrap = true,
                 },
             }
         end
         return rows
+    end
+
+    -- Derive the visible list from allEntries by the search needle (matched over a
+    -- combined name + monster + level haystack, reusing Search.MatchesText) and
+    -- the cross-check toggle. Then rebuild the rows.
+    local function ApplyFilter()
+        if listPanel == nil or not listPanel.valid then
+            return
+        end
+        local filtered = {}
+        for _, e in ipairs(allEntries) do
+            local keep = true
+            if excludeUnimplemented then
+                local status = e.implementation or 1
+                keep = (status >= gui.ImplementationStatus.Bronze) and (e.hasBehaviors == true)
+            end
+            if keep and searchNeedle ~= "" then
+                local hay = string.format("%s %s level %s",
+                    e.name or "", e.monsterName or "", tostring(e.level or ""))
+                keep = Search.MatchesText(hay, searchNeedle)
+            end
+            if keep then
+                filtered[#filtered + 1] = e
+            end
+        end
+        listPanel.children = BuildRows(filtered)
     end
 
     -- The bestiary index builds lazily in a coroutine. If it is not ready yet,
@@ -3076,22 +3162,60 @@ local function ShowVillainActionPicker(token, slot)
             end)
             return
         end
-        listPanel.children = BuildRows(entries)
+        allEntries = entries
+        ApplyFilter()
     end
 
     listPanel = gui.Panel{
         vscroll = true,
         width = "100%",
-        height = "100%",
+        -- Fills the left pane below the search input and the filter checkbox.
+        height = "100%-72",
         flow = "vertical",
     }
 
     previewPanel = gui.Panel{
         vscroll = true,
         width = "100%",
-        height = "100%",
+        height = "100%-28",
         flow = "vertical",
         halign = "center",
+    }
+
+    -- Cross-check verdict, shown under the preview card.
+    verdictLabel = gui.Label{
+        classes = { "sizeXs", "bold", "collapsed" },
+        width = "100%", height = "auto",
+        halign = "left", valign = "bottom",
+        textAlignment = "left", textWrap = true,
+        tmargin = 6,
+    }
+
+    -- Smart search: ability name, monster name, or level (reuses the global
+    -- search matcher). Results stay grouped alphabetically.
+    local searchInput = gui.SearchInput{
+        width = "100%",
+        height = 26,
+        fontSize = 14,
+        halign = "left",
+        placeholderText = "Search villain actions, monsters, levels...",
+        editlag = 0.25,
+        edit = function(element)
+            searchNeedle = Search.Normalize(element.text) or ""
+            ApplyFilter()
+        end,
+    }
+
+    -- The cross-check filter. gui.Check has intrinsic sizing -- never width 100%.
+    local excludeCheck = gui.Check{
+        text = "Exclude Narrative and Unimplemented",
+        value = excludeUnimplemented,
+        halign = "left",
+        vmargin = 6,
+        change = function(element)
+            excludeUnimplemented = element.value
+            ApplyFilter()
+        end,
     }
 
     addButton = gui.Button{
@@ -3169,7 +3293,8 @@ local function ShowVillainActionPicker(token, slot)
             tmargin = 4, bmargin = 10,
         },
 
-        -- Two-pane body: slot-locked candidate list | real ability-card preview.
+        -- Two-pane body. Left: search + cross-check filter + slot-locked list.
+        -- Right: the real ability-card preview + the cross-check verdict.
         gui.Panel{
             width = "100%",
             height = "100%-150",
@@ -3177,16 +3302,19 @@ local function ShowVillainActionPicker(token, slot)
 
             gui.Panel{
                 width = "44%", height = "100%", flow = "vertical",
+                searchInput,
+                excludeCheck,
                 listPanel,
             },
             gui.Panel{ width = "2%", height = "100%" },
             gui.Panel{
                 width = "54%", height = "100%", flow = "vertical",
                 previewPanel,
+                verdictLabel,
             },
         },
 
-        -- Cancel / Add to this creature.
+        -- Cancel / Create New Villain Action / Add to this creature.
         gui.Panel{
             width = "100%", height = "auto", flow = "horizontal",
             halign = "center", valign = "bottom", tmargin = 16,
@@ -3196,6 +3324,31 @@ local function ShowVillainActionPicker(token, slot)
                 width = 120, height = 40, hmargin = 6,
                 click = function(element)
                     gui.CloseModal()
+                end,
+            },
+            -- Build a fresh villain action from scratch in the ability editor,
+            -- preset to this slot. Mirrors the sheet's Create Ability path.
+            gui.Button{
+                text = "Create New Villain Action",
+                width = 220, height = 40, hmargin = 6,
+                click = function(element)
+                    gui.CloseModal()
+                    if CharacterSheet.instance == nil then
+                        return
+                    end
+                    local newAbility = ActivatedAbility.Create {
+                        name = "New Villain Action",
+                        categorization = "Villain Action",
+                        villainAction = slot,
+                    }
+                    CharacterSheet.instance:AddChild(newAbility:ShowEditActivatedAbilityDialog {
+                        add = function(el)
+                            CharacterSheet.instance.data.info.token.properties:AddInnateActivatedAbility(newAbility)
+                            CharacterSheet.instance:FireEvent("refreshAll")
+                        end,
+                        cancel = function(el)
+                        end,
+                    })
                 end,
             },
             addButton,

--- a/Draw Steel V/DrawSteelChararcterSheet.lua
+++ b/Draw Steel V/DrawSteelChararcterSheet.lua
@@ -2916,6 +2916,297 @@ local function ShowAdjustLevelDialog(token)
     gui.ShowModal(dialog)
 end
 
+-- Villain-action slot vocabulary. The picker is launched for one slot at a time
+-- and only offers candidates authored for that same slot (slot-locked).
+local g_villainSlotMeta = {
+    ["Villain Action 1"] = { label = "Opener",        roman = "I" },
+    ["Villain Action 2"] = { label = "Crowd Control",  roman = "II" },
+    ["Villain Action 3"] = { label = "Showstopper",    roman = "III" },
+}
+
+-- Browse every villain action across the bestiary in a given slot, preview the
+-- real ability card, and duplicate one onto this creature. CHUNK 2 (modal core):
+-- slot-locked alphabetical list + real CreateAbilityTooltip preview + "Add to
+-- this creature" (deep-copy with a fresh guid, categorization + slot preset).
+-- Search, the implementation-status cross-check filter, status dots, and "Create
+-- New Villain Action" arrive in the next pass. Reuses the cached bestiary
+-- ability index (GetBestiaryVillainActions / GetBestiaryAbilityObject) so it
+-- shares the bestiary's single GoblinScript scan rather than re-scanning.
+local function ShowVillainActionPicker(token, slot)
+    if token == nil or token.properties == nil then
+        return
+    end
+    if not token.properties:IsMonster() then
+        return
+    end
+
+    local meta = g_villainSlotMeta[slot] or { label = "Villain Action", roman = "" }
+
+    -- Forward-declared so the list / preview / add handlers can reach them.
+    local dialog
+    local listPanel
+    local previewPanel
+    local addButton
+    local selectedEntry = nil
+
+    local function RefreshPreview()
+        if previewPanel == nil or not previewPanel.valid then
+            return
+        end
+        local children
+        if selectedEntry == nil then
+            children = {
+                gui.Label{
+                    classes = { "sizeS" },
+                    text = "Select a villain action to preview it.",
+                    width = "100%", height = "auto",
+                    halign = "center", valign = "center",
+                    textAlignment = "center", textWrap = true,
+                },
+            }
+        else
+            -- The real ability card (1:1 with how it renders in play), not a
+            -- re-render. Fetched on demand for the one selected ability.
+            local obj = GetBestiaryAbilityObject(selectedEntry.monsterId, selectedEntry.name)
+            local card = nil
+            if obj ~= nil then
+                card = CreateAbilityTooltip(obj, { token = token, width = 380, pad = 8 })
+            end
+            if card ~= nil then
+                children = { card }
+            else
+                children = {
+                    gui.Label{
+                        classes = { "sizeS" },
+                        text = "This ability could not be loaded for preview.",
+                        width = "100%", height = "auto",
+                        halign = "center", valign = "center",
+                        textAlignment = "center", textWrap = true,
+                    },
+                }
+            end
+        end
+        previewPanel.children = children
+    end
+
+    local function BuildRows(entries)
+        table.sort(entries, function(a, b)
+            if a.name ~= b.name then
+                return a.name < b.name
+            end
+            return (a.monsterName or "") < (b.monsterName or "")
+        end)
+        local rows = {}
+        for i, entry in ipairs(entries) do
+            local capturedEntry = entry
+            local subText = entry.monsterName or ""
+            if entry.level ~= nil then
+                subText = string.format("%s - Level %d", subText, entry.level)
+            end
+            local row
+            row = gui.Panel{
+                classes = { "row", cond(i % 2 == 0, "evenRow", "oddRow"), "hoverable" },
+                width = "100%",
+                height = "auto",
+                flow = "vertical",
+                borderBox = true,
+                hpad = 10,
+                vpad = 6,
+                press = function(element)
+                    selectedEntry = capturedEntry
+                    if listPanel ~= nil and listPanel.valid then
+                        for _, child in ipairs(listPanel.children) do
+                            child:SetClass("selected", child == element)
+                        end
+                    end
+                    if addButton ~= nil and addButton.valid then
+                        addButton.interactable = true
+                    end
+                    RefreshPreview()
+                end,
+                gui.Label{
+                    classes = { "tableLabel", "bold" },
+                    text = capturedEntry.name,
+                    width = "100%", height = "auto",
+                    halign = "left", textWrap = true,
+                },
+                gui.Label{
+                    classes = { "sizeXs" },
+                    text = subText,
+                    width = "100%", height = "auto",
+                    halign = "left", textWrap = true,
+                },
+            }
+            rows[#rows + 1] = row
+        end
+        if #rows == 0 then
+            rows = {
+                gui.Label{
+                    classes = { "sizeS" },
+                    text = "No villain actions found for this slot.",
+                    width = "100%", height = "auto",
+                    halign = "center", textAlignment = "center", textWrap = true,
+                },
+            }
+        end
+        return rows
+    end
+
+    -- The bestiary index builds lazily in a coroutine. If it is not ready yet,
+    -- show a loading line and re-poll until it is.
+    local function Populate()
+        if listPanel == nil or not listPanel.valid then
+            return
+        end
+        local entries, ready = GetBestiaryVillainActions(slot)
+        if not ready then
+            listPanel.children = {
+                gui.Label{
+                    classes = { "sizeS" },
+                    text = "Loading bestiary...",
+                    width = "100%", height = "auto",
+                    halign = "center", textAlignment = "center",
+                },
+            }
+            dmhub.Schedule(0.3, function()
+                if mod.unloaded then
+                    return
+                end
+                Populate()
+            end)
+            return
+        end
+        listPanel.children = BuildRows(entries)
+    end
+
+    listPanel = gui.Panel{
+        vscroll = true,
+        width = "100%",
+        height = "100%",
+        flow = "vertical",
+    }
+
+    previewPanel = gui.Panel{
+        vscroll = true,
+        width = "100%",
+        height = "100%",
+        flow = "vertical",
+        halign = "center",
+    }
+
+    addButton = gui.Button{
+        text = "Add to this creature",
+        width = 200,
+        height = 40,
+        hmargin = 6,
+        interactable = false,
+        click = function(element)
+            if selectedEntry == nil then
+                return
+            end
+            local source = GetBestiaryAbilityObject(selectedEntry.monsterId, selectedEntry.name)
+            if source == nil then
+                return
+            end
+            -- Duplicate the source onto this creature (the source is untouched).
+            -- Fresh guid so it is a distinct ability; force the categorization and
+            -- the launched slot so it lands in the right group even if the source
+            -- was authored for a different slot. This modal lives outside the sheet
+            -- panel tree, so the mutation is wrapped in ModifyProperties (mirroring
+            -- the Adjust Level Apply) rather than relying on the sheet's own upload.
+            local copy = DeepCopy(source)
+            copy.guid = dmhub.GenerateGuid()
+            copy.categorization = "Villain Action"
+            copy.villainAction = slot
+            token:ModifyProperties{
+                description = "Add villain action",
+                execute = function()
+                    token.properties:AddInnateActivatedAbility(copy)
+                end,
+            }
+            if CharacterSheet.instance ~= nil then
+                CharacterSheet.instance:FireEvent("refreshAll")
+            end
+            gui.CloseModal()
+        end,
+    }
+
+    dialog = gui.Panel{
+        classes = { "dialog" },
+        styles = ThemeEngine.GetStyles(),
+        width = 820,
+        height = 600,
+        flow = "vertical",
+        borderBox = true,
+        pad = 20,
+
+        gui.Label{
+            classes = { "modalTitle" },
+            text = "Add Villain Action",
+            width = "100%", height = "auto",
+            tmargin = 4,
+        },
+
+        gui.Button{
+            classes = { "closeButton" },
+            halign = "right",
+            valign = "top",
+            floating = true,
+            margin = 8,
+            escapePriority = EscapePriority.EXIT_MODAL_DIALOG,
+            click = function(element)
+                gui.CloseModal()
+            end,
+        },
+
+        -- Context line: "Opener - Villain Action I - <creature>".
+        gui.Label{
+            classes = { "sizeS" },
+            text = string.format("<b>%s</b> - Villain Action %s - %s",
+                meta.label, meta.roman, token.name or "Monster"),
+            width = "100%", height = "auto",
+            halign = "left", textAlignment = "left", textWrap = true,
+            tmargin = 4, bmargin = 10,
+        },
+
+        -- Two-pane body: slot-locked candidate list | real ability-card preview.
+        gui.Panel{
+            width = "100%",
+            height = "100%-150",
+            flow = "horizontal",
+
+            gui.Panel{
+                width = "44%", height = "100%", flow = "vertical",
+                listPanel,
+            },
+            gui.Panel{ width = "2%", height = "100%" },
+            gui.Panel{
+                width = "54%", height = "100%", flow = "vertical",
+                previewPanel,
+            },
+        },
+
+        -- Cancel / Add to this creature.
+        gui.Panel{
+            width = "100%", height = "auto", flow = "horizontal",
+            halign = "center", valign = "bottom", tmargin = 16,
+
+            gui.Button{
+                text = "Cancel",
+                width = 120, height = 40, hmargin = 6,
+                click = function(element)
+                    gui.CloseModal()
+                end,
+            },
+            addButton,
+        },
+    }
+
+    Populate()
+    RefreshPreview()
+    gui.ShowModal(dialog)
+end
+
 local function DSCharSheet()
     --find id for recovery from resourcestable
     local recoveryid = "5bd90f9b-46be-4cf2-8ca6-a96430d62949"

--- a/Draw Steel V/DrawSteelChararcterSheet.lua
+++ b/Draw Steel V/DrawSteelChararcterSheet.lua
@@ -829,14 +829,19 @@ local function CreateAbilityListPanel()
         for _, slotId in ipairs(g_villainSlotOrder) do
             local capturedSlot = slotId
             local slotMeta = g_villainSlotMeta[slotId]
+            -- Card-sized empty slot: mirrors an ability card's footprint (60 tall,
+            -- full width) but reads as a placeholder -- quiet nested fill, a muted
+            -- centered "+ Add <slot>" -- so it signals "this slot is waiting to be
+            -- filled" rather than hiding as a thin row.
             local row = gui.Panel{
                 classes = { "villainSlotAdd", "hoverable", "collapsed" },
                 width = "100%",
-                height = 32,
+                height = 60,
                 flow = "horizontal",
+                halign = "center",
                 valign = "center",
                 borderBox = true,
-                hpad = 12,
+                vmargin = 3,
                 click = function(element)
                     local token = CharacterSheet.instance ~= nil
                         and CharacterSheet.instance.data.info.token or nil
@@ -844,11 +849,34 @@ local function CreateAbilityListPanel()
                         ShowVillainActionPicker(token, capturedSlot)
                     end
                 end,
-                gui.Label{
-                    classes = { "villainSlotAddLabel" },
-                    width = "auto", height = "auto",
-                    valign = "center",
-                    text = string.format("+  Add %s", slotMeta.label),
+                gui.Panel{
+                    width = "auto", height = "auto", flow = "vertical",
+                    halign = "center", valign = "center",
+                    gui.Panel{
+                        width = "auto", height = "auto", flow = "horizontal",
+                        halign = "center", valign = "center",
+                        gui.Panel{
+                            classes = { "villainSlotAddIcon" },
+                            bgimage = "ui-icons/Plus.png",
+                            width = 16, height = 16,
+                            valign = "center",
+                        },
+                        gui.Label{
+                            classes = { "villainSlotAddLabel" },
+                            width = "auto", height = "auto",
+                            valign = "center",
+                            hmargin = 8,
+                            text = string.format("Add %s", slotMeta.label),
+                        },
+                    },
+                    -- Subline naming the slot ("Villain Action I/II/III"), smaller.
+                    gui.Label{
+                        classes = { "villainSlotAddSub" },
+                        width = "auto", height = "auto",
+                        halign = "center",
+                        textAlignment = "center",
+                        text = string.format("Villain Action %s", slotMeta.roman),
+                    },
                 },
             }
             m_villainSlotRows[slotId] = row
@@ -882,12 +910,17 @@ local function CreateAbilityListPanel()
             { selectors = {"abilityTitle"},     color = "@fgStrong" },
             { selectors = {"abilityInfoLabel"}, color = "@fgMuted" },
 
-            -- Villain Actions empty-slot Add rows.
+            -- Villain Actions empty-slot Add cards: a quiet nested placeholder
+            -- (@bgAlt fill, muted glyph + label) that brightens (hoverable) and
+            -- gains an accent frame on hover.
             { selectors = {"villainSlotAdd"},
-              bgcolor = "@bg", borderColor = "@border", borderWidth = 1 },
+              bgcolor = "@bgAlt", borderColor = "@border", borderWidth = 1,
+              bgimage = true },
             { selectors = {"villainSlotAdd", "hover"},
-              bgcolor = "@bgAlt", borderColor = "@accent" },
-            { selectors = {"villainSlotAddLabel"}, color = "@fgMuted", fontSize = 14 },
+              borderColor = "@accent" },
+            { selectors = {"villainSlotAddLabel"}, color = "@fgMuted", fontSize = 18 },
+            { selectors = {"villainSlotAddSub"}, color = "@fgMuted", fontSize = 12 },
+            { selectors = {"villainSlotAddIcon"}, bgcolor = "@fgMuted" },
 
             SEARCH_REVEAL_RULE,
         }
@@ -3049,8 +3082,8 @@ function ShowVillainActionPicker(token, slot)
     -- Forward-declared so the list / preview / add handlers can reach them.
     local dialog
     local listPanel
+    local listContent
     local previewPanel
-    local verdictLabel
     local addButton
     local selectedEntry = nil
 
@@ -3065,29 +3098,7 @@ function ShowVillainActionPicker(token, slot)
     -- enforce; the director opts in.
     local excludeUnimplemented = false
 
-    -- The status field is unreliable on its own (the importer over-marks Silver),
-    -- so the verdict cross-checks it against whether the ability carries real
-    -- behaviors: "<Status> - mechanics verified" when it auto-resolves, or
-    -- "<Status> - no mechanics (text only)" when it is director-adjudicated.
-    local function UpdateVerdict()
-        if verdictLabel == nil or not verdictLabel.valid then
-            return
-        end
-        if selectedEntry == nil then
-            verdictLabel:SetClass("collapsed", true)
-            return
-        end
-        local status = selectedEntry.implementation or 1
-        local statusName = gui.ImplementationStatusValues[status] or "Unknown"
-        local verdict = cond(selectedEntry.hasBehaviors,
-            "mechanics verified", "no mechanics (text only)")
-        verdictLabel.text = string.format("%s - %s", statusName, verdict)
-        verdictLabel.classes = { "sizeXs", "bold", "implStatus" .. tostring(status) }
-        verdictLabel:SetClass("collapsed", false)
-    end
-
     local function RefreshPreview()
-        UpdateVerdict()
         if previewPanel == nil or not previewPanel.valid then
             return
         end
@@ -3154,8 +3165,8 @@ function ShowVillainActionPicker(token, slot)
                 vpad = 6,
                 press = function(element)
                     selectedEntry = capturedEntry
-                    if listPanel ~= nil and listPanel.valid then
-                        for _, child in ipairs(listPanel.children) do
+                    if listContent ~= nil and listContent.valid then
+                        for _, child in ipairs(listContent.children) do
                             child:SetClass("selected", child == element)
                         end
                     end
@@ -3164,15 +3175,8 @@ function ShowVillainActionPicker(token, slot)
                     end
                     RefreshPreview()
                 end,
-                -- Per-row implementation-status dot (the canonical colored dot
-                -- used on compendium entries; scheme-consistent implStatus tokens).
                 gui.Panel{
-                    classes = { "spellImplementationIcon", dotClass },
-                    halign = "left",
-                    valign = "center",
-                },
-                gui.Panel{
-                    width = "100%-24", height = "auto", flow = "vertical",
+                    width = "100%-22", height = "auto", flow = "vertical",
                     halign = "left", valign = "center",
                     gui.Label{
                         classes = { "tableLabel", "bold" },
@@ -3186,6 +3190,14 @@ function ShowVillainActionPicker(token, slot)
                         width = "100%", height = "auto",
                         halign = "left", textWrap = true,
                     },
+                },
+                -- Per-row implementation-status dot (the canonical colored dot
+                -- used on compendium entries; scheme-consistent implStatus tokens).
+                -- Right-aligned so the name leads and the status reads as a marker.
+                gui.Panel{
+                    classes = { "spellImplementationIcon", dotClass },
+                    halign = "right",
+                    valign = "center",
                 },
             }
             rows[#rows + 1] = row
@@ -3210,7 +3222,7 @@ function ShowVillainActionPicker(token, slot)
     -- combined name + monster + level haystack, reusing Search.MatchesText) and
     -- the cross-check toggle. Then rebuild the rows.
     local function ApplyFilter()
-        if listPanel == nil or not listPanel.valid then
+        if listContent == nil or not listContent.valid then
             return
         end
         local filtered = {}
@@ -3221,26 +3233,43 @@ function ShowVillainActionPicker(token, slot)
                 keep = (status >= gui.ImplementationStatus.Bronze) and (e.hasBehaviors == true)
             end
             if keep and searchNeedle ~= "" then
-                local hay = string.format("%s %s level %s",
-                    e.name or "", e.monsterName or "", tostring(e.level or ""))
-                keep = Search.MatchesText(hay, searchNeedle)
+                -- Name and monster match fuzzily (substring), but a numeric term
+                -- matches the LEVEL exactly -- "level 1" returns level 1, never
+                -- level 10 or 11. The literal word "level"/"lvl" is ignored so
+                -- "level 1" and a bare "1" behave the same. All terms must match
+                -- (AND), matching the global search's term semantics.
+                local nameHay = string.lower((e.name or "") .. " " .. (e.monsterName or ""))
+                local entryLevel = tostring(e.level or "")
+                for term in string.gmatch(searchNeedle, "%S+") do
+                    if term == "level" or term == "lvl" then
+                        -- ignore the level keyword itself
+                    elseif string.match(term, "^%d+$") ~= nil then
+                        if term ~= entryLevel then
+                            keep = false
+                            break
+                        end
+                    elseif string.find(nameHay, term, 1, true) == nil then
+                        keep = false
+                        break
+                    end
+                end
             end
             if keep then
                 filtered[#filtered + 1] = e
             end
         end
-        listPanel.children = BuildRows(filtered)
+        listContent.children = BuildRows(filtered)
     end
 
     -- The bestiary index builds lazily in a coroutine. If it is not ready yet,
     -- show a loading line and re-poll until it is.
     local function Populate()
-        if listPanel == nil or not listPanel.valid then
+        if listContent == nil or not listContent.valid then
             return
         end
         local entries, ready = GetBestiaryVillainActions(slot)
         if not ready then
-            listPanel.children = {
+            listContent.children = {
                 gui.Label{
                     classes = { "sizeS" },
                     text = "Loading bestiary...",
@@ -3260,29 +3289,34 @@ function ShowVillainActionPicker(token, slot)
         ApplyFilter()
     end
 
+    -- Inner content panel (height auto) holds the rows and grows downward from the
+    -- top; the vscroll wrapper scrolls it. Setting rows directly on the vscroll
+    -- panel let a short result set drift to the bottom -- the auto-height inner
+    -- panel keeps them anchored at the top.
+    listContent = gui.Panel{
+        width = "100%",
+        height = "auto",
+        flow = "vertical",
+        halign = "left",
+        valign = "top",
+    }
     listPanel = gui.Panel{
         vscroll = true,
         width = "100%",
         -- Fills the left pane below the search input and the filter checkbox.
         height = "100%-72",
         flow = "vertical",
+        valign = "top",
+        listContent,
     }
 
     previewPanel = gui.Panel{
         vscroll = true,
         width = "100%",
-        height = "100%-28",
+        height = "100%",
         flow = "vertical",
         halign = "center",
-    }
-
-    -- Cross-check verdict, shown under the preview card.
-    verdictLabel = gui.Label{
-        classes = { "sizeXs", "bold", "collapsed" },
-        width = "100%", height = "auto",
-        halign = "left", valign = "bottom",
-        textAlignment = "left", textWrap = true,
-        tmargin = 6,
+        valign = "top",
     }
 
     -- Smart search: ability name, monster name, or level (reuses the global
@@ -3351,9 +3385,16 @@ function ShowVillainActionPicker(token, slot)
 
     dialog = gui.Panel{
         classes = { "dialog" },
-        styles = ThemeEngine.GetStyles(),
-        width = 820,
-        height = 600,
+        -- Scoped extras: drop the long filter label a step in size so it does not
+        -- crowd the search row; and tint the Create New button's authoring glyph
+        -- (a floating child so the button keeps its frame -- the icon+text button
+        -- path would add `hasIcon`, which strips the border).
+        styles = ThemeEngine.MergeStyles{
+            { selectors = { "checkboxLabel" }, fontSize = 13 },
+            { selectors = { "createNewIcon" }, bgcolor = "@fg" },
+        },
+        width = 900,
+        height = 660,
         flow = "vertical",
         borderBox = true,
         pad = 20,
@@ -3377,14 +3418,14 @@ function ShowVillainActionPicker(token, slot)
             end,
         },
 
-        -- Context line: "Opener - Villain Action I - <creature>".
+        -- Context line: "Opener - Villain Action I - <creature>", centered.
         gui.Label{
-            classes = { "sizeS" },
+            classes = { "sizeM" },
             text = string.format("<b>%s</b> - Villain Action %s - %s",
                 meta.label, meta.roman, token.name or "Monster"),
             width = "100%", height = "auto",
-            halign = "left", textAlignment = "left", textWrap = true,
-            tmargin = 4, bmargin = 10,
+            halign = "center", textAlignment = "center", textWrap = true,
+            tmargin = 4, bmargin = 12,
         },
 
         -- Two-pane body. Left: search + cross-check filter + slot-locked list.
@@ -3400,31 +3441,36 @@ function ShowVillainActionPicker(token, slot)
                 excludeCheck,
                 listPanel,
             },
-            gui.Panel{ width = "2%", height = "100%" },
+            gui.Panel{ width = "4%", height = "100%" },
             gui.Panel{
-                width = "54%", height = "100%", flow = "vertical",
+                width = "52%", height = "100%", flow = "vertical",
                 previewPanel,
-                verdictLabel,
             },
         },
 
-        -- Cancel / Create New Villain Action / Add to this creature.
+        -- Create New / Add to this creature. (No Cancel button -- the X in the
+        -- top-right dismisses the modal, and two buttons keep the footer roomy.)
         gui.Panel{
             width = "100%", height = "auto", flow = "horizontal",
             halign = "center", valign = "bottom", tmargin = 16,
 
-            gui.Button{
-                text = "Cancel",
-                width = 120, height = 40, hmargin = 6,
-                click = function(element)
-                    gui.CloseModal()
-                end,
-            },
             -- Build a fresh villain action from scratch in the ability editor,
-            -- preset to this slot. Mirrors the sheet's Create Ability path.
+            -- preset to this slot. The pencil glyph signals authoring. Mirrors the
+            -- sheet's Create Ability path.
             gui.Button{
-                text = "Create New Villain Action",
-                width = 220, height = 40, hmargin = 6,
+                classes = { "createNewBtn" },
+                text = "Create New",
+                width = 170, height = 40, hmargin = 6,
+                -- Authoring glyph as a floating child (not the `icon` param, which
+                -- would add `hasIcon` and strip the button frame).
+                gui.Panel{
+                    classes = { "createNewIcon" },
+                    bgimage = "ui-icons/pencil.png",
+                    width = 16, height = 16,
+                    halign = "left", valign = "center",
+                    floating = true,
+                    x = 14,
+                },
                 click = function(element)
                     gui.CloseModal()
                     if CharacterSheet.instance == nil then
@@ -3435,6 +3481,13 @@ function ShowVillainActionPicker(token, slot)
                         categorization = "Villain Action",
                         villainAction = slot,
                     }
+                    -- Skip the Template / Duplicate Existing / Blank entry chooser:
+                    -- there are no villain-action templates, and Duplicate Existing
+                    -- is exactly what this picker already does. "Create New" means a
+                    -- fresh blank villain action, so go straight into the editor
+                    -- (already preset to this slot). Clearing the transient new-ability
+                    -- flag suppresses the chooser ActivatedAbility.Create would trigger.
+                    newAbility._tmp_isNewAbility = false
                     CharacterSheet.instance:AddChild(newAbility:ShowEditActivatedAbilityDialog {
                         add = function(el)
                             CharacterSheet.instance.data.info.token.properties:AddInnateActivatedAbility(newAbility)

--- a/Draw Steel V/DrawSteelChararcterSheet.lua
+++ b/Draw Steel V/DrawSteelChararcterSheet.lua
@@ -2345,6 +2345,459 @@ function CharSheet.DSEditImmunitiesPopup(element, info)
     }
 end
 
+--==============================================================
+-- Monster level scaling: the "Adjust Level" dialog (chunk 4).
+--
+-- Opens from the LEVEL indicator in the monster stat-block header. It previews
+-- the full consequence of moving to a target level -- a Now / After compare
+-- table with signed deltas, an echelon callout (only when crossing 3/4, 6/7,
+-- 9/10) and a scaling-down note -- before committing via
+-- monster:SetLevelAdjustment. All math + the generated feature live in
+-- MCDMMonster.lua (MCDMMonsterScaling + monster:Set/Clear/HasLevelAdjustment);
+-- this is presentation only.
+--
+-- Per-creature stats (EV / Stamina / Free strike) read the creature's actual
+-- current value and show After = Now + (current -> target) delta, exactly what
+-- Apply produces. Reference stats (Damage, Highest characteristic, Potency) are
+-- shown from the MCDM table / formula at the current vs target level (there is
+-- no single per-creature damage number, and characteristic / potency are
+-- echelon-derived).
+--==============================================================
+
+local function ScalingSignedString(n)
+    if n > 0 then
+        return string.format("+%d", n)
+    end
+    return string.format("%d", n)
+end
+
+local function ShowAdjustLevelDialog(token)
+    if token == nil or token.properties == nil then
+        return
+    end
+    local props = token.properties
+    if not props:IsMonster() then
+        return
+    end
+
+    local org, role = props:ScalingOrgRole()
+    local isLeaderSolo = (org == "leader" or org == "solo")
+    local dtype = MCDMMonsterScaling.DamageType(org, role)
+
+    local minLevel = MCDMMonsterScaling.minLevel
+    local maxLevel = MCDMMonsterScaling.maxLevel
+    local baseLevel = props:GetScalingBaseLevel()
+    local currentLevel = round(tonumber(props:CharacterLevel()) or baseLevel)
+    currentLevel = math.max(minLevel, math.min(maxLevel, currentLevel))
+
+    -- The creature's actual current per-creature stats (these already include
+    -- any adjustment in effect now).
+    local nowEV = round(tonumber(props:EV()) or 0)
+    local nowStamina = round(tonumber(props:MaxHitpoints()) or 0)
+    local nowFreeStrike = round(tonumber(props:OpportunityAttack()) or 0)
+
+    -- Mutable selection; starts at the current level (no change).
+    local targetLevel = currentLevel
+
+    -- Forward-declared so the helpers / event handlers below can reach them.
+    local dialog
+    local previewPanel
+    local valueLabel
+    local slider
+    local echelonBanner
+    local noteLabel
+    local footerLabel
+
+    local function signum(n)
+        if n > 0 then return 1 elseif n < 0 then return -1 else return 0 end
+    end
+
+    -- Adjustment-column text: the signed delta, or blank when unchanged.
+    local function adjStr(n)
+        if n == 0 then return "" end
+        return ScalingSignedString(n)
+    end
+
+    -- One Now / After / Adjustment compare row. The Adjustment column is tinted
+    -- success (increase) or danger (decrease); dir is its sign. Unchanged
+    -- echelon rows (dim=true) are quieted so the rows that move stay salient.
+    local function CompareRow(idx, labelText, nowText, afterText, adjText, dir, dim)
+        local changed = dir ~= 0
+        local quiet = dim and not changed
+        local adjClass = { "tableLabel", "bold" }
+        if dir > 0 then
+            adjClass = { "tableLabel", "bold", "adjustInc" }
+        elseif dir < 0 then
+            adjClass = { "tableLabel", "bold", "adjustDec" }
+        end
+        return gui.Panel{
+            classes = { "row", cond(idx % 2 == 0, "evenRow", "oddRow") },
+            width = "100%",
+            height = "auto",
+            flow = "horizontal",
+            borderBox = true,
+            hpad = 10,
+            vpad = 5,
+            opacity = cond(quiet, 0.5, 1.0),
+
+            gui.Label{ classes = { "tableLabel" }, text = labelText, width = "36%", height = "auto", halign = "left", textWrap = true },
+            gui.Label{ classes = { "tableLabel" }, text = nowText, width = "17%", height = "auto", textAlignment = "center" },
+            gui.Label{ classes = { "tableLabel" }, text = afterText, width = "17%", height = "auto", textAlignment = "center" },
+            gui.Label{ classes = adjClass, text = adjText, width = "30%", height = "auto", textAlignment = "center" },
+        }
+    end
+
+    local function BuildPreviewRows()
+        local deltas = MCDMMonsterScaling.ComputeDeltas(org, role, currentLevel, targetLevel) or {}
+        local rows = {}
+
+        rows[#rows+1] = gui.Panel{
+            classes = { "row", "headerRow" },
+            width = "100%",
+            height = "auto",
+            flow = "horizontal",
+            borderBox = true,
+            hpad = 10,
+            vpad = 8,
+            gui.Label{ classes = { "tableLabel", "bold" }, text = "", width = "36%", height = "auto" },
+            gui.Label{ classes = { "tableLabel", "bold" }, text = "Now", width = "17%", height = "auto", textAlignment = "center" },
+            gui.Label{ classes = { "tableLabel", "bold" }, text = "After", width = "17%", height = "auto", textAlignment = "center" },
+            gui.Label{ classes = { "tableLabel", "bold" }, text = "Adjustment", width = "30%", height = "auto", textAlignment = "center" },
+        }
+
+        -- Separator under the header so it reads distinctly from the data rows.
+        rows[#rows+1] = gui.Panel{ classes = { "adjustDivider" }, width = "100%", height = 1, bmargin = 2 }
+
+        local idx = 0
+        local function add(labelText, nowText, afterText, adjText, dir, dim)
+            idx = idx + 1
+            rows[#rows+1] = CompareRow(idx, labelText, nowText, afterText, adjText, dir, dim)
+        end
+
+        -- Encounter value (per-creature)
+        add("Encounter value",
+            string.format("%d", nowEV),
+            string.format("%d", nowEV + (deltas.ev or 0)),
+            adjStr(deltas.ev or 0), signum(deltas.ev or 0), false)
+
+        -- Stamina (per-creature)
+        add("Stamina",
+            string.format("%d", nowStamina),
+            string.format("%d", nowStamina + (deltas.stamina or 0)),
+            adjStr(deltas.stamina or 0), signum(deltas.stamina or 0), false)
+
+        -- Damage T1/T2/T3 (reference: MCDM table for this org/role)
+        local rowCur = MCDMMonsterScaling.RowFor(org, currentLevel)
+        local rowTgt = MCDMMonsterScaling.RowFor(org, targetLevel)
+        local dmgNow = rowCur and rowCur[dtype]
+        local dmgTgt = rowTgt and rowTgt[dtype]
+        if dmgNow ~= nil and dmgTgt ~= nil then
+            local d1, d2, d3 = deltas.t1 or 0, deltas.t2 or 0, deltas.t3 or 0
+            local changed = d1 ~= 0 or d2 ~= 0 or d3 ~= 0
+            local dStr = ""
+            if changed then
+                dStr = string.format("%s / %s / %s",
+                    ScalingSignedString(d1), ScalingSignedString(d2), ScalingSignedString(d3))
+            end
+            add("Damage (T1 / T2 / T3)",
+                string.format("%d / %d / %d", dmgNow[1], dmgNow[2], dmgNow[3]),
+                string.format("%d / %d / %d", dmgTgt[1], dmgTgt[2], dmgTgt[3]),
+                dStr, cond(changed, signum(targetLevel - currentLevel), 0), false)
+        end
+
+        -- Free strike (per-creature; T1 table delta, no characteristic)
+        add("Free strike",
+            string.format("%d", nowFreeStrike),
+            string.format("%d", nowFreeStrike + (deltas.freeStrike or 0)),
+            adjStr(deltas.freeStrike or 0), signum(deltas.freeStrike or 0), false)
+
+        -- Highest characteristic (reference formula; echelon row)
+        local charNow = MCDMMonsterScaling.HighestCharacteristic(currentLevel, isLeaderSolo)
+        local charTgt = MCDMMonsterScaling.HighestCharacteristic(targetLevel, isLeaderSolo)
+        add("Highest characteristic",
+            ScalingSignedString(charNow),
+            ScalingSignedString(charTgt),
+            adjStr(charTgt - charNow), signum(charTgt - charNow), true)
+
+        -- Potency weak/avg/strong (reference formula; echelon row)
+        local function potTriple(level)
+            local s = MCDMMonsterScaling.PotencyStrong(level, isLeaderSolo)
+            return math.max(0, s - 2), math.max(0, s - 1), s
+        end
+        local wNow, aNow, sNow = potTriple(currentLevel)
+        local wTgt, aTgt, sTgt = potTriple(targetLevel)
+        add("Potency (weak / avg / strong)",
+            string.format("%d / %d / %d", wNow, aNow, sNow),
+            string.format("%d / %d / %d", wTgt, aTgt, sTgt),
+            adjStr(sTgt - sNow), signum(sTgt - sNow), true)
+
+        return rows
+    end
+
+    local function Refresh()
+        if valueLabel ~= nil and valueLabel.valid then
+            valueLabel.text = string.format("%d", targetLevel)
+        end
+        if slider ~= nil and slider.valid then
+            slider:SetValue(targetLevel, false)
+        end
+        if previewPanel ~= nil and previewPanel.valid then
+            previewPanel.children = BuildPreviewRows()
+        end
+
+        local curEch = MCDMMonsterScaling.Echelon(currentLevel)
+        local tgtEch = MCDMMonsterScaling.Echelon(targetLevel)
+        local crossing = (tgtEch ~= curEch)
+        if echelonBanner ~= nil and echelonBanner.valid then
+            echelonBanner:SetClass("collapsed", not crossing)
+            if crossing then
+                local diff = math.abs(tgtEch - curEch)
+                local verb = cond(tgtEch > curEch, "increase", "decrease")
+                echelonBanner.text = string.format(
+                    "Echelon %d. Potency and highest characteristic %s by %d.", tgtEch, verb, diff)
+            end
+        end
+
+        if noteLabel ~= nil and noteLabel.valid then
+            noteLabel:SetClass("collapsed", not (targetLevel < baseLevel))
+        end
+
+        if footerLabel ~= nil and footerLabel.valid then
+            if targetLevel == baseLevel then
+                footerLabel.text = "At the base level. No feature is added."
+            else
+                footerLabel.text = "This adjustment adds a feature to the creature. Delete the feature or click the Reset button below to restore the creature to its original level."
+            end
+        end
+    end
+
+    local function SetTarget(n)
+        n = math.max(minLevel, math.min(maxLevel, round(tonumber(n) or targetLevel)))
+        if n == targetLevel then
+            return
+        end
+        targetLevel = n
+        Refresh()
+    end
+
+    valueLabel = gui.Label{
+        classes = { "number", "sizeL", "bold" },
+        text = string.format("%d", currentLevel),
+        width = 56,
+        height = "auto",
+        halign = "center",
+        valign = "center",
+        textAlignment = "center",
+    }
+
+    slider = gui.Slider{
+        width = "80%",
+        height = 24,
+        halign = "center",
+        vmargin = 4,
+        minValue = minLevel,
+        maxValue = maxLevel,
+        value = currentLevel,
+        round = true,
+        change = function(element)
+            SetTarget(element:GetValue())
+        end,
+    }
+
+    previewPanel = gui.Panel{
+        width = "100%",
+        height = "auto",
+        flow = "vertical",
+        tmargin = 12,
+    }
+
+    echelonBanner = gui.Label{
+        classes = { "sizeXs", "bold", "collapsed" },
+        width = "100%",
+        height = "auto",
+        halign = "left",
+        textAlignment = "left",
+        textWrap = true,
+        tmargin = 12,
+    }
+
+    noteLabel = gui.Label{
+        classes = { "sizeXs", "collapsed" },
+        text = "Some monsters have been hand-tuned and scaling values are approximate for these creatures.",
+        width = "100%",
+        height = "auto",
+        halign = "left",
+        textAlignment = "left",
+        textWrap = true,
+        tmargin = 8,
+    }
+
+    footerLabel = gui.Label{
+        classes = { "sizeXs" },
+        width = "100%",
+        height = "auto",
+        halign = "left",
+        textAlignment = "left",
+        textWrap = true,
+        tmargin = 12,
+    }
+
+    dialog = gui.Panel{
+        classes = { "dialog" },
+        -- Custom rules: tint the Adjustment column (the base tableLabel rule sets
+        -- @fg, which otherwise wins over a plain success/danger class), and a
+        -- clean 1px themed divider (a bordered box left end-cap artifacts).
+        styles = ThemeEngine.MergeStyles{
+            { selectors = { "tableLabel", "adjustInc" }, color = "@success", priority = 100 },
+            { selectors = { "tableLabel", "adjustDec" }, color = "@danger", priority = 100 },
+            { selectors = { "adjustDivider" }, bgimage = true, bgcolor = "@border" },
+        },
+        width = 660,
+        height = "auto",
+        minHeight = 440,
+        flow = "vertical",
+        borderBox = true,
+        pad = 20,
+
+        gui.Label{
+            classes = { "modalTitle" },
+            text = "Adjust Level",
+            width = "100%",
+            height = "auto",
+            tmargin = 4,
+        },
+
+        gui.Button{
+            classes = { "closeButton" },
+            halign = "right",
+            valign = "top",
+            floating = true,
+            margin = 8,
+            escapePriority = EscapePriority.EXIT_MODAL_DIALOG,
+            click = function(element)
+                gui.CloseModal()
+            end,
+        },
+
+        -- Subtitle: "<b>Name</b> - Role", centered. (Base Level lives on the
+        -- stepper row, right-aligned to the slider's edge.)
+        gui.Label{
+            classes = { "sizeS" },
+            text = string.format("<b>%s</b> - %s", token.name or "Monster", props:try_get("role", "")),
+            width = "92%",
+            height = "auto",
+            halign = "center",
+            textAlignment = "center",
+            textWrap = true,
+            tmargin = 4,
+        },
+
+        -- Stepper (minus / value / plus) centered, with Base Level right-aligned
+        -- to the slider's right edge. The wrapper matches the slider's 80% width
+        -- so "right" lands on the scale's edge.
+        gui.Panel{
+            width = "80%",
+            height = "auto",
+            halign = "center",
+            valign = "center",
+            flow = "none",
+            vmargin = 8,
+
+            gui.Panel{
+                width = "auto",
+                height = "auto",
+                flow = "horizontal",
+                halign = "center",
+                valign = "center",
+
+                gui.Button{
+                    classes = { "pagingArrow" },
+                    valign = "center",
+                    click = function(element)
+                        SetTarget(targetLevel - 1)
+                    end,
+                },
+                valueLabel,
+                gui.Button{
+                    classes = { "pagingArrow", "right" },
+                    valign = "center",
+                    click = function(element)
+                        SetTarget(targetLevel + 1)
+                    end,
+                },
+            },
+
+            gui.Label{
+                classes = { "sizeS" },
+                text = string.format("<b>Base Level:</b> %d", baseLevel),
+                width = "auto",
+                height = "auto",
+                halign = "right",
+                valign = "center",
+            },
+        },
+
+        slider,
+        previewPanel,
+        echelonBanner,
+        noteLabel,
+        footerLabel,
+
+        -- Cancel / Reset / Apply
+        gui.Panel{
+            width = "100%",
+            height = "auto",
+            flow = "horizontal",
+            halign = "center",
+            valign = "bottom",
+            tmargin = 16,
+
+            gui.Button{
+                text = "Cancel",
+                width = 120,
+                height = 40,
+                hmargin = 6,
+                click = function(element)
+                    gui.CloseModal()
+                end,
+            },
+            gui.Button{
+                text = "Reset",
+                width = 120,
+                height = 40,
+                hmargin = 6,
+                click = function(element)
+                    -- Reset returns the selection to the creature's original
+                    -- (base) level; Apply then commits the restoration.
+                    targetLevel = baseLevel
+                    Refresh()
+                end,
+            },
+            gui.Button{
+                text = "Apply",
+                width = 120,
+                height = 40,
+                hmargin = 6,
+                click = function(element)
+                    token:ModifyProperties{
+                        description = "Adjust monster level",
+                        execute = function()
+                            token.properties:SetLevelAdjustment(targetLevel)
+                        end,
+                    }
+                    if CharacterSheet.instance ~= nil then
+                        CharacterSheet.instance:FireEvent("refreshAll")
+                    end
+                    gui.CloseModal()
+                end,
+            },
+        },
+    }
+
+    Refresh()
+    gui.ShowModal(dialog)
+end
+
 local function DSCharSheet()
     --find id for recovery from resourcestable
     local recoveryid = "5bd90f9b-46be-4cf2-8ca6-a96430d62949"
@@ -3956,44 +4409,111 @@ local function DSCharSheet()
 
                             },
 
-                            gui.Label {
-
-                                text = "4",
-                                color = "white",
-                                fontSize = 26,
-                                characterLimit = 2,
-
+                            --Level number with the Adjust Level affordance to its
+                            --left (monster level scaling): a small up/down-arrow
+                            --icon button that opens the Adjust Level dialog.
+                            --Monsters only.
+                            gui.Panel {
                                 bgimage = true,
                                 bgcolor = "clear",
                                 width = "100%",
                                 height = "35%",
-
-                                valign = "top",
-                                halign = "center",
-                                textAlignment = "center",
-
-
+                                -- flow "none" so the arrow overlays to the right
+                                -- without displacing the centered level number.
+                                -- The number is declared FIRST and the arrow LAST
+                                -- so the arrow renders on top and stays clickable
+                                -- (later siblings win pointer events).
+                                flow = "none",
+                                valign = "center",
                                 tmargin = 4,
-                                lmargin = 10,
 
-                                refreshToken = function(element, info)
-                                    local level = info.token.properties:CharacterLevel()
-                                    if level == 0 then
-                                        element.text = "-"
-                                    else
-                                        element.text = string.format("%d", level)
-                                    end
+                                gui.Label {
 
-                                    element.editable = info.token.properties:IsMonster()
-                                end,
+                                    text = "4",
+                                    color = "white",
+                                    fontSize = 26,
+                                    characterLimit = 2,
 
-                                change = function(element)
-                                    local token = CharacterSheet.instance.data.info.token
-                                    local n = math.max(0,
-                                        round(tonumber(element.text) or token.properties:CharacterLevel()))
-                                    token.properties.cr = n
-                                    CharacterSheet.instance:FireEvent("refreshAll")
-                                end,
+                                    bgimage = true,
+                                    bgcolor = "clear",
+                                    width = "100%",
+                                    height = "100%",
+
+                                    halign = "center",
+                                    valign = "center",
+                                    textAlignment = "center",
+
+                                    refreshToken = function(element, info)
+                                        local level = info.token.properties:CharacterLevel()
+                                        if level == 0 then
+                                            element.text = "-"
+                                        else
+                                            element.text = string.format("%d", level)
+                                        end
+
+                                        element.editable = info.token.properties:IsMonster()
+                                    end,
+
+                                    change = function(element)
+                                        -- Guard against firing during teardown / when the value
+                                        -- did not actually change: a spurious refreshAll mid-destroy
+                                        -- recomputes stats while the modifier pipeline is half torn
+                                        -- down (e.g. Stability transiently nil).
+                                        if CharacterSheet.instance == nil then
+                                            return
+                                        end
+                                        local token = CharacterSheet.instance.data.info.token
+                                        if token == nil or token.properties == nil then
+                                            return
+                                        end
+                                        local n = math.max(0,
+                                            round(tonumber(element.text) or token.properties:CharacterLevel()))
+                                        if n == round(tonumber(token.properties.cr) or 0) then
+                                            return
+                                        end
+                                        token.properties.cr = n
+                                        CharacterSheet.instance:FireEvent("refreshAll")
+                                    end,
+                                },
+
+                                gui.Panel {
+                                    classes = { "bordered", "hoverable" },
+                                    bgimage = "panels/square.png",
+                                    bgcolor = "clear",
+                                    width = 24,
+                                    height = 26,
+                                    halign = "right",
+                                    valign = "center",
+                                    rmargin = 8,
+                                    flow = "vertical",
+
+                                    hover = gui.Tooltip("Adjust Level"),
+
+                                    refreshToken = function(element, info)
+                                        element:SetClass("collapsed", not info.token.properties:IsMonster())
+                                    end,
+
+                                    click = function(element)
+                                        ShowAdjustLevelDialog(CharacterSheet.instance.data.info.token)
+                                    end,
+
+                                    gui.Panel {
+                                        width = 13,
+                                        height = "50%",
+                                        halign = "center",
+                                        valign = "top",
+                                        bgimage = "icons/icon_arrow/icon_arrow_29.png",
+                                        bgcolor = "white",
+                                    },
+                                    gui.Panel {
+                                        width = 13,
+                                        height = "50%",
+                                        halign = "center",
+                                        valign = "bottom",
+                                        bgimage = "icons/icon_arrow/icon_arrow_30.png",
+                                        bgcolor = "white",
+                                    },
+                                },
                             },
                         },
                     },

--- a/Draw Steel V/DrawSteelChararcterSheet.lua
+++ b/Draw Steel V/DrawSteelChararcterSheet.lua
@@ -4430,9 +4430,10 @@ local function DSCharSheet()
                                 gui.Label {
 
                                     text = "4",
-                                    color = "white",
                                     fontSize = 26,
-                                    characterLimit = 2,
+                                    -- 3 chars so a scaled level fits the appended
+                                    -- asterisk (e.g. "11*").
+                                    characterLimit = 3,
 
                                     bgimage = true,
                                     bgcolor = "clear",
@@ -4443,15 +4444,86 @@ local function DSCharSheet()
                                     valign = "center",
                                     textAlignment = "center",
 
+                                    -- Level-scaling signpost. While a Level
+                                    -- Adjustment is in effect the number is
+                                    -- tinted success (scaled up) or danger
+                                    -- (scaled down) and carries a trailing
+                                    -- asterisk, so the adjusted state reads
+                                    -- without relying on color alone.
+                                    classes = { "levelValue" },
+                                    styles = ThemeEngine.MergeTokens{
+                                        { selectors = { "levelValue" }, color = "white" },
+                                        { selectors = { "levelValue", "scaledUp" }, color = "@success", priority = 100 },
+                                        { selectors = { "levelValue", "scaledDown" }, color = "@danger", priority = 100 },
+                                    },
+
                                     refreshToken = function(element, info)
-                                        local level = info.token.properties:CharacterLevel()
+                                        local c = info.token.properties
+                                        local level = round(tonumber(c:CharacterLevel()) or 0)
+                                        local adjusted = c:IsMonster() and c:HasLevelAdjustment()
+
                                         if level == 0 then
                                             element.text = "-"
+                                        elseif adjusted then
+                                            element.text = string.format("%d*", level)
                                         else
                                             element.text = string.format("%d", level)
                                         end
 
-                                        element.editable = info.token.properties:IsMonster()
+                                        local up, down = false, false
+                                        if adjusted then
+                                            local base = c:GetScalingBaseLevel()
+                                            up = level > base
+                                            down = level < base
+                                        end
+                                        element:SetClass("scaledUp", up)
+                                        element:SetClass("scaledDown", down)
+
+                                        -- While adjusted the number is a
+                                        -- read-only signpost that opens the
+                                        -- modal on click; direct level edits go
+                                        -- through the Adjust Level dialog so the
+                                        -- stored deltas stay consistent.
+                                        element.editable = c:IsMonster() and not adjusted
+                                    end,
+
+                                    -- Dynamic hover, shown only while adjusted:
+                                    -- names the base level and the revert path.
+                                    hover = function(element)
+                                        local sheet = CharacterSheet.instance
+                                        if sheet == nil then
+                                            return
+                                        end
+                                        local token = sheet.data.info.token
+                                        if token == nil or token.properties == nil then
+                                            return
+                                        end
+                                        local c = token.properties
+                                        if not (c:IsMonster() and c:HasLevelAdjustment()) then
+                                            return
+                                        end
+                                        gui.Tooltip(string.format(
+                                            "Adjusted from Level %d. Click to review.",
+                                            c:GetScalingBaseLevel()))(element)
+                                    end,
+
+                                    -- When adjusted the number is non-editable,
+                                    -- so a click opens the Adjust Level dialog
+                                    -- ("Click to review"). When not adjusted the
+                                    -- label handles its own click for inline
+                                    -- editing and this is a no-op.
+                                    click = function(element)
+                                        local sheet = CharacterSheet.instance
+                                        if sheet == nil then
+                                            return
+                                        end
+                                        local token = sheet.data.info.token
+                                        if token == nil or token.properties == nil then
+                                            return
+                                        end
+                                        if token.properties:IsMonster() and token.properties:HasLevelAdjustment() then
+                                            ShowAdjustLevelDialog(token)
+                                        end
                                     end,
 
                                     change = function(element)

--- a/Draw Steel V/DrawSteelChararcterSheet.lua
+++ b/Draw Steel V/DrawSteelChararcterSheet.lua
@@ -1180,6 +1180,30 @@ local function CreateAbilityListPanel()
                 end)
             end
         end,
+
+        --Make Solo post-apply signpost: expand the Villain Actions group and
+        --scroll + flash the first empty slot, so a freshly converted solo's
+        --empty slots are seen rather than left hidden off-page. Mirrors
+        --revealCapability's expand-then-pulse, but targets an empty slot row
+        --instead of a filled ability. Reuses the search-reveal pulse, so the
+        --signpost is the same gentle animation the director already knows.
+        revealEmptyVillainSlot = function(element)
+            if CharacterSheet.instance == nil
+                or CharacterSheet.instance.data.info.token == nil then
+                return
+            end
+            m_villainActionsLabel:SetClassTree("collapseSet", false)
+            element:FireEvent("refreshToken")
+            ScheduleRevealAndPulse(function()
+                for _, slotId in ipairs(g_villainSlotOrder) do
+                    local row = m_villainSlotRows[slotId]
+                    if row ~= nil and row.valid and not row:HasClass("collapsed") then
+                        return row
+                    end
+                end
+                return nil
+            end)
+        end,
     }
 
     ThemeEngine.OnThemeChanged(mod, function()
@@ -1967,6 +1991,75 @@ function CharSheet.CharacterSheetAndAvatarPanel()
                     end
 
                     element:SetClass("collapsed", false)
+                end,
+            },
+
+            --Make Solo / Revert Solo: promote an Elite or Leader monster to a
+            --Solo (organization -> Solo plus the Instant Solo template) in one
+            --reversible action, then signpost the now-revealed empty villain
+            --action slots. Lives directly under the organization controls it
+            --rewrites; after Apply both the org dropdown (now "Solo") and this
+            --button's revert state surface here together.
+            --
+            --Offered only for Elite and Leader baselines: the Instant Solo
+            --template's x3 EV / x2.5 Stamina math lands exactly on the sheet's
+            --Solo row for those two organizations. Standard / horde / minion
+            --baselines would produce an under-budgeted "half solo", so they are
+            --excluded for now (revisit if there is demand). A button conversion
+            --is always revertible (which is the only way a creature reaches the
+            --converted state, so the revert path stays available).
+            gui.Button {
+                classes = { "sizeM" },
+                text = "Make Solo",
+                width = 160,
+                height = 30,
+                halign = "center",
+                vmargin = 6,
+                refreshToken = function(element, info)
+                    local c = info.token.properties
+                    if not c:IsMonster() then
+                        element:SetClass("collapsed", true)
+                        return
+                    end
+                    if c:HasSoloConversion() then
+                        element:SetClass("collapsed", false)
+                        element.text = "Revert Solo"
+                        return
+                    end
+                    --Not converted: offer Make Solo only for Elite/Leader
+                    --(excludes standard/horde/minion/authored-solo).
+                    local org = c:Organization()
+                    if org ~= "elite" and org ~= "leader" then
+                        element:SetClass("collapsed", true)
+                        return
+                    end
+                    element:SetClass("collapsed", false)
+                    element.text = "Make Solo"
+                end,
+                click = function(element)
+                    local sheet = CharacterSheet.instance
+                    if sheet == nil then
+                        return
+                    end
+                    local token = sheet.data.info.token
+                    if token == nil or token.properties == nil then
+                        return
+                    end
+                    local c = token.properties
+                    if not c:IsMonster() then
+                        return
+                    end
+                    if c:HasSoloConversion() then
+                        c:RevertSolo()
+                        sheet:FireEvent("refreshAll")
+                    else
+                        c:MakeSolo()
+                        sheet:FireEvent("refreshAll")
+                        --Reveal-and-prompt (inform, don't enforce): expand the
+                        --Villain Actions group and flash the first empty slot.
+                        --No picker is forced open.
+                        sheet:FireEventTree("revealEmptyVillainSlot")
+                    end
                 end,
             },
 

--- a/Draw Steel V/DrawSteelChararcterSheet.lua
+++ b/Draw Steel V/DrawSteelChararcterSheet.lua
@@ -2611,7 +2611,10 @@ local function ShowAdjustLevelDialog(token)
             valueLabel.text = string.format("%d", targetLevel)
         end
         if slider ~= nil and slider.valid then
-            slider:SetValue(targetLevel, false)
+            -- setValueNoEvent repositions the thumb (fires updateValue) without
+            -- firing 'change'. SetValue(v, false) would skip updateValue too, so
+            -- the thumb would not follow the stepper arrows.
+            slider.data.setValueNoEvent(targetLevel)
         end
         if previewPanel ~= nil and previewPanel.valid then
             previewPanel.children = BuildPreviewRows()
@@ -2621,12 +2624,33 @@ local function ShowAdjustLevelDialog(token)
         local tgtEch = MCDMMonsterScaling.Echelon(targetLevel)
         local crossing = (tgtEch ~= curEch)
         if echelonBanner ~= nil and echelonBanner.valid then
-            echelonBanner:SetClass("collapsed", not crossing)
-            if crossing then
-                local diff = math.abs(tgtEch - curEch)
-                local verb = cond(tgtEch > curEch, "increase", "decrease")
-                echelonBanner.text = string.format(
-                    "Echelon %d. Potency and highest characteristic %s by %d.", tgtEch, verb, diff)
+            -- Report the ACTUAL characteristic and potency deltas, not the echelon
+            -- difference: they diverge at the echelon-4 leader/solo boundary, where
+            -- the characteristic is capped at +5 while potency reaches 6, so
+            -- crossing 9<->10 moves potency but leaves the characteristic unchanged.
+            local charD = MCDMMonsterScaling.HighestCharacteristic(targetLevel, isLeaderSolo)
+                        - MCDMMonsterScaling.HighestCharacteristic(currentLevel, isLeaderSolo)
+            local potD = MCDMMonsterScaling.PotencyStrong(targetLevel, isLeaderSolo)
+                       - MCDMMonsterScaling.PotencyStrong(currentLevel, isLeaderSolo)
+            local moved = (charD ~= 0 or potD ~= 0)
+            echelonBanner:SetClass("collapsed", not (crossing and moved))
+            if crossing and moved then
+                local function phrase(noun, delta)
+                    return string.format("%s %s by %d", noun,
+                        cond(delta > 0, "increases", "decreases"), math.abs(delta))
+                end
+                local body
+                if charD == potD then
+                    body = string.format("Potency and highest characteristic %s by %d",
+                        cond(potD > 0, "increase", "decrease"), math.abs(potD))
+                elseif charD == 0 then
+                    body = phrase("Potency", potD) .. "; highest characteristic is unchanged"
+                elseif potD == 0 then
+                    body = phrase("Highest characteristic", charD) .. "; potency is unchanged"
+                else
+                    body = phrase("Potency", potD) .. " and " .. string.lower(phrase("Highest characteristic", charD))
+                end
+                echelonBanner.text = string.format("Echelon %d. %s.", tgtEch, body)
             end
         end
 

--- a/Draw Steel V/DrawSteelChararcterSheet.lua
+++ b/Draw Steel V/DrawSteelChararcterSheet.lua
@@ -2396,6 +2396,43 @@ local function ShowAdjustLevelDialog(token)
     local nowStamina = round(tonumber(props:MaxHitpoints()) or 0)
     local nowFreeStrike = round(tonumber(props:OpportunityAttack()) or 0)
 
+    -- Minion squads. A level adjustment normally hits only this token, but a
+    -- minion is one of a squad of identical minions, so scaling one leaves the
+    -- rest behind. When this minion belongs to a squad we offer to scale every
+    -- member together (default on). Squad membership = same MinionSquad name and
+    -- monster type; recomputed fresh at Apply time so deaths mid-dialog can't
+    -- leave a stale target list.
+    local function CollectSquadMembers()
+        local squadName = nil
+        pcall(function() squadName = props:MinionSquad() end)
+        if not props:try_get("minion", false) or squadName == nil then
+            return { token }
+        end
+        local mtype = props:try_get("monster_type", nil)
+        local members = {}
+        for _, t in ipairs(dmhub.GetTokens() or {}) do
+            local tp = t.properties
+            local match = false
+            pcall(function()
+                match = tp ~= nil and tp:try_get("minion", false) == true
+                    and tp:MinionSquad() == squadName
+                    and (mtype == nil or tp:try_get("monster_type", nil) == mtype)
+            end)
+            if match then
+                members[#members + 1] = t
+            end
+        end
+        if #members == 0 then
+            return { token }
+        end
+        return members
+    end
+
+    local squadSize = #CollectSquadMembers()
+    local isSquadMinion = squadSize > 1
+    -- Default on: the common case is scaling the whole squad together.
+    local applyToSquad = isSquadMinion
+
     -- Mutable selection; starts at the current level (no change).
     local targetLevel = currentLevel
 
@@ -2407,6 +2444,7 @@ local function ShowAdjustLevelDialog(token)
     local echelonBanner
     local noteLabel
     local footerLabel
+    local squadCheck
 
     local function signum(n)
         if n > 0 then return 1 elseif n < 0 then return -1 else return 0 end
@@ -2642,6 +2680,18 @@ local function ShowAdjustLevelDialog(token)
         tmargin = 12,
     }
 
+    -- Squad scope toggle (minions only). Collapsed for non-squad creatures.
+    squadCheck = gui.Check{
+        text = string.format("Apply to all %d minions in this squad", squadSize),
+        value = applyToSquad,
+        halign = "left",
+        tmargin = 12,
+        change = function(element)
+            applyToSquad = element.value
+        end,
+    }
+    squadCheck:SetClass("collapsed", not isSquadMinion)
+
     dialog = gui.Panel{
         classes = { "dialog" },
         -- Custom rules: tint the Adjustment column (the base tableLabel rule sets
@@ -2741,6 +2791,7 @@ local function ShowAdjustLevelDialog(token)
         previewPanel,
         echelonBanner,
         noteLabel,
+        squadCheck,
         footerLabel,
 
         -- Cancel / Reset / Apply
@@ -2779,12 +2830,21 @@ local function ShowAdjustLevelDialog(token)
                 height = 40,
                 hmargin = 6,
                 click = function(element)
-                    token:ModifyProperties{
-                        description = "Adjust monster level",
-                        execute = function()
-                            token.properties:SetLevelAdjustment(targetLevel)
-                        end,
-                    }
+                    -- Recompute the squad fresh so a death mid-dialog can't
+                    -- target a stale member; fall back to this token alone.
+                    local targets = { token }
+                    if isSquadMinion and applyToSquad then
+                        targets = CollectSquadMembers()
+                    end
+                    for _, tok in ipairs(targets) do
+                        tok:ModifyProperties{
+                            description = "Adjust monster level",
+                            combine = true,
+                            execute = function()
+                                tok.properties:SetLevelAdjustment(targetLevel)
+                            end,
+                        }
+                    end
                     if CharacterSheet.instance ~= nil then
                         CharacterSheet.instance:FireEvent("refreshAll")
                     end

--- a/Draw Steel V/DrawSteelChararcterSheet.lua
+++ b/Draw Steel V/DrawSteelChararcterSheet.lua
@@ -2384,6 +2384,18 @@ local function ShowAdjustLevelDialog(token)
     local isLeaderSolo = (org == "leader" or org == "solo")
     local dtype = MCDMMonsterScaling.DamageType(org, role)
 
+    -- Strikes add the highest characteristic on top of the table damage and so
+    -- scale differently from non-strike power rolls (table delta + characteristic
+    -- delta vs table delta alone). Only surface a Strike damage row when this
+    -- monster actually has a strike ability, so monsters without one get no dead row.
+    local hasStrike = false
+    for _, a in ipairs(props:GetActivatedAbilities {}) do
+        if a:HasKeyword("Strike") then
+            hasStrike = true
+            break
+        end
+    end
+
     local minLevel = MCDMMonsterScaling.minLevel
     local maxLevel = MCDMMonsterScaling.maxLevel
     local baseLevel = props:GetScalingBaseLevel()
@@ -2541,6 +2553,28 @@ local function ShowAdjustLevelDialog(token)
                 string.format("%d / %d / %d", dmgNow[1], dmgNow[2], dmgNow[3]),
                 string.format("%d / %d / %d", dmgTgt[1], dmgTgt[2], dmgTgt[3]),
                 dStr, cond(changed, signum(targetLevel - currentLevel), 0), false)
+
+            -- Strike damage = table damage + highest characteristic, which scales
+            -- by the table delta plus the characteristic delta (so it moves more
+            -- than the row above when an echelon boundary is crossed). Only shown
+            -- when the monster has a strike ability.
+            if hasStrike then
+                local sCharNow = MCDMMonsterScaling.HighestCharacteristic(currentLevel, isLeaderSolo)
+                local sCharTgt = MCDMMonsterScaling.HighestCharacteristic(targetLevel, isLeaderSolo)
+                local s1 = (dmgTgt[1] + sCharTgt) - (dmgNow[1] + sCharNow)
+                local s2 = (dmgTgt[2] + sCharTgt) - (dmgNow[2] + sCharNow)
+                local s3 = (dmgTgt[3] + sCharTgt) - (dmgNow[3] + sCharNow)
+                local sChanged = s1 ~= 0 or s2 ~= 0 or s3 ~= 0
+                local sStr = ""
+                if sChanged then
+                    sStr = string.format("%s / %s / %s",
+                        ScalingSignedString(s1), ScalingSignedString(s2), ScalingSignedString(s3))
+                end
+                add("Strike damage (T1 / T2 / T3)",
+                    string.format("%d / %d / %d", dmgNow[1] + sCharNow, dmgNow[2] + sCharNow, dmgNow[3] + sCharNow),
+                    string.format("%d / %d / %d", dmgTgt[1] + sCharTgt, dmgTgt[2] + sCharTgt, dmgTgt[3] + sCharTgt),
+                    sStr, cond(sChanged, signum(targetLevel - currentLevel), 0), false)
+            end
         end
 
         -- Free strike (per-creature; T1 table delta, no characteristic)


### PR DESCRIPTION
## Summary
Adds three related monster-authoring tools for directors: on-the-fly level
scaling, a villain-action picker, and a one-click Make Solo conversion.

## Changes
- **Level scaling** — "Adjust Level" dialog + stat-block signpost; a generated,
  removable Level Adjustment feature carries EV / stamina / per-tier damage /
  characteristic / potency deltas (delta-from-authored model, byte-perfect
  restore). Per-tier MCDM math via custom attributes; literal potency gates and
  free strike scale; whole minion squads scale from one dialog; native
  echelon-4 leader/solo potency fix.
- **Villain-action picker** — browse/duplicate villain actions from the bestiary
  into a creature (slot-locked Opener / Crowd Control / Showstopper), with smart
  search, cross-checked status filter + dots, real ability-card preview, and
  "Create New". Empty slots surface on the sheet for solos/leaders.
- **Make Solo** — button (Elite/Leader only) that sets organization to Solo
  (remembering the prior org), applies the Instant Solo template, and reveals +
  flashes the empty villain slots. Revert restores org/minion and removes
  villain actions added during the conversion. Adds an `echelon` GoblinScript
  symbol.
- **GoblinScript-aware `damageToSelf`** on purge effects, so the Instant Solo
  End Effect can scale (`5 * Echelon` -> 5/10/15/20).

## Testing
- Level scaling validated against the MCDM monster-math spreadsheet; byte-perfect
  restore at the L1<->L11 boundaries.
- Bestiary no-op sweep (250 monsters): shared damage/potency/gate paths are
  no-ops for unscaled content.
- Make Solo / Revert / villain-action cleanup / multi-template stacking verified.
- `damageToSelf`: flat values unchanged, `5 * Echelon` scales, garbage inputs are
  safe no-ops.
- In-app: purge abilities, global search + place-on-map, sheet open/close + token
  switching, undo, multiplayer/player view.
- Leak/perf audit: no new theme subscriptions / think handlers / unbounded
  schedules; per-damage-roll overhead is memoized (~0ms).

## Notes for reviewer
- Make Solo is intentionally limited to Elite/Leader baselines: the Instant Solo
  x3 EV / x2.5 Stamina math lands exactly on the sheet's Solo row only for those
  orgs; other orgs would be under-budgeted "half-solos". Generalizing is deferred.
- The `damageToSelf` change is GoblinScript-eval only; making it also roll dice
  (so `1d6`-style values work) is deliberately deferred to a separate PR.
- `damageToSelf` lives in a generic purge behavior (affects all purge abilities);
  flat-value behaviour is provably unchanged (flat numbers bypass evaluation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)