### PR TITLE
Keep split melee/ranged abilities immune to regaining the opposite keyword

### DIFF
--- a/DMHub Game Rules/ModifierModifyAbilities.lua
+++ b/DMHub Game Rules/ModifierModifyAbilities.lua
@@ -98,8 +98,21 @@ CharacterModifier.RegisterAbilityModifier
 		else
 			local keywords = attr.keywords or {}
 			local abilityKeywords = ability:get_or_add("keywords", {})
+
+			--Once an ability has been split into its Melee/Ranged action bar
+			--variations, each variation must stay single-keyword: a Ranged
+			--variation gaining Melee back (or vice versa) would make the
+			--action bar's own melee/ranged split logic treat it as a fresh
+			--dual-keyword ability again.
+			local isMeleeVariation = ability:try_get("isMeleeVariation", false)
+			local isRangedVariation = ability:try_get("isRangedVariation", false)
+
 			for keyword, _ in pairs(keywords) do
-				abilityKeywords[keyword] = true
+				local blocked = (keyword == "Ranged" and isMeleeVariation)
+					or (keyword == "Melee" and isRangedVariation)
+				if not blocked then
+					abilityKeywords[keyword] = true
+				end
 			end
 			return true
 		end

--- a/DrawSteelActionBar/DrawSteelActionBar.lua
+++ b/DrawSteelActionBar/DrawSteelActionBar.lua
@@ -1453,6 +1453,19 @@ local function CreateActionBar()
             g_resources = g_token.properties:GetResources()
             g_abilities = g_token.properties:GetActivatedAbilities { bindCaster = true, manualTriggers = true }
 
+            --break out melee and ranged.
+            local abilities = {}
+            for _, ability in ipairs(g_abilities) do
+                if ability.meleeAndRanged then
+                    abilities[#abilities + 1] = ability.meleeVariation
+                    abilities[#abilities + 1] = ability.rangedVariation
+                else
+                    abilities[#abilities + 1] = ability
+                end
+            end
+
+            g_abilities = abilities
+
             g_initiative = dmhub.initiativeQueue
             if g_initiative ~= nil and g_initiative.hidden then
                 g_initiative = nil

--- a/DrawSteelActionBar/DrawSteelActionBar.lua
+++ b/DrawSteelActionBar/DrawSteelActionBar.lua
@@ -1453,19 +1453,6 @@ local function CreateActionBar()
             g_resources = g_token.properties:GetResources()
             g_abilities = g_token.properties:GetActivatedAbilities { bindCaster = true, manualTriggers = true }
 
-            --break out melee and ranged.
-            local abilities = {}
-            for _, ability in ipairs(g_abilities) do
-                if ability.meleeAndRanged then
-                    abilities[#abilities + 1] = ability.meleeVariation
-                    abilities[#abilities + 1] = ability.rangedVariation
-                else
-                    abilities[#abilities + 1] = ability
-                end
-            end
-
-            g_abilities = abilities
-
             g_initiative = dmhub.initiativeQueue
             if g_initiative ~= nil and g_initiative.hidden then
                 g_initiative = nil


### PR DESCRIPTION
## Summary
- Per feedback on the earlier version of this PR: an ability carrying both Melee and Ranged keywords should keep splitting into two action bar buttons, so that behavior is unchanged here.
- The actual bug: an ability modifier that adds a keyword can also run against an already-split melee/ranged variation, since `GetActivatedAbilities` re-applies each modifier to both variations via `GetVariations()`. If a variation regains the keyword that bifurcation deliberately stripped from it, it stops being a clean single-keyword ability, which caused inconsistent/duplicate entries downstream.
- Fix: guard the "Add" path of the `modkeywords` ability modifier (`DMHub Game Rules/ModifierModifyAbilities.lua`) so it skips adding `Ranged` to a variation flagged `isMeleeVariation`, and skips adding `Melee` to a variation flagged `isRangedVariation`. An ability that hasn't split yet is unaffected and still picks up its second keyword normally, then splits as before.