### PR TITLE
feat(lightbender): Lightbender LoE Blocked attribute blocks line of effect

### DIFF
--- a/Draw Steel Core Rules/DSRuleUtils.lua
+++ b/Draw Steel Core Rules/DSRuleUtils.lua
@@ -1,5 +1,12 @@
 local mod = dmhub.GetModLoading()
 
+-- Returns true if the token's creature has the "Lightbender" keyword.
+local function HasLightbenderKeyword(tok)
+    if tok == nil or tok.properties == nil then return false end
+    local kws = tok.properties:Keywords()
+    return kws["Lightbender"] == true
+end
+
 RuleUtils = {
     HasLineOfEffect = function(toka, tokb)
         --Honor a per-creature line-of-effect square cap (the "Line Of Effect Limit"
@@ -16,6 +23,23 @@ RuleUtils = {
             return distance <= limit
         end
         if not checkLimit(toka) or not checkLimit(tokb) then
+            return false
+        end
+
+        -- "Everything the Light Touches" malice ability: a creature with
+        -- "Lightbender LoE Blocked > 0" cannot have line of effect to any
+        -- creature that has the Lightbender keyword. Only the affected side
+        -- is blocked, so we check each direction independently.
+        if toka.properties ~= nil
+            and toka.properties:CalculateNamedCustomAttribute("Lightbender LoE Blocked") > 0
+            and HasLightbenderKeyword(tokb)
+        then
+            return false
+        end
+        if tokb.properties ~= nil
+            and tokb.properties:CalculateNamedCustomAttribute("Lightbender LoE Blocked") > 0
+            and HasLightbenderKeyword(toka)
+        then
             return false
         end
 

--- a/Draw Steel Core Rules/MCDMCreature.lua
+++ b/Draw Steel Core Rules/MCDMCreature.lua
@@ -2394,6 +2394,7 @@ creature.RegisterSymbol {
 }
 
 CustomAttribute.RegisterAttribute { id = "reach", text = "Reach", attributeType = "number", category = "Combat" }
+CustomAttribute.RegisterAttribute { id = "lightbenderloeblocked", text = "Lightbender LoE Blocked", attributeType = "number", category = "Combat" }
 function creature:GetReach()
     return self:CalculateAttribute("reach", self:BaseReach())
 end

--- a/DrawSteelActionBar/DrawSteelActionBar.lua
+++ b/DrawSteelActionBar/DrawSteelActionBar.lua
@@ -2576,6 +2576,28 @@ local function AddModifierLabelsToMarker(markers, sourceToken, targetToken, abil
         end
     end
 
+    -- "Everything the Light Touches": a creature with Lightbender LoE Blocked
+    -- cannot have line of effect to any Lightbender-keyword creature.
+    local function hasLightbenderKeyword(tok)
+        if tok == nil or tok.properties == nil then return false end
+        local kws = tok.properties:Keywords()
+        return kws["Lightbender"] == true
+    end
+    if sourceToken.properties ~= nil
+        and (sourceToken.properties:CalculateNamedCustomAttribute("Lightbender LoE Blocked") or 0) > 0
+        and hasLightbenderKeyword(targetToken)
+    then
+        markers:AddLabel("No Line of Effect", "forbidden")
+        return
+    end
+    if targetToken.properties ~= nil
+        and (targetToken.properties:CalculateNamedCustomAttribute("Lightbender LoE Blocked") or 0) > 0
+        and hasLightbenderKeyword(sourceToken)
+    then
+        markers:AddLabel("No Line of Effect", "forbidden")
+        return
+    end
+
     -- Match the validity check in CalculateSpellTargetFocusing: failReason
     -- fires when distance >= range + unitsPerSquare (i.e. `not (range+1 > d)`).
     -- Draw Steel "free diagonals" makes the 3D distance Chebyshev:


### PR DESCRIPTION
Engine-side hooks for the Lightbender's **Everything the Light Touches** malice feature, rescued from a May 19 stash (the Lua half of the "Add Lightbender Malice ability to codex" work).

## What it does

A creature whose `Lightbender LoE Blocked` custom attribute is above 0 cannot have line of effect to any creature with the **Lightbender** keyword. Only the affected side is blocked (each direction is checked independently), so the Lightbender can still target the affected creature.

- `Draw Steel Core Rules/MCDMCreature.lua` — registers the `Lightbender LoE Blocked` custom attribute (number, Combat category) for ongoing effects to set.
- `Draw Steel Core Rules/DSRuleUtils.lua` — `RuleUtils.HasLineOfEffect` enforces the block in the rules engine.
- `DrawSteelActionBar/DrawSteelActionBar.lua` — the targeting marker shows a "No Line of Effect" forbidden label so the restriction is visible while targeting instead of silently failing.

## Notes

- **Inert until content uses it**: nothing in `compendium/` currently references the attribute, so this changes no behavior on its own. The malice ability / ongoing effect that sets `Lightbender LoE Blocked` needs to exist (in-app or in the compendium) for the feature to be live.
- Applied cleanly onto current main; `luac -p` passes on all three files.