### PR TITLE
feat(roll-dialog): triggers can halve damage for every target of the roll

### DIFF
--- a/Draw Steel UI/DSRollDialog.lua
+++ b/Draw Steel UI/DSRollDialog.lua
@@ -2383,6 +2383,36 @@ function GameHud.CreateRollDialog(self)
                 end
             end
 
+            --A trigger whose powerRollModifier sets applyToAllTargets extends to
+            --every target of the roll, not just the row it was activated on
+            --(e.g. Cannonfall's Buss Buffer: "the damage is halved for the
+            --cannonfall and each target also affected by the triggering
+            --ability"). Mirror only the modifier application onto this row;
+            --cost payment, reroll handling, and triggerInfo bookkeeping stay
+            --with the row that owns the trigger.
+            for otherIndex, other in ipairs(m_multitargets) do
+                if otherIndex ~= index then
+                    for _, trigger in ipairs(other.triggers or {}) do
+                        if trigger.triggered then
+                            local powerRollModifier = trigger.modifier:try_get("powerRollModifier")
+                            if powerRollModifier ~= nil and powerRollModifier:try_get("applyToAllTargets", false) then
+                                powerRollModifier._tmp_trigger = true
+                                powerRollModifier._tmp_triggerCharid = trigger.charid
+                                powerRollModifier:InstallSymbolsFromContext{
+                                    caster = creature,
+                                    target = targetCreature,
+                                }
+                                m_options.modifiers[#m_options.modifiers + 1] = {
+                                    hint = { result = true, justification = {} },
+                                    context = { mod = powerRollModifier },
+                                    modifier = powerRollModifier,
+                                }
+                            end
+                        end
+                    end
+                end
+            end
+
             resultPanel:FireEventTree('prepare', m_options)
             local roll = CalculateRollText {
                 surges = m_multitargets[index].surges or 0,

--- a/Timeline/EmbeddedRollDialog.lua
+++ b/Timeline/EmbeddedRollDialog.lua
@@ -3726,6 +3726,36 @@ function GameHud.CreateEmbeddedRollDialog()
                 end
             end
 
+            --A trigger whose powerRollModifier sets applyToAllTargets extends to
+            --every target of the roll, not just the row it was activated on
+            --(e.g. Cannonfall's Buss Buffer: "the damage is halved for the
+            --cannonfall and each target also affected by the triggering
+            --ability"). Mirror only the modifier application onto this row;
+            --cost payment, reroll handling, and triggerInfo bookkeeping stay
+            --with the row that owns the trigger.
+            for otherIndex, other in ipairs(m_multitargets) do
+                if otherIndex ~= index then
+                    for _, trigger in ipairs(other.triggers or {}) do
+                        if trigger.triggered then
+                            local powerRollModifier = trigger.modifier:try_get("powerRollModifier")
+                            if powerRollModifier ~= nil and powerRollModifier:try_get("applyToAllTargets", false) then
+                                powerRollModifier._tmp_trigger = true
+                                powerRollModifier._tmp_triggerCharid = trigger.charid
+                                powerRollModifier:InstallSymbolsFromContext{
+                                    caster = creature,
+                                    target = targetCreature,
+                                }
+                                m_options.modifiers[#m_options.modifiers + 1] = {
+                                    hint = { result = true, justification = {} },
+                                    context = { mod = powerRollModifier },
+                                    modifier = powerRollModifier,
+                                }
+                            end
+                        end
+                    end
+                end
+            end
+
             -- Re-inject after-roll modifier entries so they survive this recalculation.
             -- The same entry objects are reused, preserving any mod.override values set by the user.
             if m_afterRollModifierEntries ~= nil then


### PR DESCRIPTION
## Summary

Adds an `applyToAllTargets` flag on a power-table trigger's `powerRollModifier`. When a trigger carrying the flag is activated on its own target row in the roll dialog, its modifier application is mirrored onto every other target row of the same power roll.

This implements the Time Raider Cannonfall's **Buss Buffer** free triggered ability: *"the damage is halved for the cannonfall and each target also affected by the triggering ability."* Previously a defender trigger's `damageMultiplier` only affected the row it was activated on (correct for Parry, wrong for Buss Buffer), so only the cannonfall's damage was halved.

## How it works

- In `RecalculateMultiTargets`, after each row applies its own activated triggers, the row also scans the other rows for activated triggers whose `powerRollModifier` sets `applyToAllTargets = true` and appends those modifiers to its own roll computation.
- Only the modifier application is mirrored: cost payment, reroll handling, and `triggerInfo` bookkeeping stay with the row that owns the trigger, so the trigger's cost is paid once.
- Implemented in the live embedded roll dialog (`Timeline/EmbeddedRollDialog.lua`) and mirrored in the legacy dialog (`Draw Steel UI/DSRollDialog.lua`) for parity.

The Buss Buffer trigger itself is bestiary data (powertabletrigger modifier with a Ranged-or-Area ability filter); this PR contains just the engine support.

## Testing

Verified live: Two Throats at Once (Ranged, 2 targets) against Time Raider Armiger 2 + Time Raider Cannonfall 1; activating Buss Buffer during the post-roll trigger window put "N damage (half)" in **both** targets' tier text on the roll message, and both tokens took halved damage. Rolls without the trigger activated, and triggers without the flag (e.g. Parry), are unaffected.