### PR TITLE
Add Prepped compendium section: Negotiators and Montage Tests

### DIFF
--- a/DMHub Compendium/Compendium.lua
+++ b/DMHub Compendium/Compendium.lua
@@ -6659,6 +6659,91 @@ local function ShowNegotiatorsPanel(contentPanel)
     contentPanel.children = {leftPanel}
 end
 
+--Editor for a single montage test, fetched live from the table by key. Reuses
+--MontageDocument:EditPanel (inherited by MontageTest). EditPanel mutates the
+--object in place but does not upload, so a Save button drives the upload.
+local function CreateMontageTestEditor(key)
+    local montage = (dmhub.GetTable(MontageTest.tableName) or {})[key]
+    if montage == nil then
+        return gui.Panel{ width = 900, height = "95%" }
+    end
+
+    return gui.Panel{
+        width = 900,
+        height = "95%",
+        vscroll = true,
+        flow = "vertical",
+        montage:EditPanel(),
+        gui.Button{
+            classes = {"sizeM"},
+            text = "Save",
+            width = 120,
+            height = 30,
+            halign = "left",
+            vmargin = 10,
+            click = function()
+                dmhub.SetAndUploadTableItem(MontageTest.tableName, montage)
+            end,
+        },
+    }
+end
+
+local function ShowMontageTestsPanel(contentPanel)
+    local itemsListPanel
+    local leftPanel
+
+    itemsListPanel = gui.Panel{
+        classes = {"list-panel"},
+        vscroll = true,
+        monitorAssets = true,
+        refreshAssets = function(element)
+            local dataTable = dmhub.GetTable(MontageTest.tableName) or {}
+            local children = {}
+            local entries = {}
+            for key,item in unhidden_pairs(dataTable) do
+                entries[#entries+1] = { key = key, item = item }
+            end
+            table.sort(entries, function(a,b)
+                return (a.item.description or "") < (b.item.description or "")
+            end)
+
+            for _,entry in ipairs(entries) do
+                local key = entry.key
+                local listItem = CreateListItem{
+                    select = element.aliveTime > 0.2,
+                    tableName = MontageTest.tableName,
+                    key = key,
+                    obliterateOnDelete = true,
+                    click = function()
+                        contentPanel.children = {leftPanel, CreateMontageTestEditor(key)}
+                    end,
+                }
+                listItem.text = entry.item.description or "Montage Test"
+                children[#children+1] = listItem
+            end
+            itemsListPanel.children = children
+        end,
+    }
+
+    itemsListPanel:FireEvent("refreshAssets")
+
+    leftPanel = gui.Panel{
+        selfStyle = {
+            flow = "vertical",
+            height = "100%",
+            width = "auto",
+        },
+        itemsListPanel,
+        AddButton{
+            click = function()
+                dmhub.SetAndUploadTableItem(MontageTest.tableName, MontageTest.CreateNew{})
+            end,
+        },
+    }
+
+    contentPanel.children = {leftPanel}
+end
+
 Compendium.CreateListItem = CreateListItem
 
 local g_registeredPanels = false

--- a/DMHub Compendium/Compendium.lua
+++ b/DMHub Compendium/Compendium.lua
@@ -6511,7 +6511,16 @@ local function CreateNegotiatorTraitList(negotiator, listField, titleText, addLa
             text = addLabel,
             halign = "left",
             click = function()
-                negotiator[listField][#negotiator[listField]+1] = NegotiatorTrait.Create{}
+                --Make sure this negotiator owns its own list before mutating it.
+                --If the field is still resolving to the shared prototype default
+                --(or is nil), pushing into it would corrupt every other negotiator,
+                --so allocate a fresh table first.
+                local list = negotiator[listField]
+                if list == nil or list == Negotiator[listField] then
+                    list = {}
+                    negotiator[listField] = list
+                end
+                list[#list+1] = NegotiatorTrait.Create{}
                 dmhub.SetAndUploadTableItem(Negotiator.tableName, negotiator)
                 Rebuild()
             end,

--- a/DMHub Compendium/Compendium.lua
+++ b/DMHub Compendium/Compendium.lua
@@ -6410,6 +6410,255 @@ local ShowJournalStylesheetsPanel = function(parentPanel)
     parentPanel.children = {leftPanel, editorPanel}
 end
 
+--Editor for a single trait (motivation or pitfall) row: name + description +
+--remove. listField is "motivations" or "pitfalls". Mutates the negotiator and
+--uploads on every change; calls onRemove to rebuild the row list.
+local function CreateNegotiatorTraitRow(negotiator, listField, trait, onRemove)
+    local rowPanel
+    rowPanel = gui.Panel{
+        flow = "horizontal",
+        width = "100%",
+        height = "auto",
+        vmargin = 2,
+        gui.Input{
+            classes = {"sizeS"},
+            width = 160,
+            height = 22,
+            valign = "top",
+            placeholderText = "Name",
+            text = trait.name,
+            change = function(element)
+                trait.name = element.text
+                dmhub.SetAndUploadTableItem(Negotiator.tableName, negotiator)
+            end,
+        },
+        gui.Input{
+            classes = {"sizeS"},
+            width = 460,
+            height = "auto",
+            minHeight = 22,
+            hmargin = 8,
+            valign = "top",
+            multiline = true,
+            placeholderText = "Description",
+            text = trait.description,
+            change = function(element)
+                trait.description = element.text
+                dmhub.SetAndUploadTableItem(Negotiator.tableName, negotiator)
+            end,
+        },
+        gui.Button{
+            classes = {"sizeS"},
+            text = "Remove",
+            width = 80,
+            height = 22,
+            valign = "top",
+            hmargin = 8,
+            click = function()
+                for i,t in ipairs(negotiator[listField]) do
+                    if t == trait then
+                        table.remove(negotiator[listField], i)
+                        break
+                    end
+                end
+                dmhub.SetAndUploadTableItem(Negotiator.tableName, negotiator)
+                onRemove()
+            end,
+        },
+    }
+    return rowPanel
+end
+
+--Builds the labelled list of trait rows (motivations or pitfalls) plus an add
+--button. Rebuilds itself in place when rows are added or removed.
+local function CreateNegotiatorTraitList(negotiator, listField, titleText, addLabel)
+    local rowsPanel
+    local Rebuild
+
+    rowsPanel = gui.Panel{
+        flow = "vertical",
+        width = "100%",
+        height = "auto",
+    }
+
+    Rebuild = function()
+        local children = {}
+        for _,trait in ipairs(negotiator[listField]) do
+            children[#children+1] = CreateNegotiatorTraitRow(negotiator, listField, trait, Rebuild)
+        end
+        rowsPanel.children = children
+    end
+
+    Rebuild()
+
+    return gui.Panel{
+        flow = "vertical",
+        width = "100%",
+        height = "auto",
+        vmargin = 8,
+        gui.Label{
+            classes = {"bold"},
+            text = titleText,
+            width = "auto",
+            height = "auto",
+        },
+        rowsPanel,
+        AddButton{
+            text = addLabel,
+            halign = "left",
+            click = function()
+                negotiator[listField][#negotiator[listField]+1] = NegotiatorTrait.Create{}
+                dmhub.SetAndUploadTableItem(Negotiator.tableName, negotiator)
+                Rebuild()
+            end,
+        },
+    }
+end
+
+--Editor for a single negotiator, fetched live from the table by key.
+local function CreateNegotiatorEditor(key)
+    local negotiator = (dmhub.GetTable(Negotiator.tableName) or {})[key]
+    if negotiator == nil then
+        return gui.Panel{ width = 900, height = "95%" }
+    end
+
+    return gui.Panel{
+        width = 900,
+        height = "95%",
+        vscroll = true,
+        flow = "vertical",
+        gui.Input{
+            classes = {"sizeL"},
+            width = 400,
+            height = 26,
+            placeholderText = "Name",
+            text = negotiator.name,
+            change = function(element)
+                negotiator.name = element.text
+                dmhub.SetAndUploadTableItem(Negotiator.tableName, negotiator)
+            end,
+        },
+        gui.Panel{
+            flow = "horizontal",
+            width = "auto",
+            height = "auto",
+            vmargin = 6,
+            gui.Label{
+                classes = {"bold"},
+                text = "Impression Score",
+                width = "auto",
+                height = 22,
+                valign = "center",
+            },
+            gui.Input{
+                classes = {"sizeS"},
+                width = 60,
+                height = 22,
+                hmargin = 8,
+                valign = "center",
+                text = tostring(negotiator.impressionScore),
+                change = function(element)
+                    local n = tonumber(element.text)
+                    if n ~= nil and n < 100 then
+                        negotiator.impressionScore = math.floor(n)
+                    end
+                    element.text = tostring(negotiator.impressionScore)
+                    dmhub.SetAndUploadTableItem(Negotiator.tableName, negotiator)
+                end,
+            },
+        },
+        gui.Input{
+            classes = {"sizeM"},
+            width = 700,
+            height = "auto",
+            minHeight = 24,
+            vmargin = 4,
+            multiline = true,
+            placeholderText = "Flavor Text",
+            text = negotiator.flavorText,
+            change = function(element)
+                negotiator.flavorText = element.text
+                dmhub.SetAndUploadTableItem(Negotiator.tableName, negotiator)
+            end,
+        },
+        gui.Input{
+            classes = {"sizeM"},
+            width = 700,
+            height = "auto",
+            minHeight = 48,
+            vmargin = 4,
+            multiline = true,
+            placeholderText = "Description",
+            text = negotiator.description,
+            change = function(element)
+                negotiator.description = element.text
+                dmhub.SetAndUploadTableItem(Negotiator.tableName, negotiator)
+            end,
+        },
+        CreateNegotiatorTraitList(negotiator, "motivations", "Motivations", "Add Motivation"),
+        CreateNegotiatorTraitList(negotiator, "pitfalls", "Pitfalls", "Add Pitfall"),
+    }
+end
+
+local function ShowNegotiatorsPanel(contentPanel)
+    local itemsListPanel
+    local leftPanel
+
+    itemsListPanel = gui.Panel{
+        classes = {"list-panel"},
+        vscroll = true,
+        monitorAssets = true,
+        refreshAssets = function(element)
+            local dataTable = dmhub.GetTable(Negotiator.tableName) or {}
+            local entries = {}
+            for key,item in unhidden_pairs(dataTable) do
+                entries[#entries+1] = { key = key, item = item }
+            end
+            table.sort(entries, function(a,b)
+                local sa = a.item.impressionScore or 0
+                local sb = b.item.impressionScore or 0
+                if sa ~= sb then return sa < sb end
+                return (a.item.name or "") < (b.item.name or "")
+            end)
+
+            local children = {}
+            for _,entry in ipairs(entries) do
+                local key = entry.key
+                local listItem = CreateListItem{
+                    select = element.aliveTime > 0.2,
+                    tableName = Negotiator.tableName,
+                    key = key,
+                    obliterateOnDelete = true,
+                    click = function()
+                        contentPanel.children = {leftPanel, CreateNegotiatorEditor(key)}
+                    end,
+                }
+                listItem.text = string.format("(%s) %s", tostring(entry.item.impressionScore or 0), entry.item.name or "")
+                children[#children+1] = listItem
+            end
+            itemsListPanel.children = children
+        end,
+    }
+
+    itemsListPanel:FireEvent("refreshAssets")
+
+    leftPanel = gui.Panel{
+        selfStyle = {
+            flow = "vertical",
+            height = "100%",
+            width = "auto",
+        },
+        itemsListPanel,
+        AddButton{
+            click = function()
+                dmhub.SetAndUploadTableItem(Negotiator.tableName, Negotiator.CreateNew{})
+            end,
+        },
+    }
+
+    contentPanel.children = {leftPanel}
+end
+
 Compendium.CreateListItem = CreateListItem
 
 local g_registeredPanels = false

--- a/DMHub Compendium/Compendium.lua
+++ b/DMHub Compendium/Compendium.lua
@@ -6260,6 +6260,10 @@ Compendium.RegisterSection{
     ord = 0,
 }
 Compendium.RegisterSection{
+    text = "Prepped",
+    ord = 5,
+}
+Compendium.RegisterSection{
     text = "Rules",
     ord = 10,
 }
@@ -6754,6 +6758,24 @@ dmhub.RegisterEventHandler("refreshTables", function(keys)
     end
 
     g_registeredPanels = true;
+
+    Compendium.Register{
+        section = "Prepped",
+        text = "Negotiators",
+        contentType = "negotiators",
+        click = function(contentPanel)
+            ShowNegotiatorsPanel(contentPanel)
+        end,
+    }
+
+    Compendium.Register{
+        section = "Prepped",
+        text = "Montage Tests",
+        contentType = "montageTests",
+        click = function(contentPanel)
+            ShowMontageTestsPanel(contentPanel)
+        end,
+    }
 
     Compendium.Register{
         section = "Character",

--- a/DocumentSystem/MontageDocument.lua
+++ b/DocumentSystem/MontageDocument.lua
@@ -44,10 +44,13 @@ MontageConsequence = RegisterGameType("MontageConsequence")
 
 ---@class MontageOutcome
 ---@field text string
----@field victories number
+---@field victoriesHard number
+---@field victoriesMedium number
 MontageOutcome = RegisterGameType("MontageOutcome")
 MontageOutcome.text = ""
-MontageOutcome.victories = 0
+--Victories awarded for this outcome depend on the montage test difficulty.
+MontageOutcome.victoriesHard = 0
+MontageOutcome.victoriesMedium = 0
 
 ---@class LiveMontageParticipant
 ---@field tokenid string
@@ -543,23 +546,30 @@ function MontageDocument:ChallengesEditor()
                     },
 
                     gui.Panel {
-                        classes = { "form" },
+                        flow = "horizontal",
                         halign = "left",
+                        valign = "center",
+                        width = "auto",
+                        height = "auto",
+                        vmargin = 2,
                         gui.Label {
-                            classes = { "form" },
-                            halign = "left",
                             text = "Attempts:",
+                            width = "auto",
+                            height = "auto",
+                            valign = "center",
+                            rmargin = 8,
                         },
                         gui.Input {
-                            classes = { "form" },
-                            halign = "left",
+                            classes = { "sizeS" },
+                            width = 40,
+                            valign = "center",
                             text = challenge.maximum,
                             characterLimit = 2,
                             change = function(element)
                                 challenge.maximum = math.max(1, tonumber(element.text) or challenge.maximum)
                                 element.text = challenge.maximum
                             end,
-                        }
+                        },
                     },
                 }
                 children[#children + 1] = gui.Panel {
@@ -647,17 +657,45 @@ function MontageDocument:OutcomesEditor()
                     width = "auto",
                     height = "auto",
                     valign = "center",
-                    rmargin = 8,
+                    rmargin = 12,
+                },
+                gui.Label {
+                    text = "Hard:",
+                    width = "auto",
+                    height = "auto",
+                    valign = "center",
+                    rmargin = 6,
                 },
                 gui.Input {
                     classes = { "sizeS" },
                     width = 40,
                     valign = "center",
                     characterLimit = 1,
-                    text = outcome.victories,
+                    text = outcome.victoriesHard,
                     change = function(element)
-                        local n = tonumber(element.text) or outcome.victories
-                        outcome.victories = n
+                        local n = tonumber(element.text) or outcome.victoriesHard
+                        outcome.victoriesHard = n
+                        element.text = tostring(n)
+                    end,
+                },
+                gui.Label {
+                    text = "Medium:",
+                    width = "auto",
+                    height = "auto",
+                    valign = "center",
+                    lmargin = 16,
+                    rmargin = 6,
+                },
+                gui.Input {
+                    classes = { "sizeS" },
+                    width = 40,
+                    valign = "center",
+                    characterLimit = 1,
+                    text = outcome.victoriesMedium,
+                    change = function(element)
+                        local n = tonumber(element.text) or outcome.victoriesMedium
+                        outcome.victoriesMedium = n
+                        element.text = tostring(n)
                     end,
                 },
             }
@@ -1115,8 +1153,8 @@ function MontageTest.CreateNew(args)
         consequences = {},
         rewards = {},
         outcomes = {
-            success = MontageOutcome.new{ victories = 1 },
-            partial = MontageOutcome.new{},
+            success = MontageOutcome.new{ victoriesHard = 2, victoriesMedium = 1 },
+            partial = MontageOutcome.new{ victoriesHard = 1, victoriesMedium = 1 },
             failure = MontageOutcome.new{},
         },
     }

--- a/DocumentSystem/MontageDocument.lua
+++ b/DocumentSystem/MontageDocument.lua
@@ -1168,3 +1168,38 @@ GameHud.RegisterPresentableDialog {
     keeplocal = false,
     create = CreateMontageTestUI,
 }
+
+--Prepped montage test used as reusable compendium content. It reuses all of
+--MontageDocument's editor and display logic but is stored in its own
+--"montageTests" data table so prepped montages live only in the compendium and
+--do not appear in the journal's document picker.
+MontageTest = RegisterGameType("MontageTest", "MontageDocument")
+MontageTest.tableName = "montageTests"
+
+function MontageTest.CreateNew(args)
+    local result = MontageTest.new{
+        description = "New Montage Test",
+        scene = "",
+        difficulty = {
+            difficulty = true,
+            [3] = { success = 3, failure = 3 },
+            [4] = { success = 4, failure = 4 },
+            [5] = { success = 5, failure = 5 },
+            [6] = { success = 6, failure = 6 },
+        },
+        challenges = {},
+        consequences = {},
+        rewards = {},
+        outcomes = {
+            success = MontageOutcome.new{ victories = 1 },
+            partial = MontageOutcome.new{},
+            failure = MontageOutcome.new{},
+        },
+    }
+    if args then
+        for k,v in pairs(args) do
+            result[k] = v
+        end
+    end
+    return result
+end

--- a/DocumentSystem/MontageDocument.lua
+++ b/DocumentSystem/MontageDocument.lua
@@ -4,12 +4,17 @@ local g_numbers = { "One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eigh
 
 ---@class MontageDocument:CustomDocument
 ---@field scene string
+---@field summary string
+---@field twist string
 ---@field difficulty table<number, {success:number, failure:number}>
 ---@field challenges MontageChallenge[]
 ---@field consequences MontageConsequence[]
 ---@field rewards MontageConsequence[]
 MontageDocument = RegisterGameType("MontageDocument", "CustomDocument")
 MontageDocument.scene = ""
+MontageDocument.summary = ""  -- shown as the "Description" box; the montage title
+                              -- lives in self.description (the CustomDocument name)
+MontageDocument.twist = ""    -- shown as the "Optional Twist" box
 MontageDocument.vscroll = false
 
 function MontageDocument:GetDifficultyInfo(numHeroes)
@@ -381,125 +386,51 @@ end
 function MontageDocument:EditPanel()
     local resultPanel
 
+    --All section headers share one style so every box is clearly labeled.
+    local function sectionLabel(text)
+        return gui.Label {
+            classes = { "bold", "sizeM" },
+            width = "auto",
+            height = "auto",
+            halign = "left",
+            valign = "top",
+            markdown = true,
+            text = text,
+        }
+    end
+
+    --All multiline prose boxes (description, scene, twist) share one style.
+    local function proseInput(getText, setText, placeholder)
+        return gui.Input {
+            classes = { "sizeS" },
+            width = "90%",
+            height = "auto",
+            text = getText(),
+            maxHeight = 200,
+            multiline = true,
+            halign = "left",
+            textAlignment = "topleft",
+            placeholderText = placeholder,
+            valign = "top",
+            vmargin = 4,
+            characterLimit = 4096,
+            change = function(element)
+                setText(element.text)
+            end,
+        }
+    end
+
     local nameInput = gui.Input {
         classes = { "sizeL" },
-        halign = "center",
+        halign = "left",
         valign = "top",
         width = 300,
         height = 20,
         text = self.description,
         vmargin = 4,
+        placeholderText = "Montage test title",
         change = function(element)
             self.description = element.text
-        end,
-    }
-
-    local testDifficulty = gui.Panel {
-        vmargin = 4,
-        flow = "vertical",
-        width = "auto",
-        height = "auto",
-        halign = "left",
-        gui.Panel {
-            flow = "horizontal",
-            height = 24,
-            width = 600,
-            gui.Label {
-                classes = { "bold" },
-                width = 200,
-                text = "Heroes",
-                textAlignment = "left",
-            },
-            gui.Label {
-                classes = { "bold" },
-                width = 200,
-                text = "Success Limit",
-                textAlignment = "left",
-            },
-            gui.Label {
-                classes = { "bold" },
-                width = 200,
-                text = "Failure Limit",
-                textAlignment = "left",
-            },
-        },
-
-        create = function(element)
-            local children = element.children
-            for i = 3, 6 do
-                local difficulty = self.difficulty[i]
-                children[#children + 1] = gui.Panel {
-                    flow = "horizontal",
-                    height = 24,
-                    width = 600,
-                    gui.Label {
-                        width = 200,
-                        height = 24,
-                        text = g_numbers[i],
-                        textAlignment = "left",
-                    },
-
-                    gui.Panel {
-                        width = 200,
-                        height = 24,
-                        gui.Input {
-                            classes = { "sizeS" },
-                            width = 20,
-                            height = 16,
-                            valign = "center",
-                            halign = "left",
-                            vpad = 1,
-                            text = difficulty.success,
-                            characterLimit = 1,
-                            change = function(element)
-                                local n = tonumber(element.text) or difficulty.success
-                                difficulty.success = n
-                                element.text = tostring(n)
-                            end,
-                        },
-                    },
-
-                    gui.Panel {
-                        width = 200,
-                        height = 24,
-                        gui.Input {
-                            classes = { "sizeS" },
-                            width = 20,
-                            height = 16,
-                            valign = "center",
-                            halign = "left",
-                            vpad = 1,
-                            text = difficulty.failure,
-                            characterLimit = 1,
-                            change = function(element)
-                                local n = tonumber(element.text) or difficulty.failure
-                                difficulty.failure = n
-                                element.text = tostring(n)
-                            end,
-                        },
-                    },
-                }
-            end
-
-            element.children = children
-        end,
-    }
-
-    local sceneInput = gui.Input {
-        classes = { "sizeS" },
-        width = "90%",
-        height = "auto",
-        text = self.scene,
-        maxHeight = 200,
-        multiline = true,
-        halign = "left",
-        textAlignment = "topleft",
-        placeholderText = "Enter scene description",
-        valign = "top",
-        vmargin = 4,
-        characterLimit = 4096,
-        change = function(element)
-            self.scene = element.text
         end,
     }
 
@@ -515,43 +446,31 @@ function MontageDocument:EditPanel()
             self:Upload()
         end,
 
+        sectionLabel("## Title"),
         nameInput,
-        testDifficulty,
 
-        gui.Label {
-            classes = { "bold", "sizeM" },
-            width = "auto",
-            height = "auto",
-            halign = "left",
-            valign = "top",
-            markdown = true,
-            text = "## Setting the Scene",
-        },
+        sectionLabel("## Description"),
+        proseInput(
+            function() return self.summary end,
+            function(text) self.summary = text end,
+            "Enter description"),
 
-        sceneInput,
+        sectionLabel("## Setting the Scene"),
+        proseInput(
+            function() return self.scene end,
+            function(text) self.scene = text end,
+            "Enter scene description"),
 
-        gui.Label {
-            classes = { "sizeM" },
-            width = "auto",
-            height = "auto",
-            halign = "left",
-            valign = "top",
-            markdown = true,
-            text = "## Montage Challenges\nThe following challenges can be part of the montage test:",
-        },
-
+        sectionLabel("## Montage Challenges\nThe following challenges can be part of the montage test:"),
         self:ChallengesEditor(),
 
-        gui.Label {
-            classes = { "sizeM" },
-            width = "auto",
-            height = "auto",
-            halign = "left",
-            valign = "top",
-            markdown = true,
-            text = "## Montage Test Outcomes\nThe montage test has the following outcomes:",
-        },
+        sectionLabel("## Optional Twist"),
+        proseInput(
+            function() return self.twist end,
+            function(text) self.twist = text end,
+            "Enter optional twist"),
 
+        sectionLabel("## Montage Test Outcomes\nThe montage test has the following outcomes:"),
         self:OutcomesEditor(),
     }
 

--- a/DocumentSystem/MontageDocument.lua
+++ b/DocumentSystem/MontageDocument.lua
@@ -636,16 +636,23 @@ function MontageDocument:OutcomesEditor()
         local victoriesPanel
         if entry.key ~= "failure" then
             victoriesPanel = gui.Panel {
-                classes = { "form" },
+                flow = "horizontal",
                 halign = "left",
-                width = 20,
+                valign = "center",
+                width = "auto",
+                height = "auto",
+                vmargin = 2,
                 gui.Label {
                     text = "Victories:",
-                    width = 120,
+                    width = "auto",
+                    height = "auto",
+                    valign = "center",
+                    rmargin = 8,
                 },
                 gui.Input {
                     classes = { "sizeS" },
                     width = 40,
+                    valign = "center",
                     characterLimit = 1,
                     text = outcome.victories,
                     change = function(element)
@@ -661,33 +668,31 @@ function MontageDocument:OutcomesEditor()
             width = 800,
             halign = "left",
             valign = "top",
-            gui.Panel {
-                classes = { "form" },
+            vmargin = 6,
+            gui.Label {
+                classes = { "bold", "sizeM" },
+                markdown = true,
+                text = "### " .. entry.text,
+                width = "auto",
+                height = "auto",
                 halign = "left",
+                valign = "top",
+            },
+            gui.Input {
+                classes = { "sizeS" },
+                multiline = true,
+                textAlignment = "topleft",
                 width = 700,
                 height = "auto",
-                gui.Label {
-                    text = entry.text .. ":",
-                    height = "auto",
-                    width = 120,
-                    halign = "left",
-                },
-                gui.Input {
-                    classes = { "sizeS" },
-                    multiline = true,
-                    textAlignment = "topleft",
-                    width = 540,
-                    height = "auto",
-                    maxHeight = 200,
-                    minHeight = 30,
-                    halign = "left",
-                    characterLimit = 512,
-                    placeholderText = "Describe outcome...",
-                    text = outcome.text,
-                    change = function(element)
-                        outcome.text = element.text
-                    end,
-                },
+                maxHeight = 200,
+                minHeight = 30,
+                halign = "left",
+                characterLimit = 512,
+                placeholderText = "Describe outcome...",
+                text = outcome.text,
+                change = function(element)
+                    outcome.text = element.text
+                end,
             },
             victoriesPanel,
         }

--- a/DocumentSystem/MontageDocument.lua
+++ b/DocumentSystem/MontageDocument.lua
@@ -390,13 +390,15 @@ function MontageDocument:EditPanel()
     local resultPanel
 
     --All section headers share one style so every box is clearly labeled.
-    local function sectionLabel(text)
+    --topMargin adds extra space above a header to delineate major sections.
+    local function sectionLabel(text, topMargin)
         return gui.Label {
             classes = { "bold", "sizeM" },
             width = "auto",
             height = "auto",
             halign = "left",
             valign = "top",
+            tmargin = topMargin or 0,
             markdown = true,
             text = text,
         }
@@ -464,16 +466,16 @@ function MontageDocument:EditPanel()
             function(text) self.scene = text end,
             "Enter scene description"),
 
-        sectionLabel("## Montage Challenges\nThe following challenges can be part of the montage test:"),
+        sectionLabel("## Montage Challenges\nThe following challenges can be part of the montage test:", 24),
         self:ChallengesEditor(),
 
-        sectionLabel("## Optional Twist"),
+        sectionLabel("## Optional Twist", 24),
         proseInput(
             function() return self.twist end,
             function(text) self.twist = text end,
             "Enter optional twist"),
 
-        sectionLabel("## Montage Test Outcomes\nThe montage test has the following outcomes:"),
+        sectionLabel("## Montage Test Outcomes\nThe montage test has the following outcomes:", 24),
         self:OutcomesEditor(),
     }
 

--- a/Draw Steel V/NegotiationRules.lua
+++ b/Draw Steel V/NegotiationRules.lua
@@ -418,3 +418,48 @@ MCDMMotivation.motivations = {
 
 
 }
+
+--Prepped negotiator archetype used as reusable compendium content. This is
+--distinct from MCDMNegotiation, which is the live negotiation created on a
+--token during play. A Negotiator is the GM-authored archetype from the manual's
+--"Sample Negotiators": a name, an impression score, flavor text, a description,
+--and free-form named motivations and pitfalls.
+NegotiatorTrait = RegisterGameType("NegotiatorTrait")
+NegotiatorTrait.name = ""
+NegotiatorTrait.description = ""
+
+function NegotiatorTrait.Create(args)
+    args = args or {}
+    return NegotiatorTrait.new{
+        name = args.name or "",
+        description = args.description or "",
+    }
+end
+
+Negotiator = RegisterGameType("Negotiator")
+Negotiator.tableName = "negotiators"
+Negotiator.name = "New Negotiator"
+Negotiator.impressionScore = 1
+Negotiator.flavorText = ""
+Negotiator.description = ""
+--ordered lists of NegotiatorTrait. Always set to fresh tables by CreateNew so
+--instances never share the prototype default.
+Negotiator.motivations = {}
+Negotiator.pitfalls = {}
+
+function Negotiator.CreateNew(args)
+    local result = Negotiator.new{
+        name = "New Negotiator",
+        impressionScore = 1,
+        flavorText = "",
+        description = "",
+        motivations = {},
+        pitfalls = {},
+    }
+    if args then
+        for k,v in pairs(args) do
+            result[k] = v
+        end
+    end
+    return result
+end


### PR DESCRIPTION
Adds a new top-level **Prepped** section to the compendium (a sibling of Character and Rules) with two GM-authored, reusable content libraries.

## Negotiators
A new `Negotiator` data type (table `negotiators`) for negotiation NPC archetypes, modeled on the manual's "Sample Negotiators":
- Name, Impression Score (any number < 100), Flavor Text, Description
- Addable, named Motivations and Pitfalls (shared `NegotiatorTrait` row type)
- List sorts by Impression Score, then name
- Add-trait handler guards against mutating the shared prototype table

## Montage Tests
A new `MontageTest` type (table `montageTests`) that reuses the existing `MontageDocument` editor/display logic but stores in its own table, so prepped montages stay in the compendium and out of the journal. Editor reworked to mirror a published montage test:
- Labeled sections: Title, Description, Setting the Scene, Montage Challenges, Optional Twist, Montage Test Outcomes
- Difficulty grid removed from the editor (the underlying `difficulty` data is retained for live play)
- Each challenge shows a labeled **Attempts** field
- Outcomes fixed to Total Success / Partial Success / Total Failure
- Total Success and Partial Success take per-difficulty (**Hard** / **Medium**) Victories values; Total Failure is always 0
- Extra spacing delineates the major sections

## Scope
Authoring/storage only. Using a prepped entry live (applying a Negotiator to a token, launching a Montage Test as a `LiveMontage`, and awarding the per-difficulty Victories during play) is intentionally deferred.

## Verification
No CLI test runner exists for this mod; every change was verified live in a running DMHub instance via the MCP bridge (clean mod reloads, data round-trip probes, and screenshots of the rendered editors).