### PR TITLE
Olothec Hidden-immunity: context-aware immunity speech

### DIFF
--- a/DMHub Game Rules/CharacterModifier.lua
+++ b/DMHub Game Rules/CharacterModifier.lua
@@ -1464,6 +1464,12 @@ CharacterModifier.RegisterType('conditionimmunity', "Condition Immunity")
 
 --a 'conditionimmunity' modifier has the following properties:
 --  - conditions: a list of condition id's which we are immune to.
+--conditionimmunity: grants immunity to the conditions listed in modifier.conditions
+--(a list of condition ids). Optional field: modifier.immunityMessage -- when set to
+--a non-empty string, creature:GetConditionImmunityMessage reads it (via try_get) so
+--the immunity-blocked speech can be overridden with a context-specific line instead
+--of the generic "I can't be <Name>!". Used e.g. by Olothec transformation effects
+--that block hiding.
 CharacterModifier.TypeInfo.conditionimmunity = {
 	init = function(modifier)
 		modifier.conditions = {}

--- a/DMHub Game Rules/Creature.lua
+++ b/DMHub Game Rules/Creature.lua
@@ -9902,6 +9902,32 @@ function creature:GetConditionImmunities()
 	return result
 end
 
+--- Returns a custom in-character immunity message for a condition, if any active
+--- modifier that grants immunity to that condition also specifies an
+--- immunityMessage. Used to override the default immunity speech (e.g. an
+--- Olothec transformation effect grants Hidden-immunity but wants to say
+--- "I can't hide from that Olothec right now" instead of "I can't be Hidden!").
+--- Returns the first non-empty message found, or nil when none applies.
+--- @param condid string
+--- @return string|nil
+function creature:GetConditionImmunityMessage(condid)
+	local modifiers = self:GetActiveModifiers()
+	for i,mod in ipairs(modifiers) do
+		local m = mod.mod
+		if m.behavior == "conditionimmunity" then
+			local message = m:try_get("immunityMessage")
+			if message ~= nil and message ~= "" then
+				for j,c in ipairs(m:try_get("conditions", {})) do
+					if c == condid then
+						return message
+					end
+				end
+			end
+		end
+	end
+	return nil
+end
+
 
 
 

--- a/Draw Steel Core Rules/MCDMCreature.lua
+++ b/Draw Steel Core Rules/MCDMCreature.lua
@@ -3446,7 +3446,15 @@ function creature:InflictCondition(conditionid, args)
             local conditionsTable = dmhub.GetTable(CharacterCondition.tableName)
             local conditionInfo = conditionsTable[conditionid]
             if conditionInfo ~= nil then
-                local text = g_conditionImmunitySpeech[string.lower(conditionInfo.name)]
+                --A modifier that grants the immunity may specify its own custom
+                --line (immunityMessage), used verbatim to override the generic
+                --speech. This lets special-case effects (e.g. Olothec
+                --transformations that specifically block hiding) say something
+                --context-appropriate instead of "I can't be Hidden!". Otherwise
+                --fall back to the per-condition variations table, then a generic
+                --line.
+                local text = self:GetConditionImmunityMessage(conditionid)
+                    or g_conditionImmunitySpeech[string.lower(conditionInfo.name)]
                     or string.format("I can't be %s!", conditionInfo.name)
                 local language = self:CurrentlySpokenLanguage()
                 if language ~= nil then


### PR DESCRIPTION
## What

When a creature is immune to a condition, it "speaks" in character (e.g. "I can't be Slowed!"). Because *Hidden* isn't in the per-condition variations table, a creature immune to Hidden fell back to the generic "I can't be Hidden!".

The Olothec Legs/Head/Torso Transformation effects (and Slimed) grant Hidden-immunity because a creature under them cannot hide from the Olothec. For those, the generic line reads wrong. This makes the immunity message overridable per immunity-source so they can instead say **"I can't hide from that Olothec right now"** -- deliberately a little ambiguous, signalling a special circumstance.

## Approach (data-driven)

The custom message lives on the immunity data rather than being hardcoded against effect GUIDs -- so it travels with the effect, is reusable for any future special-case immunity, and survives content re-IDs.

- **`DMHub Game Rules/CharacterModifier.lua`** -- document the optional `immunityMessage` field on the `conditionimmunity` behavior.
- **`DMHub Game Rules/Creature.lua`** -- add `creature:GetConditionImmunityMessage(condid)`: returns the first non-empty `immunityMessage` from an active `conditionimmunity` modifier that lists `condid` (read via `try_get`), else nil.
- **`Draw Steel Core Rules/MCDMCreature.lua`** -- `InflictCondition`'s immune branch now prefers the custom `immunityMessage`, then the per-condition variations table, then the generic line.

## Live data (already applied to the game compendium)

Each of **Legs / Head / Torso Transformation** received a Hidden `conditionimmunity` modifier, and all three plus **Slimed** have `immunityMessage = "I can't hide from that Olothec right now"`. (These are `characterOngoingEffects` table edits, not part of this code diff.)

## Testing

Verified live: with a transformation active, inflicting Hidden is blocked and the creature speaks "I can't hide from that Olothec right now"; a non-listed condition (Slowed) correctly falls through to the normal text; all four effect definitions persist after upload and Lua reload.