### PR TITLE
fix(character-panel): clear stale perks from abandoned careers

### DIFF
--- a/Draw Steel Character Builder/FeatureCache.lua
+++ b/Draw Steel Character Builder/FeatureCache.lua
@@ -1309,7 +1309,10 @@ end
 local function categoriserAddBuildFeatures(creature, addEntry)
     if creature.typeName ~= "character" then return end
 
-    local ok, details = pcall(function() return creature:GetClassFeaturesAndChoicesWithDetails() end)
+    -- Cached (TTL memo) variant: this index is itself rebuilt on a short TTL, so
+    -- a slightly stale details table changes nothing here, and it lets the tac
+    -- panel Perks section share one build per creature per window.
+    local ok, details = pcall(function() return creature:GetClassFeaturesAndChoicesWithDetailsCached() end)
     if not ok or type(details) ~= "table" then return end
 
     --Pass 1: resolve the chosen option features of every made generic

--- a/Draw Steel Core Rules/MCDMCharacterPanel.lua
+++ b/Draw Steel Core Rules/MCDMCharacterPanel.lua
@@ -6141,7 +6141,9 @@ function TacPanel.Perks()
             -- abandoned careers, since their choice guids linger in levelChoices even
             -- though they no longer map to any active feature. Filtering through
             -- GetClassFeaturesAndChoicesWithDetails matches the builder and sheet.
-            local features = creature:GetClassFeaturesAndChoicesWithDetails()
+            -- The cached variant is a TTL memo so this frequently-fired refresh
+            -- stays cheap and shares its build with the Features section.
+            local features = creature:GetClassFeaturesAndChoicesWithDetailsCached()
             if features then
                 for _,f in ipairs(features) do
                     if f.feature and f.feature.typeName == "CharacterFeatChoice" then

--- a/Draw Steel Core Rules/MCDMCharacterPanel.lua
+++ b/Draw Steel Core Rules/MCDMCharacterPanel.lua
@@ -6136,19 +6136,32 @@ function TacPanel.Perks()
             local seen = {}
             local levelChoices = creature:GetLevelChoices() or {}
             local featTable = dmhub.GetTableVisible(CharacterFeat.tableName)
-            for _,choices in pairs(levelChoices) do
-                for _,guid in ipairs(choices) do
-                    if not seen[guid] then
-                        seen[guid] = true
-                        local featItem = featTable[guid]
-                        if featItem then
-                            specs[#specs+1] = {
-                                entryKey = "perks",
-                                entryId  = guid,
-                                charid   = charid,
-                                title    = featItem.name,
-                                body     = featItem.description,
-                            }
+            -- Only display perks that belong to a current feature choice. Iterating
+            -- levelChoices directly would also surface stale perks left behind by
+            -- abandoned careers, since their choice guids linger in levelChoices even
+            -- though they no longer map to any active feature. Filtering through
+            -- GetClassFeaturesAndChoicesWithDetails matches the builder and sheet.
+            local features = creature:GetClassFeaturesAndChoicesWithDetails()
+            if features then
+                for _,f in ipairs(features) do
+                    if f.feature and f.feature.typeName == "CharacterFeatChoice" then
+                        local choices = levelChoices[f.feature.guid]
+                        if choices then
+                            for _,guid in ipairs(choices) do
+                                if not seen[guid] then
+                                    seen[guid] = true
+                                    local featItem = featTable[guid]
+                                    if featItem then
+                                        specs[#specs+1] = {
+                                            entryKey = "perks",
+                                            entryId  = guid,
+                                            charid   = charid,
+                                            title    = featItem.name,
+                                            body     = featItem.description,
+                                        }
+                                    end
+                                end
+                            end
                         end
                     end
                 end

--- a/Draw Steel Core Rules/MCDMCustomRules.lua
+++ b/Draw Steel Core Rules/MCDMCustomRules.lua
@@ -208,6 +208,29 @@ function character:GetClassFeaturesAndChoicesWithDetails()
 	return passedResult
 end
 
+-- TTL memo over GetClassFeaturesAndChoicesWithDetails. That call rebuilds a
+-- large table (it walks every source and resolves choices) and is polled by
+-- panels that refresh many times a second (the tac panel Features and Perks
+-- sections). A short time-to-live, keyed by creature identity (weak so it
+-- self-prunes), collapses that storm into one build per creature per window --
+-- the same idiom FeatureCache.lua uses for its categoriser index. The result is
+-- treated as read-only by callers; do not mutate the returned table.
+local g_classFeatureDetailsCache = setmetatable({}, { __mode = "k" })
+local CLASS_FEATURE_DETAILS_TTL = 1.0
+
+--returns a list of { class/race/background/characterType = Class/Race/Background, levels = {list of ints}, feature = CharacterFeature or CharacterChoice }
+function character:GetClassFeaturesAndChoicesWithDetailsCached()
+	local now = dmhub.Time()
+	local cached = g_classFeatureDetailsCache[self]
+	if cached ~= nil and (now - cached.time) < CLASS_FEATURE_DETAILS_TTL then
+		return cached.result
+	end
+
+	local result = self:GetClassFeaturesAndChoicesWithDetails()
+	g_classFeatureDetailsCache[self] = { time = now, result = result }
+	return result
+end
+
 --- Returns an array of { feature = CharacterChoice, ... } entries for every
 --- CharacterChoice-derived feature reachable from this creature's "catch-all"
 --- sources -- the ones not covered by the per-source builder tabs.


### PR DESCRIPTION
## Summary
The live character panel's PERKS section displayed stale perks left behind after switching a hero's Career. Selecting a new Career and Perk would leave the old career's Perk in the panel, so a level-1 hero could show several Perks instead of one. The character sheet's Features section and the Builder were already correct.

## Changes
- `TacPanel.Perks` in `Draw Steel Core Rules/MCDMCharacterPanel.lua` no longer iterates every `levelChoices` entry. It now filters through `creature:GetClassFeaturesAndChoicesWithDetails()` and only displays choices keyed by a current `CharacterFeatChoice` feature -- matching the builder's `cachePerks` and the sheet's Features categoriser.

## Root cause
When a career is abandoned, its perk-choice guids stay in `levelChoices` (keyed by the old feature's guid). The panel showed any feat resolvable from those guids. Switching perks within the same career reuses the same feature guid, which is why that case never bugged out.

## Testing
Verified against a live DMHub instance: a hero with a stale `Master of Disguise` perk from an abandoned career showed `Area of Expertise, Master of Disguise` under the old code and correctly `Area of Expertise` only under the fix. All other heroes showed identical perk sets before/after (no valid perks dropped). Reload was clean (43 mods). User confirmed in-app.