### PR TITLE
Spoiler-hidden power roll modifiers with director reveal

### DIFF
--- a/Draw Steel Core Rules/MCDModifyPowerRolls.lua
+++ b/Draw Steel Core Rules/MCDModifyPowerRolls.lua
@@ -1088,6 +1088,37 @@ CharacterModifier.TypeInfo.power = {
 
             local children = {}
 
+            --Spoiler eyelid: wraps/unwraps the modifier name in {#...} spoiler
+            --markup (see PowerRollSpoilers in Timeline/EmbeddedRollDialog) so
+            --authors don't need to remember the markup. A spoilered name hides
+            --the modifier's name and description from players in the roll
+            --dialogs until the director reveals it.
+            local spoilerEye = nil
+            local spoilers = rawget(_G, "PowerRollSpoilers")
+            if spoilers ~= nil then
+                local spoilered = spoilers.HasSpoiler(modifier.name or "")
+                spoilerEye = gui.VisibilityPanel{
+                    visible = not spoilered,
+                    hmargin = 6,
+                    valign = "center",
+                    hoverCursor = "hand",
+                    click = function(element)
+                        local name = modifier.name or ""
+                        if spoilers.HasSpoiler(name) then
+                            modifier.name = spoilers.Strip(name)
+                        elseif name ~= "" then
+                            modifier.name = "{#" .. name .. "}"
+                        end
+                        Refresh()
+                    end,
+                    linger = function(element)
+                        gui.Tooltip(cond(spoilers.HasSpoiler(modifier.name or ""),
+                            "This modifier is a spoiler: players see its name and description redacted in the roll dialog until the director reveals it. Click to make it visible to players.",
+                            "This modifier is visible to players. Click to hide its name and description from players as a spoiler."))(element)
+                    end,
+                }
+            end
+
             children[#children+1] = gui.Panel{
                 classes = {"formPanel"},
                 gui.Label{
@@ -1102,6 +1133,7 @@ CharacterModifier.TypeInfo.power = {
                         Refresh()
                     end,
                 },
+                spoilerEye,
             }
 
             children[#children+1] = gui.Panel{

--- a/Draw Steel UI/DSRollDialog.lua
+++ b/Draw Steel UI/DSRollDialog.lua
@@ -843,7 +843,13 @@ function GameHud.CreateRollDialog(self)
 
                 element:SetClass("triggered", info.triggered)
 
-                label.text = info.modifier.name
+                local triggerName = info.modifier.name
+                if PowerRollSpoilers.HasSpoiler(triggerName) then
+                    local revealed = PowerRollSpoilers.IsRevealed(PowerRollSpoilers.Key(triggerName),
+                        PowerRollSpoilers.DefaultRevealed(triggerName))
+                    triggerName = PowerRollSpoilers.Format(triggerName, revealed)
+                end
+                label.text = triggerName
             end,
             --- @param element Panel
             ping = function(element, count)
@@ -1913,7 +1919,27 @@ function GameHud.CreateRollDialog(self)
                                 justification)
                         end
 
-                        local text = mod.modifier.name
+                        --Spoilered modifier names ({#...} markup, see
+                        --PowerRollSpoilers in Timeline/EmbeddedRollDialog):
+                        --players see a redaction bar until the director
+                        --reveals them; the director sees the plain text.
+                        local rawName = mod.modifier.name or ""
+                        local spoiler = PowerRollSpoilers.HasSpoiler(rawName)
+                        local spoilerRevealed = false
+                        if spoiler then
+                            spoilerRevealed = PowerRollSpoilers.IsRevealed(PowerRollSpoilers.Key(rawName),
+                                PowerRollSpoilers.DefaultRevealed(rawName))
+                            if dmhub.isDM or spoilerRevealed then
+                                tooltip = PowerRollSpoilers.Format(tooltip, spoilerRevealed)
+                            else
+                                tooltip = PowerRollSpoilers.Format(rawName, false)
+                            end
+                        end
+
+                        local text = rawName
+                        if spoiler then
+                            text = PowerRollSpoilers.Format(rawName, spoilerRevealed)
+                        end
                         if mod.modFromTarget then
                             text = string.format("Target is %s", text)
                         end

--- a/Timeline/AbilitySidebar.lua
+++ b/Timeline/AbilitySidebar.lua
@@ -150,6 +150,37 @@ local function CreateReadOnlyModifierPill(modInfo)
     local isBuff = modInfo.buffOrDebuff == "buff"
     local isDebuff = modInfo.buffOrDebuff == "debuff"
 
+    --The latest broadcast info for this pill, so spoiler reveals can reformat
+    --the label without waiting for the next broadcast.
+    local m_info = modInfo
+
+    --Spoilered modifier names ({#...} markup, see PowerRollSpoilers in
+    --EmbeddedRollDialog) render as a redaction bar for players until the
+    --director reveals them.
+    local function FormatPillName(info)
+        local text = info.name
+        if PowerRollSpoilers.HasSpoiler(text) then
+            local raw = info.spoilerName or text
+            local revealed = PowerRollSpoilers.IsRevealed(PowerRollSpoilers.Key(raw),
+                PowerRollSpoilers.DefaultRevealed(raw))
+            text = PowerRollSpoilers.Format(text, revealed)
+        end
+        return text
+    end
+
+    --The director gets the eyelid toggle on the mirror pill too, since a
+    --player's roll shows for the director only as this read-only view.
+    local spoilerEye = nil
+    if dmhub.isDM and PowerRollSpoilers.HasSpoiler(modInfo.spoilerName or modInfo.name or "") then
+        local raw = modInfo.spoilerName or modInfo.name
+        spoilerEye = PowerRollSpoilers.CreateEyeButton{
+            key = PowerRollSpoilers.Key(raw),
+            name = raw,
+            description = modInfo.spoilerDescription or "",
+            defaultRevealed = PowerRollSpoilers.DefaultRevealed(raw),
+        }
+    end
+
     return gui.Panel{
         classes = {"modPill", "bgAlt"},
         borderWidth = 2,
@@ -193,19 +224,30 @@ local function CreateReadOnlyModifierPill(modInfo)
 
         gui.Label{
             classes = {"modLabel", "sizeM"},
-            text = modInfo.name,
+            text = FormatPillName(modInfo),
             width = "auto",
             height = "auto",
             lmargin = 0,
             rmargin = 4,
             valign = "center",
 
+            --Re-render the redaction when the director reveals or hides the
+            --spoiler mid-roll.
+            monitorGame = PowerRollSpoilers.DocumentPath(),
+            refreshGame = function(element)
+                element.text = FormatPillName(m_info)
+            end,
+
             -- Label brightens from muted to default when enabled.
             updateModifierPill = function(element, info)
+                m_info = info
+                element.text = FormatPillName(info)
                 element:SetClass("fg", info.enabled)
                 element:SetClass("fgMuted", not info.enabled)
             end,
         },
+
+        spoilerEye,
     }
 end
 

--- a/Timeline/EmbeddedRollDialog.lua
+++ b/Timeline/EmbeddedRollDialog.lua
@@ -144,6 +144,16 @@ function PowerRollSpoilers.DefaultRevealed(text)
     return text ~= nil and string.find(text, "{#", 1, true) == nil
 end
 
+--- Remove spoiler markers from text, keeping the content (the editing
+--- counterpart of wrapping text in {#...}).
+function PowerRollSpoilers.Strip(text)
+    if text == nil then
+        return text
+    end
+    local result = string.gsub(text, "{[#!](.-)}", "%1")
+    return result
+end
+
 function PowerRollSpoilers.DocumentPath()
     return mod:GetDocumentPath(PowerRollSpoilers.documentId)
 end

--- a/Timeline/EmbeddedRollDialog.lua
+++ b/Timeline/EmbeddedRollDialog.lua
@@ -100,6 +100,235 @@ local g_rollOptionsPlayer = {
 
 local g_boonsLabels = { "BANE", "BANE", "X", "EDGE", "EDGE" }
 
+--------------------------------------------------------------------------------
+-- Spoiler support for power roll modifiers.
+--
+-- A modifier whose name contains {#...} spoiler markup (the document system's
+-- spoiler syntax, see DocumentSystem/MarkdownDocument.lua) is treated as a
+-- secret: players see the badge name and hover text as a redaction bar, while
+-- the director sees the plain text plus an eyelid icon on the badge. Clicking
+-- the eyelid reveals the spoiler to players (recorded in a shared document so
+-- the reveal persists for future rolls) and posts the modifier's name and
+-- description to the action log, where the director can click the same eyelid
+-- to hide it again.
+--------------------------------------------------------------------------------
+
+PowerRollSpoilers = {
+    documentId = "powerRollSpoilerReveals",
+}
+
+--- True if the text contains spoiler markup ({#hidden} or {!revealed}).
+function PowerRollSpoilers.HasSpoiler(text)
+    if text == nil then
+        return false
+    end
+    return string.find(text, "{#", 1, true) ~= nil or string.find(text, "{!", 1, true) ~= nil
+end
+
+--- The key used to record a reveal: the concatenated content of the spoiler
+--- spans, so "{#Soft Underbelly}" and "Target is {#Soft Underbelly}" share a key.
+function PowerRollSpoilers.Key(text)
+    local parts = {}
+    for span in string.gmatch(text, "{[#!](.-)}") do
+        parts[#parts + 1] = span
+    end
+    if #parts == 0 then
+        return text
+    end
+    return table.concat(parts, "|")
+end
+
+--- Whether the text's spoilers default to revealed absent any recorded state
+--- (authored with {!...} rather than {#...}).
+function PowerRollSpoilers.DefaultRevealed(text)
+    return text ~= nil and string.find(text, "{#", 1, true) == nil
+end
+
+function PowerRollSpoilers.DocumentPath()
+    return mod:GetDocumentPath(PowerRollSpoilers.documentId)
+end
+
+function PowerRollSpoilers.IsRevealed(key, defaultRevealed)
+    local doc = mod:GetDocumentSnapshot(PowerRollSpoilers.documentId)
+    local revealed = doc.data.revealed
+    if revealed == nil or revealed[key] == nil then
+        return defaultRevealed == true
+    end
+    return revealed[key] == true
+end
+
+function PowerRollSpoilers.SetRevealed(key, value)
+    local doc = mod:GetDocumentSnapshot(PowerRollSpoilers.documentId)
+    doc:BeginChange()
+    local revealed = doc.data.revealed or {}
+    revealed[key] = value
+    doc.data.revealed = revealed
+    doc:CompleteChange("Reveal spoiler to players", {undoable = false})
+end
+
+--- Format text containing spoiler markup for display. Unrevealed spoilers
+--- render as a redaction bar for players; the director and revealed spoilers
+--- get the plain text with the markers stripped.
+function PowerRollSpoilers.Format(text, revealed)
+    if text == nil or string.find(text, "{", 1, true) == nil then
+        return text
+    end
+    if dmhub.isDM or revealed then
+        text = string.gsub(text, "{#", "{!")
+    end
+    return MarkdownDocument.FormatRichText(text, {player = true})
+end
+
+--- Reveal a spoiler to players and post it to the action log.
+--- info: { key, name, description, tokenid }
+function PowerRollSpoilers.Reveal(info)
+    PowerRollSpoilers.SetRevealed(info.key, true)
+    chat.SendCustom(SpoilerRevealChatMessage.new{
+        spoilerKey = info.key,
+        spoilerName = info.name or "",
+        spoilerDescription = info.description or "",
+        tokenid = info.tokenid or "",
+    })
+end
+
+--- The eyelid toggle shown to the director next to a spoilered modifier.
+--- info: { key, name, description, tokenid, defaultRevealed }
+function PowerRollSpoilers.CreateEyeButton(info, options)
+    local args = {
+        visible = PowerRollSpoilers.IsRevealed(info.key, info.defaultRevealed),
+        width = 14,
+        height = 14,
+        valign = "center",
+        rmargin = 2,
+        swallowPress = true,
+        hoverCursor = "hand",
+        click = function(element)
+            local revealed = PowerRollSpoilers.IsRevealed(info.key, info.defaultRevealed)
+            if revealed then
+                PowerRollSpoilers.SetRevealed(info.key, false)
+            else
+                PowerRollSpoilers.Reveal(info)
+            end
+            element:FireEvent("visible", not revealed)
+        end,
+        linger = function(element)
+            local revealed = PowerRollSpoilers.IsRevealed(info.key, info.defaultRevealed)
+            gui.Tooltip(cond(revealed,
+                "This is visible to players. Click to hide it from them.",
+                "This is hidden from players. Click to reveal it to them and post it to the action log."))(element)
+        end,
+        --Keep the eyelid in sync when the reveal is toggled from elsewhere
+        --(another dialog, the action log message, or another client).
+        monitorGame = PowerRollSpoilers.DocumentPath(),
+        refreshGame = function(element)
+            element:FireEvent("visible", PowerRollSpoilers.IsRevealed(info.key, info.defaultRevealed))
+        end,
+    }
+    for k, v in pairs(options or {}) do
+        args[k] = v
+    end
+    return gui.VisibilityPanel(args)
+end
+
+--- Action log message posted when the director reveals a spoilered modifier.
+--- Renders live from the shared reveal document, so the director can hide the
+--- spoiler again from the message itself and players' views update in place.
+SpoilerRevealChatMessage = RegisterGameType("SpoilerRevealChatMessage")
+SpoilerRevealChatMessage.spoilerKey = ""
+SpoilerRevealChatMessage.spoilerName = ""
+SpoilerRevealChatMessage.spoilerDescription = ""
+SpoilerRevealChatMessage.tokenid = ""
+
+function SpoilerRevealChatMessage.Render(self, message)
+    local key = self.spoilerKey
+
+    local nameLabel = gui.Label{
+        classes = {"action-log-name", "sizeS", "bold"},
+    }
+
+    local descriptionLabel = nil
+    if self.spoilerDescription ~= "" then
+        descriptionLabel = gui.Label{
+            classes = {"action-log-subtext", "sizeXs"},
+        }
+    end
+
+    local eye = nil
+    if dmhub.isDM then
+        eye = PowerRollSpoilers.CreateEyeButton({
+            key = key,
+            name = self.spoilerName,
+            description = self.spoilerDescription,
+            tokenid = self.tokenid,
+        }, {
+            lmargin = 4,
+            --The reveal already happened; from here the eyelid only toggles
+            --visibility without posting another message.
+            click = function(element)
+                local revealed = PowerRollSpoilers.IsRevealed(key, false)
+                PowerRollSpoilers.SetRevealed(key, not revealed)
+                element:FireEvent("visible", not revealed)
+            end,
+        })
+    end
+
+    local function RefreshContent()
+        local revealed = PowerRollSpoilers.IsRevealed(key, false)
+        nameLabel.text = PowerRollSpoilers.Format(self.spoilerName, revealed)
+        if descriptionLabel ~= nil then
+            if dmhub.isDM or revealed then
+                descriptionLabel.text = PowerRollSpoilers.Format(self.spoilerDescription, revealed)
+            else
+                descriptionLabel.text = PowerRollSpoilers.Format("{#" .. self.spoilerDescription .. "}", false)
+            end
+        end
+        if eye ~= nil then
+            eye:FireEvent("visible", revealed)
+        end
+    end
+
+    local headerRow = gui.Panel{
+        flow = "horizontal",
+        width = "auto",
+        height = "auto",
+        halign = "left",
+        nameLabel,
+        eye,
+    }
+
+    local token = nil
+    if self.tokenid ~= "" then
+        token = dmhub.GetCharacterById(self.tokenid)
+        if token ~= nil and not token.valid then
+            token = nil
+        end
+    end
+
+    local card = CreateActionLogCard{
+        token = token,
+        hideName = true,
+        content = {headerRow, descriptionLabel},
+    }
+
+    local resultPanel
+    resultPanel = gui.Panel{
+        classes = {"chat-message-panel"},
+        flow = "vertical",
+        width = "100%",
+        height = "auto",
+        monitorGame = PowerRollSpoilers.DocumentPath(),
+        refreshGame = function(element)
+            RefreshContent()
+        end,
+        create = function(element)
+            RefreshContent()
+        end,
+        card,
+    }
+
+    return resultPanel
+end
+
 local function ModifierPanel(args)
 
     local resultPanel
@@ -121,6 +350,10 @@ local function ModifierPanel(args)
     --the badge after the label.
     local m_content = args.content
     args.content = nil
+
+    --Optional director-only spoiler eyelid toggle shown after the label.
+    local m_eye = args.eye
+    args.eye = nil
 
     local classes = args.classes or {}
     classes[#classes+1] = "modifierPanel"
@@ -191,6 +424,10 @@ local function ModifierPanel(args)
             ApplySelectionColors(value)
         end,
     }
+
+    if m_eye ~= nil then
+        params[#params+1] = m_eye
+    end
 
     if m_content ~= nil then
         params[#params+1] = m_content
@@ -747,7 +984,13 @@ function GameHud.CreateEmbeddedRollDialog()
                 elseif modInfo.value < 0 then
                     labelType = "debuff"
                 end
-                markers:AddLabel(mod.modifier.name, labelType)
+                local labelText = mod.modifier.name
+                if PowerRollSpoilers.HasSpoiler(labelText) then
+                    local revealed = PowerRollSpoilers.IsRevealed(PowerRollSpoilers.Key(labelText),
+                        PowerRollSpoilers.DefaultRevealed(labelText))
+                    labelText = PowerRollSpoilers.Format(labelText, revealed)
+                end
+                markers:AddLabel(labelText, labelType)
             end
         end
     end
@@ -1130,13 +1373,23 @@ function GameHud.CreateEmbeddedRollDialog()
                     text = string.format("Target is %s", text)
                 end
 
-                modifiers[#modifiers+1] = {
+                local entry = {
                     name = text,
                     guid = m.modifier.guid or "",
                     enabled = ischecked,
                     forced = force,
                     buffOrDebuff = buffOrDebuff,
                 }
+
+                --Spoilered modifiers carry their raw name and description so
+                --the director's read-only mirror can reveal them to players
+                --and post them to the action log.
+                if PowerRollSpoilers.HasSpoiler(m.modifier.name or "") then
+                    entry.spoilerName = m.modifier.name
+                    entry.spoilerDescription = m.modifier:try_get("description", "")
+                end
+
+                modifiers[#modifiers+1] = entry
                 ::continueBroadcast::
             end
         end
@@ -2789,7 +3042,16 @@ function GameHud.CreateEmbeddedRollDialog()
         height = "auto",
         flow = "horizontal",
         wrap = true,
+        --Rebuild the badges when the director reveals or hides a spoilered
+        --modifier so the redaction updates live on player clients.
+        monitorGame = PowerRollSpoilers.DocumentPath(),
         events = {
+
+            refreshGame = function(element)
+                if m_options ~= nil and m_options.modifiers ~= nil then
+                    element:FireEvent("prepare", m_options)
+                end
+            end,
 
             -- Here we get a pass at deciding any modifications to which modifiers are available
             -- that will modify rollProperties (e.g. damage) after edges and banes have been calculated.
@@ -2851,6 +3113,30 @@ function GameHud.CreateEmbeddedRollDialog()
 
                         local check --gui.Check that will come out of this.
 
+                        local rawName = mod.modifier.name or ""
+                        local spoiler = PowerRollSpoilers.HasSpoiler(rawName)
+                        local spoilerRevealed = false
+                        local spoilerEye = nil
+                        if spoiler then
+                            local spoilerKey = PowerRollSpoilers.Key(rawName)
+                            local defaultRevealed = PowerRollSpoilers.DefaultRevealed(rawName)
+                            spoilerRevealed = PowerRollSpoilers.IsRevealed(spoilerKey, defaultRevealed)
+                            if dmhub.isDM then
+                                local ownerCreature = cond(mod.modFromTarget, targetCreature, creature)
+                                local tokenid = nil
+                                if ownerCreature ~= nil then
+                                    tokenid = dmhub.LookupTokenId(ownerCreature)
+                                end
+                                spoilerEye = PowerRollSpoilers.CreateEyeButton{
+                                    key = spoilerKey,
+                                    name = rawName,
+                                    description = mod.modifier:try_get("description", ""),
+                                    tokenid = tokenid,
+                                    defaultRevealed = defaultRevealed,
+                                }
+                            end
+                        end
+
                         local tooltip = mod.modifier:GetSummaryText()
                         if creature ~= nil then
                             tooltip = StringInterpolateGoblinScript(tooltip, creature)
@@ -2859,8 +3145,21 @@ function GameHud.CreateEmbeddedRollDialog()
                             tooltip = string.format("%s\n<color=%s>%s", tooltip, cond(ischecked, '#aaffaa', '#ffaaaa'),
                                 justification)
                         end
+                        if spoiler then
+                            if dmhub.isDM or spoilerRevealed then
+                                tooltip = PowerRollSpoilers.Format(tooltip, spoilerRevealed)
+                            else
+                                --Show players only the redacted name: passing the full
+                                --summary through would let its embedded color tags
+                                --defeat the redaction bar.
+                                tooltip = PowerRollSpoilers.Format(rawName, false)
+                            end
+                        end
 
-                        local text = mod.modifier.name
+                        local text = rawName
+                        if spoiler then
+                            text = PowerRollSpoilers.Format(rawName, spoilerRevealed)
+                        end
                         if mod.modFromTarget then
                             text = string.format("Target is %s", text)
                         end
@@ -2983,6 +3282,7 @@ function GameHud.CreateEmbeddedRollDialog()
                             value = ischecked,
                             hmargin = 2,
                             mod = mod,
+                            eye = spoilerEye,
                             content = mappingContent,
                             data = {
                                 mod = mod,
@@ -3120,7 +3420,16 @@ function GameHud.CreateEmbeddedRollDialog()
         flow = "horizontal",
         wrap = true,
         bmargin = 6,
+        --Rebuild the badges when the director reveals or hides a spoilered
+        --modifier so the redaction updates live on player clients.
+        monitorGame = PowerRollSpoilers.DocumentPath(),
         events = {
+            refreshGame = function(element)
+                if m_options ~= nil and m_options.modifiers ~= nil then
+                    element:FireEvent("prepare", m_options)
+                end
+            end,
+
             prepare = function(element, options)
                 if creature == nil or options.modifiers == nil then
                     element.children = {}
@@ -3150,6 +3459,30 @@ function GameHud.CreateEmbeddedRollDialog()
                             ischecked = mod.hint.result
                         end
 
+                        local rawName = mod.modifier.name or ""
+                        local spoiler = PowerRollSpoilers.HasSpoiler(rawName)
+                        local spoilerRevealed = false
+                        local spoilerEye = nil
+                        if spoiler then
+                            local spoilerKey = PowerRollSpoilers.Key(rawName)
+                            local defaultRevealed = PowerRollSpoilers.DefaultRevealed(rawName)
+                            spoilerRevealed = PowerRollSpoilers.IsRevealed(spoilerKey, defaultRevealed)
+                            if dmhub.isDM then
+                                local ownerCreature = cond(mod.modFromTarget, targetCreature, creature)
+                                local tokenid = nil
+                                if ownerCreature ~= nil then
+                                    tokenid = dmhub.LookupTokenId(ownerCreature)
+                                end
+                                spoilerEye = PowerRollSpoilers.CreateEyeButton{
+                                    key = spoilerKey,
+                                    name = rawName,
+                                    description = mod.modifier:try_get("description", ""),
+                                    tokenid = tokenid,
+                                    defaultRevealed = defaultRevealed,
+                                }
+                            end
+                        end
+
                         local tooltip = mod.modifier:GetSummaryText()
                         if creature ~= nil then
                             tooltip = StringInterpolateGoblinScript(tooltip, creature)
@@ -3158,8 +3491,21 @@ function GameHud.CreateEmbeddedRollDialog()
                             tooltip = string.format("%s\n<color=%s>%s", tooltip, cond(ischecked, '#aaffaa', '#ffaaaa'),
                                 justification)
                         end
+                        if spoiler then
+                            if dmhub.isDM or spoilerRevealed then
+                                tooltip = PowerRollSpoilers.Format(tooltip, spoilerRevealed)
+                            else
+                                --Show players only the redacted name: passing the full
+                                --summary through would let its embedded color tags
+                                --defeat the redaction bar.
+                                tooltip = PowerRollSpoilers.Format(rawName, false)
+                            end
+                        end
 
-                        local text = mod.modifier.name
+                        local text = rawName
+                        if spoiler then
+                            text = PowerRollSpoilers.Format(rawName, spoilerRevealed)
+                        end
                         if mod.modFromTarget then
                             text = string.format("Target is %s", text)
                         end
@@ -3191,6 +3537,7 @@ function GameHud.CreateEmbeddedRollDialog()
                             value = ischecked,
                             hmargin = 2,
                             mod = mod,
+                            eye = spoilerEye,
                             data = {
                                 mod = mod,
                                 modifierIndex = modifierIndex,


### PR DESCRIPTION
## What

A power roll modifier whose **name** contains `{#...}` spoiler markup (the document system's spoiler syntax) is now treated as a secret in the roll dialogs. First use case: the arixx's **Soft Underbelly** trait, whose modifier is named `{#Soft Underbelly}` so prone attackers don't learn the mechanic from the roll modal.

## Behavior

- **Players** see the badge name, its hover tooltip, and the targeting-arrow label as a redaction bar - the same blackout treatment document spoilers use. The modifier still functions normally; only the explanation is hidden.
- **The director** sees the plain text plus a closed-eyelid toggle (`gui.VisibilityPanel`) on the badge - in the interactive dialog and in the read-only mirror shown while a player rolls.
- **Clicking the eyelid** reveals the spoiler to players and posts an action log card with the modifier's name and description, so the whole table learns it at once. The card carries the same eyelid so the director can hide it again.
- **Reveals persist**: state lives in a shared document (`powerRollSpoilerReveals`) keyed by the spoiler text, so it holds for all future rolls in the game and syncs live to any open dialogs via `monitorGame`.
- **Authoring**: the power roll modifier editor's Name row gets the same eyelid icon - clicking it wraps/unwraps the name in the spoiler markers, so authors never have to type `{#...}` by hand.

## Implementation notes

- `PowerRollSpoilers` helpers + `SpoilerRevealChatMessage` live at the top of `Timeline/EmbeddedRollDialog.lua`; `Timeline/AbilitySidebar.lua` reuses them for the mirror pill and `Draw Steel Core Rules/MCDModifyPowerRolls.lua` for the editor toggle.
- The broadcast dialog state adds `spoilerName`/`spoilerDescription` for spoilered modifiers only, so the mirror can reveal without local access to the creature.
- Player-hidden tooltips show only the redacted name rather than wrapping the full summary, because the summary's embedded `<color>` tags would defeat the redaction bar.
- The legacy `Draw Steel UI/DSRollDialog.lua` gets redaction (no eyelid) so spoilered names can't leak through it.
- Authoring convention: mark only the inner modifier's name; the trait/feature name stays plain so statblocks are unaffected. `{!...}` authors a spoiler as starting revealed.

## Testing

Verified live against the arixx: DM badge + eyelid, reveal -> action log card, hide/re-reveal syncing across open UI, player-path redaction output from the formatter, and the editor toggle's wrap/strip round trip.