### PR TITLE
Fix character builder implementation badge showing on non-feature options

### DIFF
--- a/Draw Steel Character Builder/FeatureCache.lua
+++ b/Draw Steel Character Builder/FeatureCache.lua
@@ -882,13 +882,24 @@ function CBOptionWrapper:GetGuid()
 end
 
 --- The implementation status of this option, matching gui.ImplementationStatus
---- (0 = Narrative, 1 = Unimplemented, 2 = Bronze, 3 = Silver, 4 = Gold). Mirrors
---- the class/compendium editor, which treats an unset status as Unimplemented
---- (see DSClassEditor's feature:try_get("implementation", 1)), so options an
---- author never marked surface as Unimplemented rather than silently blank.
---- @return number
+--- (0 = Narrative, 1 = Unimplemented, 2 = Bronze, 3 = Silver, 4 = Gold), or nil
+--- when the option does not track an implementation status at all.
+---
+--- Implementation status is a property of CharacterFeature (class feature and
+--- animal-trait picks etc.), so the badge is limited to options derived from it;
+--- for those an unset status defaults to Unimplemented to mirror the class/
+--- compendium editor (feature:try_get("implementation", 1)). Every other kind of
+--- choice entry returns nil so the builder hides the badge instead of mislabeling
+--- it "Unimplemented" -- this covers both plain option tables (subclasses, skills,
+--- languages, tools) and non-feature game objects such as Deity and DeityDomain
+--- picks, which have try_get but no implementation concept.
+--- @return number|nil
 function CBOptionWrapper:GetImplementation()
-    return _safeGet(self.option, "implementation", 1)
+    local option = self.option
+    if option == nil or option.IsDerivedFrom == nil or option.IsDerivedFrom("CharacterFeature") ~= true then
+        return nil
+    end
+    return option:try_get("implementation", 1)
 end
 
 --- @return string


### PR DESCRIPTION
## Summary
The implementation-status badge added in #149 shows "Unimplemented" on options that have no implementation concept -- skills, subclasses, languages, tools, and Deity/DeityDomain picks all get a red "Unimplemented" marker in the character builder. Skills in particular are on/off; there is no implementation tier to display.

## Why this wasn't already fixed
The follow-up fixes for this were pushed to #149 *after* it had already been merged at its first commit, so they never reached `main`. `main` currently contains only the original `GetImplementation`, which defaults every option to Unimplemented:

```lua
function CBOptionWrapper:GetImplementation()
    return _safeGet(self.option, "implementation", 1)
end
```

## Fix
`implementation` is a property of `CharacterFeature`, so gate the badge on the option being derived from it. Options that are plain choice tables (skills, subclasses, ...) or non-feature game objects (Deity, DeityDomain) return `nil`, and the badge's existing `updateImplementation` handler hides itself on `nil`. Real feature picks keep the Unimplemented-when-unset default that mirrors the class/compendium editor.

Only `GetImplementation` changes; the badge UI (`FeatureSelector`) is already in `main` from #149.

## Verification (live, against a running instance)
| Option | Result |
|---|---|
| Feature with status set | its tier (e.g. Bronze) |
| Feature with no status | Unimplemented (intended default) |
| Skill | hidden |
| Subclass | hidden |
| Deity | hidden |
| Deity Domain | hidden |