### PR TITLE
feat(damage): bypassTempStamina flag routes damage past temporary Stamina

### DIFF
--- a/Draw Steel Core Rules/MCDMCreature.lua
+++ b/Draw Steel Core Rules/MCDMCreature.lua
@@ -5177,7 +5177,12 @@ function creature.TakeDamage(self, amount, note, info)
             end
         end
 
-        amount = self:RemoveTemporaryHitpoints(amount, note or string.format("%d Damage", original_amount))
+        --bypassTempStamina: damage originating "inside" a temporary-Stamina shield
+        --(e.g. the Shambling Mound's sack poisoning the creature it engulfed) goes
+        --straight to real Stamina instead of being absorbed by the shield.
+        if not info.bypassTempStamina then
+            amount = self:RemoveTemporaryHitpoints(amount, note or string.format("%d Damage", original_amount))
+        end
 
         if amount >= self:MaxHitpoints() + self:CurrentHitpoints() then
             instadeath = true


### PR DESCRIPTION
## Summary

Adds an opt-in `info.bypassTempStamina` flag to `creature.TakeDamage` in `Draw Steel Core Rules/MCDMCreature.lua`. When set, the damage skips `RemoveTemporaryHitpoints` and applies directly to real Stamina.

## Why

Damage that originates *inside* a temporary-Stamina shield should not be absorbed by that shield. The motivating case is the Shambling Mound's Engulf: the engulfed creature's escape hatch is modeled as temporary Stamina on the target (destroying the "sack" frees them), but the mound's own poison damage happens inside the sack and must hit the creature's real Stamina, not eat the very shield that represents the sack.

## Notes

- No behavior change for any existing caller: the flag defaults to falsy and `info` is already normalized with `info = info or {}` at the top of `TakeDamage`.
- This is the engine-side hook recovered from a floating stash ("floating: engulf bypassTempStamina WIP", 2026-07-14); the Engulf ability content that uses it is implemented separately.