### PR TITLE
fix(search): surface deeply-nested class & ancestry features in search

### DIFF
--- a/DMHub Compendium/Compendium.lua
+++ b/DMHub Compendium/Compendium.lua
@@ -6911,15 +6911,41 @@ Search.RegisterProvider{
     end,
 }
 
--- Global-search provider: buried class/subclass sub-features (e.g. "Healing
--- Grace", "Sermon of Grace") surfaced as first-class results that deep-link to
--- the class filtered to that feature -- not just the opaque "Conduit" container.
--- The feature names are indexed lazily and cached (the index is large and
--- rarely changes); a class/subclass table refresh invalidates it.
+-- Global-search provider: buried sub-features surfaced as first-class results
+-- that deep-link to their container filtered to that feature -- not just the
+-- opaque "Conduit"/"Dragon Knight" container. Covers class/subclass features
+-- (e.g. "Healing Grace", "Sermon of Grace") AND ancestry traits, including
+-- deeply-nested purchased traits (e.g. "Draconian Guard"), since VisitAllFeatures
+-- walks the whole feature tree. The feature names are indexed lazily and cached
+-- (the index is large and rarely changes); a classes/subclasses/races table
+-- refresh invalidates it.
 local g_classFeatureIndex = nil
 
 local function BuildClassFeatureIndex()
     local index = {}
+
+    -- Shared per-content-object walk: append every uniquely-named feature in a
+    -- single ClassLevel to the index. `seen` dedupes names within one container
+    -- (a feature gained at several levels appears once). Guarded so a malformed
+    -- level doesn't drop the whole index.
+    local function indexClassLevel(classLevel, displayName, contentType, key, seen)
+        pcall(function()
+            classLevel:VisitAllFeatures(function(feature)
+                local fname = feature:try_get("name")
+                if type(fname) == "string" and #fname > 0 and not seen[fname] then
+                    seen[fname] = true
+                    index[#index+1] = {
+                        name = fname,
+                        className = displayName,
+                        contentType = contentType,
+                        classKey = key,
+                    }
+                end
+            end)
+        end)
+    end
+
+    -- Classes/subclasses expose a map of named levels.
     for _,tableName in ipairs({"classes", "subclasses"}) do
         local t = dmhub.GetTable(tableName) or {}
         for ck, class in unhidden_pairs(t) do
@@ -6927,31 +6953,34 @@ local function BuildClassFeatureIndex()
             local levels = class:try_get("levels")
             if type(className) == "string" and type(levels) == "table" then
                 local seen = {}
-                -- Guard per-class: a malformed level shouldn't drop the whole index.
-                pcall(function()
-                    for _,classLevel in pairs(levels) do
-                        classLevel:VisitAllFeatures(function(feature)
-                            local fname = feature:try_get("name")
-                            if type(fname) == "string" and #fname > 0 and not seen[fname] then
-                                seen[fname] = true
-                                index[#index+1] = {
-                                    name = fname,
-                                    className = className,
-                                    contentType = tableName,
-                                    classKey = ck,
-                                }
-                            end
-                        end)
-                    end
-                end)
+                for _,classLevel in pairs(levels) do
+                    indexClassLevel(classLevel, className, tableName, ck, seen)
+                end
             end
         end
     end
+
+    -- Ancestries (races) expose a single class level via GetClassLevel(); their
+    -- signature and purchased traits live as nested features under it. The same
+    -- editor (ClassLevel:CreateEditor) renders both, so the deep-link target key
+    -- works identically.
+    local raceTable = dmhub.GetTable(Race.tableName) or {}
+    for rk, race in unhidden_pairs(raceTable) do
+        local raceName = race.name
+        if type(raceName) == "string" then
+            local classLevel = nil
+            pcall(function() classLevel = race:GetClassLevel() end)
+            if classLevel ~= nil then
+                indexClassLevel(classLevel, raceName, Race.tableName, rk, {})
+            end
+        end
+    end
+
     return index
 end
 
 dmhub.RegisterEventHandler("refreshTables", function(keys)
-    if keys == nil or keys.classes ~= nil or keys.subclasses ~= nil then
+    if keys == nil or keys.classes ~= nil or keys.subclasses ~= nil or keys[Race.tableName] ~= nil then
         g_classFeatureIndex = nil
     end
 end)

--- a/Draw Steel UI/DSClassEditor.lua
+++ b/Draw Steel UI/DSClassEditor.lua
@@ -21,6 +21,57 @@ local IsCharacterFeatureType = function(item)
 	return item ~= nil and g_validFeatureTypes[item.typeName] == true
 end
 
+-- Class/ancestry editor search filter. The shared Search.MatchesObject caps its
+-- recursive walk at depth 6, but feature NAMES in deeply-nested structures (a
+-- level's "Domain Feature" choice -> a domain list -> the feature) land at depth
+-- 7. That made deep features (Censor "Blessing of Iron", elementalist wards)
+-- fail this filter and get hidden entirely. This is a private, editor-only copy
+-- of that matcher with a deeper cap so those features match. It is the SAME
+-- algorithm as Search.MatchesObject (verbatim needle, lowered haystack, the same
+-- multi-term AND split), only with a higher depth limit -- so every match the
+-- old filter found is still found, plus the deep ones. The shared
+-- Search.MatchesObject is deliberately NOT changed, so no other consumer (the
+-- compendium-browser list filter, language picker, ...) shifts behaviour or pays
+-- the extra walk cost. Cap 10 covers the deepest real nesting (7) with headroom
+-- (a choice inside a domain feature would be 9); names never sit deeper.
+local FEATURE_SEARCH_DEPTH = 10
+
+local function MatchesFeatureNeedleSingle(obj, needle, depth)
+	depth = depth or 0
+	if depth > FEATURE_SEARCH_DEPTH then
+		return false
+	end
+	if type(obj) == "table" then
+		for k,v in pairs(obj) do
+			if MatchesFeatureNeedleSingle(k, needle, depth+1) or MatchesFeatureNeedleSingle(v, needle, depth+1) then
+				return true
+			end
+		end
+	elseif type(obj) == "string" then
+		if string.find(string.lower(obj), needle, 1, true) ~= nil then
+			return true
+		end
+	end
+	return false
+end
+
+-- Drop-in replacement for the old MatchesSearchRecursive(obj, search) calls in
+-- this editor.
+-- Mirrors Search.MatchesObject's contract exactly (needle used verbatim, terms
+-- AND-matched) so it is a strict superset of the previous behaviour.
+local function MatchesFeatureSearch(obj, search)
+	local terms = Search.SplitTerms(search)
+	if terms == nil then
+		return MatchesFeatureNeedleSingle(obj, search, 0)
+	end
+	for _,term in ipairs(terms) do
+		if not MatchesFeatureNeedleSingle(obj, term, 0) then
+			return false
+		end
+	end
+	return true
+end
+
 local CreateFeatureSummary = function(feature, featuresList, index, parentPanel, DescribeFeature, options)
 	options = options or {}
 
@@ -82,7 +133,7 @@ local CreateFeatureSummary = function(feature, featuresList, index, parentPanel,
             end
 
             element:SetClassTree("searching", true)
-            if MatchesSearchRecursive(feature, text) then
+            if MatchesFeatureSearch(feature, text) then
                 element:SetClassTree("matchSearch", true)
             else
                 element:SetClassTree("matchSearch", false)
@@ -728,7 +779,7 @@ local CreateChoiceEditor = function(feature, featuresList, index, parentPanel, c
             end
 
             element:SetClassTree("searching", true)
-            if MatchesSearchRecursive(feature, text) then
+            if MatchesFeatureSearch(feature, text) then
                 element:SetClassTree("matchSearch", true)
             else
                 element:SetClassTree("matchSearch", false)
@@ -1280,7 +1331,7 @@ function Class.CreateLevelEditor(children, class, UploadClass, startLevel, finis
 				end
 
 				element:SetClassTree("searching", true)
-				if MatchesSearchRecursive(classLevel, text) then
+				if MatchesFeatureSearch(classLevel, text) then
 					element:SetClassTree("matchSearch", true)
 				else
 					element:SetClassTree("matchSearch", false)
@@ -1312,7 +1363,7 @@ function Class.CreateLevelEditor(children, class, UploadClass, startLevel, finis
 				end
 
 				element:SetClass("searching", true)
-				local matched = MatchesSearchRecursive(classLevel, text)
+				local matched = MatchesFeatureSearch(classLevel, text)
 				element:SetClass("matchSearch", matched)
 				if matched then
 					--auto-expanding to show the match: build the deferred body.

--- a/Draw Steel UI/DSClassEditor.lua
+++ b/Draw Steel UI/DSClassEditor.lua
@@ -327,6 +327,9 @@ local CreateChoiceEditor = function(feature, featuresList, index, parentPanel, c
 	}
 
 	local body
+	-- Captured so the searchCompendium handler can toggle its expanded state when
+	-- auto-expanding along a matched path (mirrors the level card's header).
+	local headerPanel
 
 	local nameLabel = gui.Label{
             classes = {cond(feature:try_get("imported", false), cond(feature:try_get("importOverride", false), "accent", "")), "sizeL", "bold"},
@@ -352,7 +355,7 @@ local CreateChoiceEditor = function(feature, featuresList, index, parentPanel, c
         }
     end
 
-	children[#children+1] = gui.Panel{
+	headerPanel = gui.Panel{
 		classes = {"featureCardHeader"},
 		tri,
 		nameLabel,
@@ -471,6 +474,8 @@ local CreateChoiceEditor = function(feature, featuresList, index, parentPanel, c
 			}
 		end,
 	}
+
+	children[#children+1] = headerPanel
 
 	-- The body's sub-editors are constructed by builder functions invoked from
 	-- BuildChoiceBody (lazily, on first expansion). Constructing them eagerly
@@ -770,20 +775,34 @@ local CreateChoiceEditor = function(feature, featuresList, index, parentPanel, c
 		height = "auto",
 		children = children,
 
+        -- Mirror the level card's filter (see ClassLevel:CreateEditor): element-only
+        -- SetClass (NOT SetClassTree) so a matching choice does NOT force-show its
+        -- non-matching option cards -- each option card sets its own matchSearch via
+        -- its own handler, and the hide rule {hideOnSearchMismatch, searching,
+        -- ~matchSearch} collapses the misses. On a match we also auto-expand the body
+        -- so the buried feature is actually visible: EnsureBuilt builds the deferred
+        -- body (if lazy) and re-fires the filter into the freshly built children, so
+        -- the reveal cascades down the matched path (choice -> option -> feature).
         searchCompendium = function(element, text)
             m_lastSearch = text or ""
             if text == "" then
-                element:SetClassTree("searching", false)
-                element:SetClassTree("matchSearch", false)
+                element:SetClass("searching", false)
+                element:SetClass("matchSearch", false)
+                body:SetClass("collapsed-anim", true)
+                tri:SetClass("expanded", false)
+                headerPanel:SetClass("expanded", false)
                 return
             end
 
-            element:SetClassTree("searching", true)
-            if MatchesFeatureSearch(feature, text) then
-                element:SetClassTree("matchSearch", true)
-            else
-                element:SetClassTree("matchSearch", false)
+            element:SetClass("searching", true)
+            local matched = MatchesFeatureSearch(feature, text)
+            element:SetClass("matchSearch", matched)
+            if matched and body.data ~= nil and body.data.EnsureBuilt ~= nil then
+                body.data.EnsureBuilt(text)
             end
+            body:SetClass("collapsed-anim", not matched)
+            tri:SetClass("expanded", matched)
+            headerPanel:SetClass("expanded", matched)
         end,
 	}
 


### PR DESCRIPTION
## Summary
Fixes two related global-search gaps where nested features weren't reachable.
First, ancestry traits (including deeply-nested purchased traits) were never
indexed, so they couldn't be found. Second, when you searched a feature buried
inside a class/ancestry -- e.g. Censor "Blessing of Iron" under Domain Feature ->
Protection Domain -- the editor either hid the whole level or showed every option
unfiltered. Both are now fixed; nested features behave like shallow ones (show
only the match).

## Changes
- Index ancestry traits: `BuildClassFeatureIndex` now also walks the `races`
  table (via `GetClassLevel`), so nested ancestry traits are searchable and
  deep-link into the ancestry editor; `races` added to the cache invalidation.
- Reach deep class features: the class/ancestry editor filter capped its
  recursive walk at depth 6, but feature names nest at depth 7 (domain features,
  elementalist wards). Added a private editor-only cap-10 matcher with identical
  semantics -- a strict superset of the old behaviour. Shared `Search.MatchesObject`
  is left unchanged, so no other consumer is affected.
- Narrow to the match: a matched choice card now uses element-only `SetClass`
  (not a subtree stamp) and auto-expands the matched path via `EnsureBuilt`, so
  the reveal cascades choice -> option -> feature while non-matching siblings hide.

## Testing
Verified live against a running DMHub instance:
- "Draconian Guard" / "Remember Your Oath" (ancestry purchased traits) now return
  results and deep-link into the Dragon Knight editor.
- "Blessing of Iron" deep-link and manual filter both reveal the feature (path
  built and expanded), with sibling domains (Creation/War/Storm) hidden.
- Clearing the filter restores the collapsed state.
- Shallow-feature regression ("Templar") still narrows correctly.

## Notes for reviewer
- The depth fix is deliberately a private, editor-local matcher rather than a bump
  to the shared `Search.MatchesObject` cap -- to avoid slowing the compendium-browser
  list filter and other consumers. Measured cost on the heaviest class is ~1.1ms ->
  ~2.8ms, editor-only.
- The narrowing fix mirrors a pattern the level card already used; the leaf card
  builder was intentionally left as-is (subtree stamping is harmless for a leaf).