### PR TITLE
Show implementation status on character builder feature choices

### DIFF
--- a/Draw Steel Character Builder/FeatureCache.lua
+++ b/Draw Steel Character Builder/FeatureCache.lua
@@ -881,6 +881,16 @@ function CBOptionWrapper:GetGuid()
     return _safeGet(self.option, "guid", _safeGet(self.option, "id"))
 end
 
+--- The implementation status of this option, matching gui.ImplementationStatus
+--- (0 = Narrative, 1 = Unimplemented, 2 = Bronze, 3 = Silver, 4 = Gold). Mirrors
+--- the class/compendium editor, which treats an unset status as Unimplemented
+--- (see DSClassEditor's feature:try_get("implementation", 1)), so options an
+--- author never marked surface as Unimplemented rather than silently blank.
+--- @return number
+function CBOptionWrapper:GetImplementation()
+    return _safeGet(self.option, "implementation", 1)
+end
+
 --- @return string
 function CBOptionWrapper:GetName()
     return _safeGet(self.option, "name", _safeGet(self.option, "text"))

--- a/Draw Steel Character Builder/FeatureSelector.lua
+++ b/Draw Steel Character Builder/FeatureSelector.lua
@@ -533,6 +533,7 @@ function CBFeatureSelector.SelectionPanel(selector, feature)
                 end
                 element:FireEventTree("updateName", name)
                 element:FireEventTree("updateDesc", option:GetDescription())
+                element:FireEventTree("updateImplementation", option:GetImplementation())
                 element:FireEventTree("customPanel", option:Panel())
 
                 -- Enable dragging if selection is allowed
@@ -603,6 +604,50 @@ function CBFeatureSelector.SelectionPanel(selector, feature)
                     text = "",
                     updateName = function(element, text)
                         if element.text ~= text then element.text = text end
+                    end,
+                },
+            },
+            -- Implementation-status badge so the player can see how complete an
+            -- option's mechanics are before choosing it (mirrors the status dot
+            -- the compendium/class editor shows authors). Unset options report
+            -- Unimplemented -- see CBOptionWrapper:GetImplementation.
+            gui.Panel{
+                classes = {"builder-base", "panel-base", "collapsed"},
+                flow = "horizontal",
+                width = "auto",
+                height = "auto",
+                halign = "left",
+                hmargin = 8,
+                tmargin = 2,
+                bmargin = 2,
+                interactable = false,
+                updateImplementation = function(element, impl)
+                    local visible = impl ~= nil
+                    element:SetClass("collapsed", not visible)
+                    if not visible then return end
+                    element:FireEventTree("implementation", impl)
+                    element:FireEventTree("updateImplLabel", impl)
+                end,
+                gui.ImplementationStatusIcon{
+                    halign = "left",
+                    valign = "center",
+                    implementation = 1,
+                },
+                gui.Label{
+                    classes = {"builder-base", "label"},
+                    fontSize = 14,
+                    bold = false,
+                    italics = false,
+                    width = "auto",
+                    height = "auto",
+                    halign = "left",
+                    valign = "center",
+                    text = "",
+                    updateImplLabel = function(element, impl)
+                        element.text = gui.ImplementationStatusValues[impl] or ""
+                        for i = 0, 4 do
+                            element:SetClass("implStatus" .. i, i == impl)
+                        end
                     end,
                 },
             },


### PR DESCRIPTION
## Summary
The compendium / class editor shows each feature option's implementation status (Narrative / Unimplemented / Bronze / Silver / Gold via `gui.ImplementationStatusIcon`), but the character builder's `FeatureSelector` never surfaced it. Players selecting options (e.g. Animal Traits) had no signal about how complete an option's mechanics were before committing to it.

## Changes
- **`Draw Steel Character Builder/FeatureCache.lua`** — add `CBOptionWrapper:GetImplementation()`, reading the option's `implementation` field and defaulting an unset status to `Unimplemented` to match the editor (`feature:try_get("implementation", 1)`).
- **`Draw Steel Character Builder/FeatureSelector.lua`** — render an implementation badge (the canonical colored status dot + the status name) under each option's name in the builder's option list, wired through `refreshBuilderState` alongside the existing `updateName` / `updateDesc` fires.

Because `FeatureSelector` is the shared builder option renderer, every point/choice feature list in the builder now shows the badge.

## Verification (against a running DMHub instance)
- `reload_lua` reloaded all 42 mods with no console errors.
- `CBOptionWrapper:GetImplementation()` against live data returns `3` -> "Silver" for an option with the field set, and `1` -> "Unimplemented" for one without (1,148 live features carry an explicit status).
- The badge markup renders correctly across all five tiers (Gold / Silver / Bronze / Unimplemented / Narrative) with the matching `implStatus` colors.