### PR TITLE
fix(audio): gate starter-playlist seeding on game fully loaded

### DIFF
--- a/DMHub Core Panels/Audio.lua
+++ b/DMHub Core Panels/Audio.lua
@@ -1871,7 +1871,17 @@ PollAudioPlaylists = function()
 		return
 	end
 
-	if dmhub.isDM and not m_didEnsureStarters then
+	--Seed starter playlists only once the game is FULLY loaded. A document snapshot
+	--read before the game's mod documents have synced returns an empty ("isnew") doc
+	--even when the cloud actually holds configured playlists -- and EnsureStarterPlaylists
+	--seeding into that empty read then PUT-overwrites the real cloud doc, silently wiping
+	--a DM's configured playlists. (The soundboard has no equivalent seed-on-empty path,
+	--which is why a live incident reset the playlists while 25 configured soundboard slots
+	--in the same game survived.) Gating on gameLoadingProgress >= 1 -- the same "load
+	--complete" test the title screen uses -- guarantees the snapshot reflects real synced
+	--state before we ever seed. m_didEnsureStarters stays false while still loading so a
+	--later poll tick retries the seed once loading completes.
+	if dmhub.isDM and not m_didEnsureStarters and (dmhub.gameLoadingProgress or 0) >= 1 then
 		EnsureStarterPlaylists()
 		m_didEnsureStarters = true
 	end


### PR DESCRIPTION
## Summary
Fixes silent data loss where a DM's configured audio playlists could be wiped and reset to the empty starter playlists. `EnsureStarterPlaylists` seeds empty starters whenever the `audioPlaylists` shared document reads with no `playlists` key. A document snapshot read before the game's mod documents have finished syncing returns an empty ("isnew") doc even when the cloud actually holds configured playlists; seeding into that empty read then issues a full PUT that overwrites the real cloud document. Gating the one-time seed behind "game fully loaded" ensures the snapshot reflects real synced state before we ever seed.

## Changes
- Gate the one-time `EnsureStarterPlaylists()` call in `PollAudioPlaylists` behind `(dmhub.gameLoadingProgress or 0) >= 1` (the same "load complete" idiom the title screen uses).
- `m_didEnsureStarters` is left `false` while still loading, so a later poll tick retries the seed once loading completes.
- Comment documenting the root cause so the guard is not "simplified" away later.

## Testing
- Diagnosed live over the MCP bridge: the affected game's `audioPlaylists` doc held only the 3 empty starters while 25 configured soundboard slots in the same game survived. The soundboard has no seed-on-empty path, which is exactly why it was untouched by the same transient-empty read - pinpointing the seed + PUT as the wipe mechanism.
- Post-fix live verification: clean Lua reload (43 mods, no new console errors); the guard passes in the loaded state so normal new-game seeding still runs; the existing playlist doc was untouched by the reload.
- Confirmed in-app by the reporter that the fix resolves the issue.

## Notes for reviewer
- Pure tightening of an existing `if` condition: it can only ever prevent a premature seed-write, never add one. `EnsureStarterPlaylists` also keeps its own `playlists ~= nil` idempotency guard (defense in depth).
- The load-race itself is not reproducible on demand (it needs a real game load with a slow document sync), so verification is by code reasoning plus the live diagnosis above.
- This prevents future loss; it does not restore already-wiped playlists.