### PR TITLE
Olothec: Writhing Envelopment save-lock and blocked-action speech

### DIFF
--- a/DMHub Game Rules/CharacterModifier.lua
+++ b/DMHub Game Rules/CharacterModifier.lua
@@ -1464,6 +1464,12 @@ CharacterModifier.RegisterType('conditionimmunity', "Condition Immunity")
 
 --a 'conditionimmunity' modifier has the following properties:
 --  - conditions: a list of condition id's which we are immune to.
+--conditionimmunity: grants immunity to the conditions listed in modifier.conditions
+--(a list of condition ids). Optional field: modifier.immunityMessage -- when set to
+--a non-empty string, creature:GetConditionImmunityMessage reads it (via try_get) so
+--the immunity-blocked speech can be overridden with a context-specific line instead
+--of the generic "I can't be <Name>!". Used e.g. by Olothec transformation effects
+--that block hiding.
 CharacterModifier.TypeInfo.conditionimmunity = {
 	init = function(modifier)
 		modifier.conditions = {}

--- a/DMHub Game Rules/Creature.lua
+++ b/DMHub Game Rules/Creature.lua
@@ -9902,6 +9902,32 @@ function creature:GetConditionImmunities()
 	return result
 end
 
+--- Returns a custom in-character immunity message for a condition, if any active
+--- modifier that grants immunity to that condition also specifies an
+--- immunityMessage. Used to override the default immunity speech (e.g. an
+--- Olothec transformation effect grants Hidden-immunity but wants to say
+--- "I can't hide from that Olothec right now" instead of "I can't be Hidden!").
+--- Returns the first non-empty message found, or nil when none applies.
+--- @param condid string
+--- @return string|nil
+function creature:GetConditionImmunityMessage(condid)
+	local modifiers = self:GetActiveModifiers()
+	for i,mod in ipairs(modifiers) do
+		local m = mod.mod
+		if m.behavior == "conditionimmunity" then
+			local message = m:try_get("immunityMessage")
+			if message ~= nil and message ~= "" then
+				for j,c in ipairs(m:try_get("conditions", {})) do
+					if c == condid then
+						return message
+					end
+				end
+			end
+		end
+	end
+	return nil
+end
+
 
 
 

--- a/Draw Steel Core Rules/MCDMCreature.lua
+++ b/Draw Steel Core Rules/MCDMCreature.lua
@@ -3024,6 +3024,33 @@ function character:BaseHitpoints()
     return ExecuteGoblinScript(c.hitpointsCalculation, self:LookupSymbol {}, 1, "Base hitpoints")
 end
 
+--Writhing Envelopment (and similar effects): a creature carrying the
+--"Cannot Save Against Other Effects" custom attribute can't roll saving throws
+--to end any other condition or ongoing effect. Rather than prompting for a roll
+--that would just be wasted, the creature protests via a speech bubble and the
+--save is skipped. Returns true when the save should be suppressed.
+local function SuppressSaveAgainstOtherEffects(self)
+    if (self:CalculateNamedCustomAttribute("Cannot Save Against Other Effects") or 0) <= 0 then
+        return false
+    end
+
+    local token = dmhub.LookupToken(self)
+    if token ~= nil and token.valid then
+        token:ModifyProperties{
+            description = "Cannot Save",
+            undoable = false,
+            execute = function()
+                self:CharacterSpeech{
+                    text = "I can't make Saving Throws while grabbed this way!",
+                    langid = self:CurrentlySpokenLanguage(),
+                }
+            end,
+        }
+    end
+
+    return true
+end
+
 function creature:RollOngoingEffectSave(id, abilityOptions)
     abilityOptions = abilityOptions or {}
     abilityOptions.symbols = abilityOptions.symbols or {}
@@ -3041,6 +3068,10 @@ function creature:RollOngoingEffectSave(id, abilityOptions)
     end
 
     if index == nil then
+        return
+    end
+
+    if SuppressSaveAgainstOtherEffects(self) then
         return
     end
 
@@ -3130,6 +3161,10 @@ function creature:RollConditionSave(condid, abilityOptions)
                 self:InflictCondition(condid, { purge = true })
             end,
         }
