### PR TITLE
fix(search): dedupe all compendium content in global search

### DIFF
--- a/Codex Titlescreen/CodexTitleBar.lua
+++ b/Codex Titlescreen/CodexTitleBar.lua
@@ -995,12 +995,15 @@ local function CreateSearchBar()
 
         local links = CustomDocument.SearchLinks(text)
         for _,link in ipairs(links) do
-            -- Monsters are owned by the dedicated "monsters" search provider
-            -- (richer actions: Place on Map / Edit Monster, and DM-gated).
-            -- SearchLinks emits a bare "monster" link only for the document
-            -- link picker; skip it here so the title-bar search does not show a
-            -- dead duplicate row (and does not leak monster names to players).
-            if link.type == "monster" then
+            -- Compendium content (markdown-table entries like items/titles, and
+            -- monsters) is owned by the dedicated compendium-content / monsters
+            -- search providers, which give richer actions ("Open in Compendium",
+            -- "Place on Map" / "Edit Monster") and DM-gating. SearchLinks emits
+            -- these only for the document link picker; skip them here so the
+            -- title-bar search shows no dead duplicate rows (and does not leak
+            -- monster names to players). Prefix suggestions ("Search items...")
+            -- and rulebook / journal / map links are kept.
+            if BucketForLinkType(link.type) == "compendium" and not link.isPrefix then
                 goto continue
             end
             link.score = scoreMatch(link.name, text)


### PR DESCRIPTION
## Summary
Follow-up to #142. That PR removed the duplicate monster row from the
title-bar global search; items and titles duplicated in exactly the same
way. The markdown-table name search added in 9276a66 makes
CustomDocument.SearchLinks return compendium content (items, titles,
monsters) that the dedicated compendium-content / monsters providers
already cover, producing a second, dead lower-cased row per result. This
replaces the monster-specific skip with a bucket-based one so all current
and future compendium content is deduped.

## Changes
- In Codex Titlescreen/CodexTitleBar.lua, skip any non-prefix
  CustomDocument.SearchLinks result that lands in the `compendium` bucket
  (monsters, items, titles, ...) instead of only `type == "monster"`.

## Testing
- Global search as DM: monsters, items, and titles each show only their
  dedicated provider row ("Place on Map" / "Edit Monster" or "Open in
  Compendium"); no lower-cased duplicate rows.
- Prefix suggestions ("Search items..." via typing `it`) still appear.
- Rulebook (PDF), journal, and map results are unaffected (they map to the
  rulebooks / ingame buckets, not compendium).
- Journal link picker still finds monsters/items/titles -- the shared
  SearchLinks function is untouched.
- Verified the filter behaviour against the live instance: items, titles,
  and monsters are dropped while the `item:` prefix suggestion is kept.

## Notes for reviewer
- The duplicates also lacked the DM-gating the dedicated providers have, so
  this also stops monster/compendium names leaking to non-DM players in
  global search.
- Scoped to the search consumer rather than SearchLinks itself, since the
  journal link picker legitimately needs those results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)