### PR TITLE
fix(character-panel): stop destroying the With-Captain features chip

### DIFF
--- a/Draw Steel Core Rules/MCDMCharacterPanel.lua
+++ b/Draw Steel Core Rules/MCDMCharacterPanel.lua
@@ -6034,26 +6034,30 @@ function TacPanel.Features()
         local children = {}
 
         --Minion "With Captain": a standalone chip (not a characterFeatures entry,
-        --so the categoriser never sees it). Built once, then reused.
+        --so the categoriser never sees it). Built once, then reused. Always kept
+        --in `children` (never conditionally omitted) -- the engine destroys any
+        --panel orphaned by a `children` reassignment, so omitting it here would
+        --permanently destroy it the first time a non-captained token is shown,
+        --crashing the next reconcile that tried to reuse it. applyFilter (above)
+        --hides it via the "collapsed" class based on data.active instead.
+        if m_withCaptainChip == nil then
+            m_withCaptainChip = TacPanel.FeatureChip(token, "With Captain", nil, lockFilterOnOpen)
+            m_withCaptainWrap = gui.Panel{
+                classes = {"panel", "cond-chips"},
+                wrap = true,
+                lmargin = 6,
+                m_withCaptainChip,
+            }
+        end
         if creature.withCaptain and creature.minion then
             local captainText = creature.withCaptain
-            if m_withCaptainChip == nil then
-                m_withCaptainChip = TacPanel.FeatureChip(token, "With Captain",
-                    function() return captainText end, lockFilterOnOpen)
-                m_withCaptainWrap = gui.Panel{
-                    classes = {"panel", "cond-chips"},
-                    wrap = true,
-                    lmargin = 6,
-                    m_withCaptainChip,
-                }
-            end
             m_withCaptainChip:FireEvent("update", token, "With Captain",
                 function() return captainText end, "With Captain " .. (captainText or ""))
             m_withCaptainChip.data.active = true
-            children[#children+1] = m_withCaptainWrap
-        elseif m_withCaptainChip ~= nil then
+        else
             m_withCaptainChip.data.active = false
         end
+        children[#children+1] = m_withCaptainWrap
 
         --Group panels, reused by bucket id, in the index's bucket order.
         m_currentOrder = {}


### PR DESCRIPTION
## Summary
- Fixes a crash (`attempt to index a nil value (field 'data')` at `MCDMCharacterPanel.lua:6055`) when opening the tac-panel Features section for a token after a captained minion had been shown previously.
- The "With Captain" chip panel was reused across token switches but only added to the groups container's `children` when the selected token was a captained minion. Any panel omitted from a `children` reassignment is orphaned and permanently destroyed by the engine, so the next reconcile for a non-captained token tried to update the already-destroyed chip and crashed.
- Fix keeps the chip/wrap always present in `children` and toggles its visibility via the `collapsed` class instead (mirroring the existing `applyFilter` hide logic), so it's never orphaned/destroyed.

## Test plan
- [x] Reproduced the crash sequence live via `execute_lua` driving `TacPanel.Features()` directly: captain-minion refresh -> plain token refresh -> plain token refresh again. Confirmed this sequence errored at line 6055 before the fix.
- [x] Re-ran the same sequence after the fix and confirmed all three refreshes succeed with no error.