+        return
+    end
+
+    if SuppressSaveAgainstOtherEffects(self) then
         return
     end
 
@@ -3446,7 +3481,15 @@ function creature:InflictCondition(conditionid, args)
             local conditionsTable = dmhub.GetTable(CharacterCondition.tableName)
             local conditionInfo = conditionsTable[conditionid]
             if conditionInfo ~= nil then
-                local text = g_conditionImmunitySpeech[string.lower(conditionInfo.name)]
+                --A modifier that grants the immunity may specify its own custom
+                --line (immunityMessage), used verbatim to override the generic
+                --speech. This lets special-case effects (e.g. Olothec
+                --transformations that specifically block hiding) say something
+                --context-appropriate instead of "I can't be Hidden!". Otherwise
+                --fall back to the per-condition variations table, then a generic
+                --line.
+                local text = self:GetConditionImmunityMessage(conditionid)
+                    or g_conditionImmunitySpeech[string.lower(conditionInfo.name)]
                     or string.format("I can't be %s!", conditionInfo.name)
                 local language = self:CurrentlySpokenLanguage()
                 if language ~= nil then

--- a/Draw Steel Core Rules/MCDModifyPowerRolls.lua
+++ b/Draw Steel Core Rules/MCDModifyPowerRolls.lua
@@ -368,6 +368,11 @@ CharacterModifier.TypeInfo.power = {
 		local powerRollSymbols = self:AppendSymbols{
 			ability = GenerateSymbols(options.ability),
 			target = GenerateSymbols(options.target),
+			--Expose the creature making the roll so activation conditions can test
+			--the attacker (e.g. "Caster.Keywords has 'Olothec'" on an
+			--enemy_ability_power_roll modifier). options.caster is the roller;
+			--for enemy ability rolls that is the attacker striking the bearer.
+			caster = options.caster ~= nil and GenerateSymbols(options.caster) or nil,
             title = options.title or "",
 		}
 


### PR DESCRIPTION
## Context

The Olothec is a Solo horror built around trapping a single hero and denying them their usual escape valves. In two specific circumstances a player loses an action they would normally expect to have -- and without feedback that reads as a bug rather than a deliberate rule. Alongside enforcing the mechanics, these changes give the player an **in-character speech bubble explaining why**, at the exact moment the missing action is reached for.

## What this does

**1. Writhing Envelopment save-lock.** While grabbed this way, a creature can't roll saving throws to end any *other* condition or ongoing effect. `RollConditionSave` / `RollOngoingEffectSave` now honor the "Cannot Save Against Other Effects" attribute: the save is skipped and the creature says *"I can't make Saving Throws while grabbed this way!"* instead of showing a prompt that would do nothing.

**2. Keyword-gated double edge on Strikes.** Enemy-ability power rolls can now read a `caster` symbol in their activation condition. The Writhing Envelopment rider uses this to grant the Olothec a double edge on Strikes against the grabbed target, gated to the `Olothec` keyword so it does not leak to other enemies of the target.

**3. Custom condition-immunity speech.** `GetConditionImmunityMessage` reads an optional `immunityMessage` on `conditionimmunity` modifiers, so an Olothec effect that blocks a hero from hiding can explain why with a context-specific line rather than the generic *"I can't be Hidden!"*.

## Files
- `Draw Steel Core Rules/MCDMCreature.lua` -- save suppression + speech; immunity-speech hook in `InflictCondition`
- `Draw Steel Core Rules/MCDModifyPowerRolls.lua` -- expose `caster` to power-roll activation conditions
- `DMHub Game Rules/Creature.lua` -- `GetConditionImmunityMessage`
- `DMHub Game Rules/CharacterModifier.lua` -- documents the `immunityMessage` field on `conditionimmunity`

The data-side wiring (the rider's double-edge modifier and the malice ability applying the rider) is game content and was uploaded to the live game directly, so it is not part of this diff.

## Verification
Exercised end-to-end in a running instance: rider attaches when the grab lands; a save-ends condition survived the save attempt with the speech bubble firing; the double edge activated for the Olothec + a Strike, and correctly did **not** activate for a non-Olothec attacker or a non-Strike ability.