### PR TITLE
GoblinScript: add Cast.DuplicateTargetCount(target) field

### DIFF
--- a/DMHub Game Rules/ActivatedAbilityCast.lua
+++ b/DMHub Game Rules/ActivatedAbilityCast.lua
@@ -222,6 +222,11 @@ ActivatedAbilityCast.helpSymbols = {
 		type = "function",
 		desc = "A function which given a target of the roll will return the tier of the result against this target.",
 	},
+	duplicatetargetcount = {
+		name = "Duplicate Target Count",
+		type = "function",
+		desc = "A function which given a target returns the number of times that creature was selected as a target of this ability cast (e.g. via Allow Duplicate Targeting). Returns 0 if the creature was not targeted.",
+	},
     inflictedconditions = {
         name = "Inflicted Conditions",
         type = "boolean",
@@ -541,6 +546,28 @@ ActivatedAbilityCast.lookupSymbols = {
 			end
 
 			return c:try_get("tokenToTier", {})[targetToken.charid] or c.tier
+		end
+	end,
+
+	duplicatetargetcount = function(c)
+		return function(target)
+			if type(target) == "function" then
+				target = target("self")
+			end
+
+			local targetToken = dmhub.LookupToken(target)
+			if targetToken == nil then
+				return 0
+			end
+
+			local result = 0
+			for _,t in ipairs(c:try_get("targets", {})) do
+				if t.token ~= nil and t.token.charid == targetToken.charid then
+					result = result + 1
+				end
+			end
+
+			return result
 		end
 	end,
 

--- a/GoblinScript_Guide.md
+++ b/GoblinScript_Guide.md
@@ -395,6 +395,7 @@ Available during ability resolution (after power roll, while applying effects).
 | Tier | Number | Power roll tier (1, 2, or 3) |
 | Tier For Target | Number | Tier for a specific target |
 | Target Count | Number | Creatures targeted |
+| Duplicate Target Count | Function | `Duplicate Target Count(target)` -- times a creature was selected as a target |
 | Spaces Moved | Number | Squares moved during ability |
 | Damage Dealt | Number | Total damage dealt |
 | Damage Raw | Number | Damage before reductions |


### PR DESCRIPTION
## Summary
- Adds `Cast.DuplicateTargetCount(target)`, a function-type GoblinScript field on `ActivatedAbilityCast` that returns how many times a given creature was selected as a target of the current cast.
- Mirrors the existing `Cast.TierForTarget(target)` pattern, since a creature's "Target" symbol has no inherent notion of which cast/targets-list is asking -- the count only exists on the cast context.
- Useful for abilities with "Allow Duplicate Targeting" enabled (e.g. an ongoing effect or Power Table Effect behavior that should scale based on how many times a creature was hit).
- Documented in `GoblinScript_Guide.md`'s Cast Fields table.

## Test plan
- [ ] In DMHub, build a multi-target ability with Allow Duplicate Targeting on, select the same creature 3 times, and confirm `Cast.DuplicateTargetCount(Target) > 2` evaluates true in a downstream behavior formula (e.g. via Character Inspector or a test ongoing effect).
- [ ] Confirm `Cast.DuplicateTargetCount(Target)` returns 0 for a creature not among the cast's targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)