### PR TITLE
feat(abilities): new Lift Into The Air behavior (lift_vertical)

### DIFF
--- a/Draw Steel Ability Behaviors/AbilityFall.lua
+++ b/Draw Steel Ability Behaviors/AbilityFall.lua
@@ -29,6 +29,118 @@ function ActivatedAbilityFallBehavior:EditorItems(parentPanel)
 	return result
 end
 
+--- @class ActivatedAbilityLiftVerticalBehavior:ActivatedAbilityBehavior
+--- Lifts each target straight up into the air by a number of squares (no
+--- horizontal movement, no prompt). The target must be able to fly when this
+--- runs -- pair it with an Ability Duration Effect granting fly earlier in the
+--- same ability. The target's move type is switched to flying so the engine
+--- allows it to rise into open air. When the ability finishes, if the target
+--- can no longer fly (the duration effect has expired), its move type is
+--- restored to a ground type and it falls if still in mid air.
+RegisterGameType("ActivatedAbilityLiftVerticalBehavior", "ActivatedAbilityBehavior")
+
+ActivatedAbility.RegisterType
+{
+	id = 'lift_vertical',
+	text = 'Lift Into The Air',
+	createBehavior = function()
+		return ActivatedAbilityLiftVerticalBehavior.new{
+		}
+	end
+}
+
+ActivatedAbilityLiftVerticalBehavior.summary = 'Lift Into The Air'
+
+--Vertical distance (in squares) each target is lifted, as a GoblinScript
+--formula evaluated against the target.
+ActivatedAbilityLiftVerticalBehavior.distance = "1"
+
+--If true, when the cast finishes any lifted target that can no longer fly is
+--put back on a ground move type and falls if it is still in mid air.
+ActivatedAbilityLiftVerticalBehavior.landAtEnd = true
+
+function ActivatedAbilityLiftVerticalBehavior:Cast(ability, casterToken, targets, options)
+	local liftedTokens = {}
+	for _, target in ipairs(targets) do
+		local tok = target.token
+		if tok ~= nil and tok.valid then
+			local dist = math.floor(tonumber(dmhub.EvalGoblinScript(self.distance, tok.properties:LookupSymbol(options.symbols or {}), string.format("Lift distance for %s", ability.name))) or 0)
+			if dist > 0 and tok.properties:CanFly() then
+				tok.properties:SetAndUploadCurrentMoveType("fly")
+				tok:MoveVertical(tok.floorAltitude + dist)
+				liftedTokens[#liftedTokens+1] = tok
+			end
+		end
+	end
+
+	if #liftedTokens == 0 then
+		return
+	end
+
+	ability:CommitToPaying(casterToken, options)
+
+	if self.landAtEnd then
+		--Runs after earlier behaviors' finish handlers, in particular after an
+		--Ability Duration Effect granting fly has been removed, so CanFly() here
+		--reflects the creature's normal movement.
+		options.OnFinishCastHandlers = options.OnFinishCastHandlers or {}
+		options.OnFinishCastHandlers[#options.OnFinishCastHandlers+1] = function()
+			for _, tok in ipairs(liftedTokens) do
+				if tok.valid and not tok.properties:CanFly() then
+					tok.properties:SetAndUploadCurrentMoveType("walk")
+					tok:TryFall()
+					--TryFall applies the falling rules (fall damage, prone) but treats
+					--a creature hovering only 1 square up as not falling and leaves it
+					--in place; step such a creature down to the ground instead.
+					if tok.valid and tok.altitude > tok.loc.withGroundAltitude.altitude then
+						tok:MoveVertical(tok.loc.withGroundAltitude.altitude)
+					end
+				end
+			end
+		end
+	end
+end
+
+function ActivatedAbilityLiftVerticalBehavior:EditorItems(parentPanel)
+	local result = {}
+	self:ApplyToEditor(parentPanel, result)
+	self:FilterEditor(parentPanel, result)
+
+	result[#result+1] = gui.Panel{
+		classes = {"formPanel"},
+		gui.Label{
+			classes = {"formLabel"},
+			text = "Lift Distance:",
+		},
+		gui.GoblinScriptInput{
+			classes = {"formInput"},
+			value = self.distance,
+			change = function(element)
+				self.distance = element.value
+			end,
+			documentation = {
+				help = "The number of squares each target is lifted straight up into the air. The target must be able to fly for the lift to happen.",
+				output = "number",
+				subject = creature.helpSymbols,
+				subjectDescription = "The creature being lifted",
+				examples = {
+					{ script = "1", text = "Lift the target one square into the air." },
+				},
+			},
+		},
+	}
+
+	result[#result+1] = gui.Check{
+		text = "Land When Ability Ends",
+		value = self.landAtEnd,
+		change = function(element)
+			self.landAtEnd = element.value
+		end,
+	}
+
+	return result
+end
+
 --- @class ActivatedAbilityDigVerticalBehavior:ActivatedAbilityBehavior
 --- The Dig maneuver's movement: the caster chooses a purely vertical distance
 --- (straight up or down through the ground) up to its size, then moves there.


### PR DESCRIPTION
## Summary

Adds `ActivatedAbilityLiftVerticalBehavior` (editor label **Lift Into The Air**, id `lift_vertical`) to `Draw Steel Ability Behaviors/AbilityFall.lua` -- alongside the existing Fall and Dig Vertical behaviors.

The behavior lifts each target straight up into the air by a GoblinScript-evaluated distance (default 1 square), for abilities like Time Raider Tyrannis's **Air Raid!** ("Each target is psionically lifted into the air, flies up to their speed, and makes a free strike. If a target doesn't land in an unoccupied space, they fall.").

## How it works

- The lift only happens if the target can currently fly, so it is meant to be paired with an Ability Duration Effect granting fly earlier in the same ability's behavior list. A walker is never yanked into the air.
- The target's move type is switched to flying before `MoveVertical` -- the engine refuses to raise a token whose current move type can't be airborne (same constraint the Dig behavior documents).
- **Land When Ability Ends** (default on): registers an `OnFinishCastHandlers` entry. Finish handlers run in registration order, so the fly-granting duration effect (an earlier behavior) has already been removed when it runs and `CanFly()` is fresh. For each lifted creature that can no longer fly it restores a ground move type and calls `TryFall()` for a rules-correct fall (fall damage, prone, landing animation).
- `TryFall()` quirk: the engine treats a creature hovering exactly 1 square up as not falling and leaves it parked in mid air (falls only engage at 2+ squares). The handler detects that case and steps the creature down to the ground with `MoveVertical` -- a 1-square drop is within everyone's safe-fall distance, so this is rules-equivalent.

## Editor

`EditorItems` exposes a GoblinScript **Lift Distance** input (documented, with examples) and a **Land When Ability Ends** checkbox, so the behavior is reusable from the ability editor for any future "lifted into the air" ability.

## Testing

Verified live in the Codex on the Air Raid! implementation: fly granted -> lifted to altitude 1 with flying move type -> target flies/free strikes -> on cast finish the fly grant expires, move type returns to walk, and the creature lands (verified both the 1-square step-down and a real `TryFall` drop from 2 squares, which correctly applied the falling rules). Cancelling mid-chain also runs the handlers, so no creature is left floating.