### PR TITLE
Fix PDF bookmark flag not updating immediately on add/remove

### DIFF
--- a/DMHub Core Panels/JournalPDFViewer.lua
+++ b/DMHub Core Panels/JournalPDFViewer.lua
@@ -414,6 +414,11 @@ local ShowPDFViewerDialogInternal = function(doc, starting_page)
 
     local RefreshPage
 
+    --forward-declared like RefreshPage so the bookmark add/edit/remove handlers
+    --(defined before dialogPanel exists) can capture it as an upvalue. Assigned
+    --once dialogPanel is created; nudges the contents grid to re-read bookmarks.
+    local RefreshBookmarks
+
     CreateDragPanel = function()
         return gui.Panel {
             classes = { "dragPanel", "hidden" },
@@ -794,6 +799,7 @@ local ShowPDFViewerDialogInternal = function(doc, starting_page)
                         }
                         doc.bookmarks = bookmarks
                         doc:Upload()
+                        RefreshBookmarks()
                         gui.CloseModal()
                     end,
                 }
@@ -1114,6 +1120,14 @@ local ShowPDFViewerDialogInternal = function(doc, starting_page)
                         element.data.invalidated = true
                     end,
 
+                    --fired locally when a bookmark is added/edited/removed so the
+                    --gated think loop re-reads doc.bookmarks and re-fires the flag
+                    --state immediately, instead of waiting for the doc:Upload()
+                    --round-trip to come back through the Documents asset monitor.
+                    refreshbookmarks = function(element)
+                        element.data.invalidated = true
+                    end,
+
                     thinkTime = 0.01,
                     think = function(element)
                         local parent = element.parent
@@ -1216,6 +1230,7 @@ local ShowPDFViewerDialogInternal = function(doc, starting_page)
                                                 bookmarks[bookmarkid] = nil
                                                 doc.bookmarks = bookmarks
                                                 doc:Upload()
+                                                RefreshBookmarks()
                                                 element.popup = nil
                                             end,
                                         }
@@ -2616,6 +2631,10 @@ local ShowPDFViewerDialogInternal = function(doc, starting_page)
             m_settings.vscroll = pdfScrollViewPanel.vscrollPosition
             WriteSettings()
         end
+    end
+
+    RefreshBookmarks = function()
+        dialogPanel:FireEventTree("refreshbookmarks")
     end
 
     RefreshPage()


### PR DESCRIPTION
## What
Adding, editing, or removing a bookmark in the PDF viewer didn't update the red bookmark flag in the contents sidebar right away — the flag only appeared/disappeared after the `doc:Upload()` round-tripped back through the Documents asset monitor, or on the next scroll/page change.

## Why
The flag is rendered by the contents grid's `think` loop, which is gated by an early-return and only re-reads `doc.bookmarks` when the panel is invalidated (or scroll/size/current page changes). The add/edit and remove handlers mutated `doc.bookmarks` and uploaded, but never invalidated the panel — so nothing woke the loop until the asset monitor eventually fired.

## Fix
- Add a forward-declared `RefreshBookmarks()` helper that fires a `refreshbookmarks` event down the dialog tree.
- The contents grid handles `refreshbookmarks` by setting `invalidated = true`, so the loop re-reads bookmarks and re-renders the flag on the next tick.
- Call it from the add/edit and remove handlers, right after `doc:Upload()`.

## Testing
Verified in-app: adding and deleting a bookmark now flips the flag immediately.
