### PR TITLE
feat(villain-actions): show ability preview card when a Villain Action is gated

### DIFF
--- a/Draw Steel Core Rules/MCDMActivatedAbility.lua
+++ b/Draw Steel Core Rules/MCDMActivatedAbility.lua
@@ -1501,6 +1501,25 @@ function ActivatedAbility:Render(options, params)
         }
     end
 
+    -- Optional caller-supplied danger-tinted footer note, appended at the very
+    -- bottom of the card. Reuses the suppressPanel styling. Used by the Villain
+    -- Action strip to explain a gated drawer ("already used this round/encounter")
+    -- while still showing the full ability preview above it.
+    local footerPanel = nil
+    local footerNote = params.footerNote
+    if footerNote ~= nil and footerNote ~= "" then
+        footerPanel = gui.Label {
+            bgimage = true,
+            classes = { "bgDanger" },
+            width = "100%",
+            height = "auto",
+            fontSize = 14,
+            hpad = 16,
+            vpad = 4,
+            text = footerNote,
+        }
+    end
+
     --king panel
     local args = {
         id = 'spellInfo',
@@ -2318,6 +2337,8 @@ function ActivatedAbility:Render(options, params)
         },
 
         suppressPanel,
+
+        footerPanel,
     }
 
 

--- a/Draw Steel Core Rules/MCDMInitiativeBar.lua
+++ b/Draw Steel Core Rules/MCDMInitiativeBar.lua
@@ -1490,22 +1490,21 @@ local function CreateVillainActionDrawer(slotKey, slotNumeral)
         hover = function(element)
             if m_token == nil or m_ability == nil or not m_token.valid then return end
 
+            -- Always show the full ability preview card. When the drawer is
+            -- gated, append a danger-tinted footer note to the card explaining
+            -- why, rather than replacing the preview with a bare text tooltip.
+            local footerNote = nil
             if VillainActionState.HasUsed(m_token.charid, slotKey) then
-                gui.Tooltip{
-                    text = (m_ability.name or "This Villain Action") .. " has already been used this encounter.",
-                }(element)
+                footerNote = (m_ability.name or "This Villain Action") .. " has already been used this encounter."
             elseif CharacterResource.GetVillainActions() <= 0 then
-                gui.Tooltip{
-                    text = "You have already used a Villain Action this round.",
-                }(element)
+                footerNote = "You have already used a Villain Action this round."
+            end
+
+            local tooltip = CreateAbilityTooltip(m_ability, {token = m_token, width = 480, footerNote = footerNote})
+            if tooltip ~= nil then
+                element.tooltip = tooltip
             else
-                -- Full ability preview card for available drawers.
-                local tooltip = CreateAbilityTooltip(m_ability, {token = m_token, width = 480})
-                if tooltip ~= nil then
-                    element.tooltip = tooltip
-                else
-                    gui.Tooltip{text = m_ability.name or ""}(element)
-                end
+                gui.Tooltip{text = m_ability.name or ""}(element)
             end
         end,
 
@@ -1544,6 +1543,22 @@ local function CreateVillainActionDrawer(slotKey, slotNumeral)
                             element.popup = nil
                             InvokeVillainAction(token, ability)
                         end,
+                    },
+                    {
+                        text = "Mark as Used",
+                        click = function()
+                            element.popup = nil
+                            -- Mirror the engine's normal consumption hook
+                            -- (the cast-cleanup path in ActivatedAbility):
+                            -- mark this slot used for the encounter and spend
+                            -- the per-round Villain Action budget, without
+                            -- firing the ability. Both writes are undoable.
+                            VillainActionState.MarkUsed(token.charid, slotKey)
+                            if CharacterResource.GetVillainActions() > 0 then
+                                CharacterResource.SetVillainActions(0, "Villain Action used")
+                            end
+                        end,
+                        hidden = consumed,
                     },
                     {
                         text = "Reset this Villain Action",


### PR DESCRIPTION
## Summary
On the Villain Action panel under the initiative tracker, hovering a drawer that was gated (this VA already used this encounter, or the round's VA budget already spent) replaced the full ability preview with a bare text tooltip -- so there was no way to read the ability until the next round. This PR keeps the full preview card visible in those states and explains the gate with a danger-tinted footer note. It also adds a director-only "Mark as Used" right-click action for an unused Villain Action.

## Changes
- `MCDMActivatedAbility.lua`: `Render` gains an optional `params.footerNote`. When set, a `bgDanger`-classed footer label is appended at the bottom of the card, reusing the existing `suppressPanel` styling. No-op (no behaviour change) when absent.
- `MCDMInitiativeBar.lua`: the drawer hover handler now always builds the full `CreateAbilityTooltip` card, passing a `footerNote` when gated:
  - VA already used this encounter -> "<name> has already been used this encounter."
  - Round VA budget spent (an unused VA) -> "You have already used a Villain Action this round."
- `MCDMInitiativeBar.lua`: new director-only "Mark as Used" right-click entry, shown only when the VA is not already consumed. Mirrors the engine's normal cast-cleanup consumption hook (`VillainActionState.MarkUsed` + spend the per-round budget via `SetVillainActions(0, ...)`) without firing the ability. Both writes are undoable.

## Testing
- Reloaded Lua (43 mods) with no console errors.
- Manually verified in-game by the author: gated drawers now show the preview card with the red footer; the "Mark as Used" entry consumes the slot and round budget as expected.

## Notes for reviewer
- Left-click gating is unchanged: showing the preview does not enable casting, and "Use anyway" remains the override.
- "Mark as Used" records two undoable changes (shared VA doc + global resource), matching the engine's existing two-step consumption path.