### PR TITLE
fix(search): drop duplicate monster row from global search

### DIFF
--- a/Codex Titlescreen/CodexTitleBar.lua
+++ b/Codex Titlescreen/CodexTitleBar.lua
@@ -995,6 +995,14 @@ local function CreateSearchBar()
 
         local links = CustomDocument.SearchLinks(text)
         for _,link in ipairs(links) do
+            -- Monsters are owned by the dedicated "monsters" search provider
+            -- (richer actions: Place on Map / Edit Monster, and DM-gated).
+            -- SearchLinks emits a bare "monster" link only for the document
+            -- link picker; skip it here so the title-bar search does not show a
+            -- dead duplicate row (and does not leak monster names to players).
+            if link.type == "monster" then
+                goto continue
+            end
             link.score = scoreMatch(link.name, text)
             -- Render name + a muted type-label chip (like tokens), instead of
             -- baking "(Map)"/"(Document)" into the text -- so maps/journals tag
@@ -1027,6 +1035,7 @@ local function CreateSearchBar()
                 CustomDocument.OpenContent(CustomDocument.ResolveLink(link.link))
             end
             results[#results+1] = link
+            ::continue::
         end
 
         for k,doc in pairs(assets.pdfDocumentsTable) do


### PR DESCRIPTION
## Summary
Global search showed two rows per monster: the dedicated "Monster" provider
row (Place on Map / Edit Monster) and a redundant lower-cased "monster" row
whose primary action did nothing useful. The duplicate came from
CustomDocument.SearchLinks, which recently started emitting bare monster
links (commit 9276a66). This filters those out of the title-bar search
consumer while leaving the shared SearchLinks function intact.

## Changes
- In Codex Titlescreen/CodexTitleBar.lua, skip `type == "monster"` links
  returned by CustomDocument.SearchLinks when building global-search results.

## Testing
- Global search as DM: only the dedicated "Monster" row (Place on Map /
  Edit Monster) now appears; the dead duplicate is gone.
- Journal link picker still finds monsters via both paths that call
  SearchLinks (live `[` autocomplete and invalid-link suggestions) -- the
  shared function is unchanged.

## Notes for reviewer
- The duplicate also lacked the DM gate the dedicated provider has, so it was
  exposing monster names to non-DM players in global search; that path is
  removed too.
- Fix is deliberately scoped to the search consumer rather than SearchLinks
  itself, since the journal link picker legitimately needs monster results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)