### PR TITLE
Audio studio UI and folder fixes

### DIFF
--- a/DMHub Core Panels/Audio.lua
+++ b/DMHub Core Panels/Audio.lua
@@ -9926,6 +9926,7 @@ local CreateStudioPlaylistsCard = function(heightSpec)
 		--between a short name and the count label bubble up to the header's
 		--expand-toggle instead of being swallowed by the rename zone (James field
 		--report, 2026-07-03).
+		local nameEditWide = false
 		local nameLabel
 		nameLabel = gui.Label{
 			editableOnDoubleClick = true,
@@ -9955,6 +9956,27 @@ local CreateStudioPlaylistsCard = function(heightSpec)
 				ModifyPlaylist(playlistid, "Rename playlist", function(pl2)
 					pl2.name = newName
 				end)
+			end,
+			--Rename display fix: while editing, fill the row width and stop
+			--ellipsizing so the whole typed name stays visible; on edit-end restore
+			--hug-content + ellipsis (display mode keeps the dead space right of a
+			--short name as the header's expand-toggle zone). The editable-label text
+			--edit fires no begin/end event (change only fires on commit), so poll
+			--element.editing in think and mutate only on the transition to avoid
+			--per-frame relayout.
+			thinkTime = 0.1,
+			think = function(element)
+				local wide = element.editing == true
+				if wide ~= nameEditWide then
+					nameEditWide = wide
+					if wide then
+						element.selfStyle.width = "100%"
+						element.selfStyle.textOverflow = "overflow"
+					else
+						element.selfStyle.width = "auto"
+						element.selfStyle.textOverflow = "ellipsis"
+					end
+				end
 			end,
 		}
 		local nameLabelWrapper = gui.Panel{
@@ -10572,6 +10594,7 @@ local CreateStudioVariantPoolsCard = function(heightSpec)
 		--bubbles to the header's expand-toggle, whose REBUILD destroys this label
 		--between the two clicks of a double-click, so rename could never fire (James
 		--field bug b2f08de8).
+		local nameEditWide = false
 		local nameLabel
 		nameLabel = gui.Label{
 			editableOnDoubleClick = true,
@@ -10607,6 +10630,27 @@ local CreateStudioVariantPoolsCard = function(heightSpec)
 						if mod.unloaded or not label.valid then return end
 						label:BeginEditing()
 					end)
+				end
+			end,
+			--Rename display fix: while editing, fill the row width and stop
+			--ellipsizing so the whole typed name stays visible; on edit-end restore
+			--hug-content + ellipsis (display mode keeps the dead space right of a
+			--short name as the header's expand-toggle zone). The editable-label text
+			--edit fires no begin/end event (change only fires on commit), so poll
+			--element.editing in think and mutate only on the transition to avoid
+			--per-frame relayout.
+			thinkTime = 0.1,
+			think = function(element)
+				local wide = element.editing == true
+				if wide ~= nameEditWide then
+					nameEditWide = wide
+					if wide then
+						element.selfStyle.width = "100%"
+						element.selfStyle.textOverflow = "overflow"
+					else
+						element.selfStyle.width = "auto"
+						element.selfStyle.textOverflow = "ellipsis"
+					end
 				end
 			end,
 		}

--- a/DMHub Core Panels/Audio.lua
+++ b/DMHub Core Panels/Audio.lua
@@ -7001,7 +7001,7 @@ local g_pendingRevealFolder = nil
 local function FindTopLevelFolderByName(name)
 	local lower = string.lower(name)
 	for fid,f in pairs(assets.audioFoldersTable) do
-		if not f.hidden and f.parentFolder == nil and string.lower(f.description or "") == lower then
+		if not f.hidden and (f.parentFolder == nil or f.parentFolder == "") and string.lower(f.description or "") == lower then
 			return fid
 		end
 	end
@@ -8947,6 +8947,22 @@ local CreateAudioLibraryTree = function()
 	--exist; the data is mutated locally first, so an immediate rebuild reflects it.
 	local RequestRebuild = function() end
 
+	--Drag-only "move to top level" drop bar. Hidden at rest; revealed the moment a
+	--folder or clip drag begins (beginDrag on every draggable node/row calls
+	--RevealRootDropBar), and re-hidden by its own think once the drag ends. Built
+	--further down and assigned to m_rootDropBar; m_dragSource is the element being
+	--dragged so the think can poll its .dragging flag to know when to hide.
+	local m_rootDropBar
+	local m_dragSource
+	local function RevealRootDropBar(source)
+		m_dragSource = source
+		if m_rootDropBar ~= nil and m_rootDropBar.valid then
+			m_rootDropBar.interactable = true
+			m_rootDropBar:SetClass("hidden", false)
+			m_rootDropBar.thinkTime = 0.1
+		end
+	end
+
 	--C6 library search. m_searchText is the active lowercase filter ("" = none).
 	--m_preSearchExpanded snapshots the user's expansion state (m_expanded) the moment
 	--a search session STARTS (first non-empty search text), so clearing the search
@@ -9004,7 +9020,14 @@ local CreateAudioLibraryTree = function()
 		local poolBuild = m_studioBuildMode ~= nil and m_studioBuildMode.poolid ~= nil
 		for id,folder in pairs(assets.audioFoldersTable) do
 			if not folder.hidden then
-				local pk = folder.parentFolder or "__root__"
+				--A nil OR empty-string parentFolder means top level. Moving a folder to top
+				--level stores "" (assigning nil to the AudioFolderLua field serializes to an
+				--empty string, not nil), and "" is truthy in Lua, so a plain `or "__root__"`
+				--would group a moved-to-top folder under a "" key that nothing renders -- the
+				--folder would vanish from the tree. Same normalization applied to clips below
+				--and in FindTopLevelFolderByName.
+				local pk = folder.parentFolder
+				if pk == nil or pk == "" then pk = "__root__" end
 				local t = foldersByParent[pk]
 				if t == nil then t = {} foldersByParent[pk] = t end
 				t[#t+1] = { id = id, folder = folder }
@@ -9012,7 +9035,8 @@ local CreateAudioLibraryTree = function()
 		end
 		for _,asset in pairs(assets.audioTable) do
 			if not asset.hidden and (not poolBuild or asset.category == "effects" or asset.category == "ambience") then
-				local fk = asset.parentFolder or defaultFolder
+				local fk = asset.parentFolder
+				if fk == nil or fk == "" then fk = defaultFolder end
 				local t = clipsByFolder[fk]
 				if t == nil then t = {} clipsByFolder[fk] = t end
 				t[#t+1] = asset
@@ -9222,13 +9246,17 @@ local CreateAudioLibraryTree = function()
 		return ids
 	end
 
-	--Resolve the folder a drop landed on: the nearest enclosing folder node, or
-	--"__root__" when dropped on the library root (top level). nil = invalid drop.
+	--Resolve the folder a drop landed on: the dedicated "move to top level" drop
+	--bar or the library root => "__root__"; otherwise the nearest enclosing folder
+	--node. nil = invalid drop. The audioLibraryRoot / audioRootDropZone checks test
+	--self too: FindParentWithClass walks ancestors only, so a drop on the root panel
+	--or the drop bar itself would otherwise never resolve to top level.
 	local function ResolveDrop(target)
 		if target == nil then return nil end
+		if target:HasClass("audioRootDropZone") or target:FindParentWithClass("audioRootDropZone") ~= nil then return "__root__" end
 		local node = target:FindParentWithClass("audioFolderNode")
 		if node ~= nil then return node.data.folderid end
-		if target:FindParentWithClass("audioLibraryRoot") ~= nil then return "__root__" end
+		if target:HasClass("audioLibraryRoot") or target:FindParentWithClass("audioLibraryRoot") ~= nil then return "__root__" end
 		return nil
 	end
 
@@ -9441,6 +9469,9 @@ local CreateAudioLibraryTree = function()
 				if dest == nil then return end
 				MoveFolderToFolder(folderid, dest)
 				RequestRebuild()
+			end,
+			beginDrag = function(element)
+				RevealRootDropBar(element)
 			end,
 
 			create = function(element)
@@ -9708,12 +9739,61 @@ local CreateAudioLibraryTree = function()
 		end,
 	}
 
+	--Drag-only drop target for moving a folder/clip out to the top level. Floating
+	--so it overlays the top of the tree without shifting layout; starts hidden +
+	--non-interactable and is revealed by RevealRootDropBar on any drag start. The
+	--dragged element's own drag/canDragOnto handlers do the actual move -- this bar
+	--only needs to exist as a dragTarget that ResolveDrop maps to "__root__" (via its
+	--audioRootDropZone class). Higher dragTargetPriority so a drop on it wins over the
+	--folder/tree underneath. Its think hides it again once the drag ends.
+	m_rootDropBar = gui.Panel{
+		classes = {"audioRootDropZone", "hidden"},
+		floating = true,
+		interactable = false,
+		dragTarget = true,
+		dragTargetPriority = 10,
+		width = "100%-8",
+		height = 28,
+		halign = "center",
+		valign = "top",
+		y = 30,
+		flow = "horizontal",
+		borderBox = true,
+		bgimage = "panels/square.png",
+		bgcolor = "@accent",
+		opacity = 0.85,
+		cornerRadius = 6,
+		borderWidth = 2,
+		borderColor = "@accent",
+		thinkTime = nil,
+		think = function(element)
+			if m_dragSource == nil or not m_dragSource.valid or not m_dragSource.dragging then
+				m_dragSource = nil
+				element.interactable = false
+				element:SetClass("hidden", true)
+				element.thinkTime = nil
+			end
+		end,
+		gui.Label{
+			text = "Move to top level",
+			width = "auto",
+			height = "auto",
+			halign = "center",
+			valign = "center",
+			fontSize = 14,
+			bold = true,
+			color = "white",
+			interactable = false,
+		},
+	}
+
 	return gui.Panel{
 		flow = "vertical",
 		width = "100%",
 		height = "100%-24",
 		searchInput,
 		m_root,
+		m_rootDropBar,
 	}
 end
 


### PR DESCRIPTION
## Summary
In the audio Studio, renaming a playlist or variant pool truncated the field to an ellipsis after a few characters (e.g. typing "james" showed "Ja...") even though the row had plenty of empty width. The typed text was never lost -- it saved correctly -- but you couldn't see what you were typing. This widens the rename field to fill the row while editing and stops it ellipsizing, restoring the normal hug-content display when editing ends.

## Changes
- Playlist rename field (`CreateStudioPlaylistsCard`) and variant-pool rename field (`CreateStudioVariantPoolsCard`): while editing, set the label width to fill the row and switch `textOverflow` from `ellipsis` to `overflow`; on edit-end, restore `width = auto` + `ellipsis`.
- Trigger: editable-label text editing fires no begin/end event (only `change`, on commit), so `element.editing` is polled in a lightweight `think` (thinkTime 0.1) that mutates style only on the edit-begin/edit-end transition -- no per-frame relayout.

## Testing
- Reproduced live over the MCP bridge: measured the rename field staying clamped near `minWidth` during editing (wide glyphs like `m`/`h` overflow at ~3 chars), while the stored name path was confirmed to save the full string.
- Instrumented test confirmed no `edit` event fires for editable-label text editing (direct-key and `events={}` forms both silent); `think` fires reliably during editing and can read `element.editing`.
- After the fix: verified in-app -- the field expands to fill the row and shows the full name with no ellipsis while typing, and snaps back to the normal hug-content display (with ellipsis for long names) on commit/cancel. Applies to both playlist and variant-pool rows.

## Notes for reviewer
- Display-mode behaviour is unchanged: the label still hugs its content so the dead space to the right of a short name remains part of the header's expand-toggle click-zone (a prior James field fix). The width/ellipsis swap only happens during active editing.
- Cost is a trivial `think` per visible rename row (one property read + compare per tick, style mutation only on edit transitions), alive only while the card is expanded.