### PR TITLE
fix(tac-panel): show modified EV for monsters in character panel

### DIFF
--- a/Draw Steel Core Rules/MCDMCharacterPanel.lua
+++ b/Draw Steel Core Rules/MCDMCharacterPanel.lua
@@ -2626,7 +2626,7 @@ function TacPanel.Summary()
                         local text = element.text
                         if token.properties:IsMonster() then
                             local role = token.properties:try_get("role", "")
-                            local ev = token.properties:try_get("ev", 1)
+                            local ev = token.properties:EV()
                             if role ~= "" then
                                 text = string.format("LEVEL %d %s  EV %d", level, string.upper(role), ev)
                             else


### PR DESCRIPTION
## Summary
The EV indicator on the character (TAC) panel did not reflect EV attribute
modifiers. When a monster was scaled up/down with the new level-scaling feature,
the character sheet and stat block showed the adjusted EV but this panel kept
showing the original value, even after a reload.

## Changes
- `MCDMCharacterPanel.lua`: the per-token Level/EV label now calls `monster:EV()`
  instead of reading the raw stored `ev` field via `try_get("ev", 1)`.

## Testing
- Verified live against a scaled Goblin Assassin: raw `ev` field = 3,
  `:EV()` = 5. Panel now displays the scaled value.
- Confirmed `:EV()` returns clean integers across monster types on the map
  (matches the stat block, which already uses `:EV()` with `%d`).

## Notes for reviewer
- This brings the panel into parity with the stat block (MCDMMonster.lua:478)
  and character sheet, so it also now reflects other `ev` modifiers such as the
  Instant Solo template (EV*3), not only level scaling.
- Display-only change; no impact on saved state or encounter EV budgeting
  (the encounter total already used `:EV()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)