### PR TITLE
fix(bestiary): don't let the stat-block linger replace the implementation diamond tooltip

### DIFF
--- a/DMHub Core Panels/CharacterPanel.lua
+++ b/DMHub Core Panels/CharacterPanel.lua
@@ -533,6 +533,15 @@ local function CreateMonsterEntry(nodeid)
 
             --render a tooltip of the monster.
             linger = function(element)
+                --If the cursor is on the implementation-status diamond, its own
+                --tooltip is showing; don't replace it with the stat block.
+                local diamond = element:FindChildRecursive(function(p)
+                    return p:HasClass("implementationDiamond")
+                end)
+                if diamond ~= nil and diamond:HasClass("hover") then
+                    return
+                end
+
                 local dock = element:FindParentWithClass("dock")
 
                 local monsterEntry = assets.monsters[nodeid]


### PR DESCRIPTION
## Problem

Hovering the implementation-status diamond in the bestiary showed its tooltip for only a second or two before it vanished.

## Cause

The diamond is a child of the `monsterEntry` row, and the row has a `linger` handler that shows the full monster stat-block tooltip after ~1-2 seconds of hovering anywhere on the row. Parking the cursor on the diamond also armed the row's linger, so the stat block fired and replaced the diamond's tooltip. (Verified live: there is no engine tooltip timeout -- a programmatically spawned tooltip on the same panel persisted 13+ seconds and survived `refreshAssets`.)

## Fix

In the row's `linger` handler, stand down when the implementation diamond itself is the hovered element (gated on the engine-managed `hover` class). Hovering the creature's name or anywhere else on the row still shows the stat block as before.

## Verification

Reloaded Lua in a running Codex instance: the diamond tooltip now persists while hovered, and the stat-block preview still appears when hovering the rest of the row.