### PR TITLE
feat(journal): vertical rhythm — line-height, paragraph spacing, indents

### DIFF
--- a/DocumentSystem/MarkdownDocument.lua
+++ b/DocumentSystem/MarkdownDocument.lua
@@ -923,6 +923,13 @@ end
 -- Test hook.
 MarkdownDocument.__SkinClassTextMarkup = SkinClassTextMarkup
 
+-- A vertical gap rendered inside a single TMP label: a blank line sized to n px.
+-- Returns nil for non-positive n so callers can skip inserting a line.
+local function SkinGapLine(n)
+    if type(n) ~= "number" or n <= 0 then return nil end
+    return string.format("<size=%dpx> </size>", n)
+end
+
 local ApplySkinToText
 ApplySkinToText = function(text, base)
     if type(text) ~= "string" or text == "" then return text end
@@ -941,16 +948,25 @@ ApplySkinToText = function(text, base)
         lines[#lines + 1] = string.sub(text, start, nl - 1)
         start = nl + 1
     end
+    local bodyPS = (base.body or {}).paragraphSpacing
     for _, line in ipairs(lines) do
         local hashes, hContent = string.match(line, "^(#+) (.*)$")
         local bmarker, bContent = string.match(line, "^([%-%*]) (.*)$")
         local onum, oContent = string.match(line, "^(%d+%.) (.*)$")
         if hashes ~= nil and #hashes >= 1 and #hashes <= 5 then
-            out[#out + 1] = SkinHeadingMarkup((base.headings or {})[#hashes], hContent)
+            local h = (base.headings or {})[#hashes] or {}
+            local before = SkinGapLine(h.spaceBefore)
+            if before then out[#out + 1] = before end
+            out[#out + 1] = SkinHeadingMarkup(h, hContent)
+            local after = SkinGapLine(h.spaceAfter)
+            if after then out[#out + 1] = after end
         elseif bmarker ~= nil then
             out[#out + 1] = SkinBulletMarkup(base.bullet, bmarker, bContent)
         elseif onum ~= nil then
             out[#out + 1] = SkinOrderedMarkup(base.ordered, onum, oContent)
+        elseif line == "" then
+            local gap = SkinGapLine(bodyPS)
+            out[#out + 1] = gap or SkinBodyMarkup(base.body, line)
         else
             out[#out + 1] = SkinBodyMarkup(base.body, line)
         end

--- a/DocumentSystem/MarkdownDocument.lua
+++ b/DocumentSystem/MarkdownDocument.lua
@@ -813,6 +813,13 @@ local function SkinBodyMarkup(body, content)
         open = open .. string.format("<color=%s>", color)
         close = "</color>" .. close
     end
+    -- line-height: percent of the line's font size. Unset or 100 = no tag, so
+    -- the default skin stays a visual no-op. Wrapped + closed so it does not
+    -- bleed into adjacent heading lines that set no line-height.
+    if body.lineHeight and body.lineHeight ~= 100 then
+        open = open .. string.format("<line-height=%d%%>", body.lineHeight)
+        close = "</line-height>" .. close
+    end
     return open .. content .. close
 end
 

--- a/DocumentSystem/MarkdownDocument.lua
+++ b/DocumentSystem/MarkdownDocument.lua
@@ -820,6 +820,16 @@ local function SkinBodyMarkup(body, content)
         open = open .. string.format("<line-height=%d%%>", body.lineHeight)
         close = "</line-height>" .. close
     end
+    -- first-line indent (px). Positive indents the first visual line via a
+    -- horizontal space; negative is a hanging indent (wrapped lines pushed in,
+    -- matching SkinBulletMarkup). 0/nil = no markup.
+    local fli = body.firstLineIndent or 0
+    if fli > 0 then
+        open = open .. string.format("<space=%dpx>", fli)
+    elseif fli < 0 then
+        open = string.format("<indent=%dpx>", -fli) .. open
+        close = close .. "</indent>"
+    end
     return open .. content .. close
 end
 


### PR DESCRIPTION
## What

Wires up four journal-stylesheet typography fields that existed in the data model but weren't rendered, so a stylesheet can control vertical rhythm (the P1 item from the gap analysis against the printed MCDM book — leading + space-after are used by nearly every paragraph style in the book).

All rendered by injecting TextMeshPro markup through the existing per-line pipeline (a whole text run is one `gui.Label`, so this is in-text markup, not panel margins). One file: `DocumentSystem/MarkdownDocument.lua`.

| Field | Rendering |
|---|---|
| `body.lineHeight` (%) | `<line-height=N%>…</line-height>` |
| `body.firstLineIndent` (px) | positive → `<space=Npx>`; negative → `<indent=Npx>…</indent>` (hanging) |
| `body.paragraphSpacing` (px) | sized blank line between paragraphs |
| `headings[n].spaceBefore` / `spaceAfter` (px) | sized blank line around headings |

**No editor UI** — deliberate; these are set by editing the stylesheet directly (the editor stays curated).

## Commits

- `0a040770` body line-height
- `79a7fe6c` body first-line / hanging indent
- `38f44164` paragraph spacing + heading space-before/after

## Backward compatibility

The headline property: the default skin (all fields unset/0/nil) emits **no** new tags — markup is byte-identical to before. Proven from the code for all four fields in review, and asserted per-task via `MarkdownDocument.__ApplySkinToText`.

## Testing

No CLI runner; verified live via the DMHub bridge — logic assertions on the emitted markup string plus screenshots (looser line spacing, first-line/hanging indents, paragraph + heading gaps). Each task FAIL→PASS + a backward-compat assertion; final whole-branch review: ready to merge.

## Known / accepted for v1

- A blank line immediately before a heading produces an additive gap (paragraph-spacing + the heading's space-before). Flagged and accepted; a designer can zero one knob.
- Numeric fields use `%d` (matching the existing `sizePct`/`tracking` convention); fractional input is a pre-existing codebase-wide concern best hardened holistically in a follow-up, not in this branch.