### PR TITLE
Fix dual Melee+Ranged abilities splitting into two action bar buttons

### DIFF
--- a/DrawSteelActionBar/DrawSteelActionBar.lua
+++ b/DrawSteelActionBar/DrawSteelActionBar.lua
@@ -1451,20 +1451,12 @@ local function CreateActionBar()
             end
 
             g_resources = g_token.properties:GetResources()
+            --Dual Melee+Ranged abilities (e.g. Doorkicker's Dynamic Entry) stay as a
+            --single meleeAndRanged entry here instead of being split into two buttons.
+            --Selecting it sets g_currentAbility to the still-dual-keyword ability,
+            --which CalculateSpellTargeting/CreateSynthesizedSpellsPanel already detect
+            --to show the melee/ranged chip picker (same path used for invoked abilities).
             g_abilities = g_token.properties:GetActivatedAbilities { bindCaster = true, manualTriggers = true }
-
-            --break out melee and ranged.
-            local abilities = {}
-            for _, ability in ipairs(g_abilities) do
-                if ability.meleeAndRanged then
-                    abilities[#abilities + 1] = ability.meleeVariation
-                    abilities[#abilities + 1] = ability.rangedVariation
-                else
-                    abilities[#abilities + 1] = ability
-                end
-            end
-
-            g_abilities = abilities
 
             g_initiative = dmhub.initiativeQueue
             if g_initiative ~= nil and g_initiative.hidden then


### PR DESCRIPTION
## Summary
- An ability can end up carrying both the Melee and Ranged keywords at once (e.g. a base Ranged ability that gains the Melee tag at runtime from a kit feature). `GetActivatedAbilities` correctly bifurcates such an ability into a single `meleeAndRanged` entry, but the action bar's `refresh()` was then re-splitting it into two separate buttons instead of leaving it as one entry.
- That pre-split bypassed the existing melee/ranged chip-picker (`CreateSynthesizedSpellsPanel` / `CalculateSpellTargeting`), which only shows when the currently-selected ability still carries both keywords. Since the ability was always pre-split, the chip picker never had a chance to appear.
- Fix: stop pre-splitting in the drawer list-building step. The ability now stays as one action bar entry, so selecting it surfaces the melee/ranged chip picker instead of two duplicate buttons.

## Test plan
- Reproduced live via the DMHub MCP bridge: confirmed a dual-keyword ability appeared twice in the action bar drawer before the fix, and exactly once after.
- Confirmed selecting the single entry fires `beginCasting` and correctly routes into the existing melee/ranged variant-selection flow.
- Verified no console errors after hot-reloading the change.