### PR TITLE
feat(forced movement): optional promptText override on forced movement

### DIFF
--- a/DMHub Compendium/ActivatedAbilityEditor.lua
+++ b/DMHub Compendium/ActivatedAbilityEditor.lua
@@ -3003,6 +3003,22 @@ function ActivatedAbilityBehavior:ForcedMovementEditor(parentPanel, list)
 
 		},
 	}
+
+	list[#list+1] = gui.Panel{
+		classes = "formPanel",
+		gui.Label{
+			classes = "formLabel",
+			text = "Prompt Text:",
+		},
+		gui.Input{
+			classes = "formInput",
+			text = self:try_get("promptText", ""),
+			placeholderText = "You may pull the target 4 squares",
+			change = function(element)
+				self.promptText = element.text
+			end,
+		},
+	}
 end
 
 --'half'/'none'

--- a/DMHub Game Rules/ActivatedAbility.lua
+++ b/DMHub Game Rules/ActivatedAbility.lua
@@ -5056,6 +5056,12 @@ ActivatedAbilityForcedMovementBehavior.moveTypeOptions = {
 }
 
 ActivatedAbilityForcedMovementBehavior.moveType = "push"
+
+--Optional override for the prompt shown when the movement resolves. Blank uses the
+--generic "You may push/pull the target N squares". Supports {GoblinScript} formulas
+--and <<range>> for the post-adjustment distance.
+ActivatedAbilityForcedMovementBehavior.promptText = ""
+
 function ActivatedAbilityForcedMovementBehavior:Cast(ability, casterToken, targets, options)
     ability:CommitToPaying(casterToken, options)
 
@@ -5148,6 +5154,15 @@ function ActivatedAbilityForcedMovementBehavior:Cast(ability, casterToken, targe
 
 			local abilityName = "Forced Movement: " .. self.moveType
 			local description = string.format("You may %s the target %d square%s", self.moveType, range, range > 1 and "s" or "")
+
+			--An authored promptText replaces the generic wording. <<range>> resolves to
+			--the distance after Stability and the other adjustments below, so a custom
+			--prompt keeps naming the number of squares the target will actually move.
+			local promptText = self:try_get("promptText", "")
+			if trim(promptText) ~= "" then
+				description = string.gsub(promptText, "<<range>>", string.format("%d", range))
+				description = StringInterpolateGoblinScript(description, casterToken.properties:LookupSymbol{})
+			end
 
 			local abilityAttr = {
 				name = string.gsub(self.moveType, "^%l", string.upper) .. "!",


### PR DESCRIPTION
ActivatedAbilityForcedMovementBehavior built its resolve prompt from a hardcoded `"You may push/pull the target N squares"`, shared by every push and pull in the game, so an ability could not word its own prompt in the language of its rules text.

Adds an optional `promptText` field: blank keeps the generic wording, set replaces it. Supports `{GoblinScript}` interpolation and `<<range>>` for the distance **after** Stability, Big Versus Little and the Forced Movement Increase/Bonus adjustments.

The `<<range>>` substitution has to happen at this site because `MCDMUtils.DeepReplace` runs on the standard-ability clone *before* `abilityAttr` overwrites `description`/`promptOverride`. The `" (Stability: -2)"` suffix is still appended, so a custom prompt naming `<<range>>` stays consistent with it rather than restating the ability's unadjusted distance.

Exposed as a **Prompt Text** input in the ability editor's forced movement section.

Note this only affects the explicit `forcedmovement` behavior. The tier-text (`"pull 5"`) path in `MCDMAbilityBehavior.lua` builds its own identical prompt string and is untouched.

### Testing
- Verified the rendered prompt for the first user, the Time Raider's Gravity Well malice ability: `A creature who ends their turn in the gravity well area is pulled up to <<range>> squares towards the well.` renders as "...up to 4 squares..." normally, and "...up to 2 squares towards the well. (Stability: -2)" against Stability 2.
- Verified a behavior with no `promptText` still produces the generic "You may push the target 3 squares".
- Both files are ASCII-clean and pass `luac -p`; loaded into a running Codex with no errors.

The companion data change (the Gravity Well ability itself) is on `draw-steel-data` main as 7ec33c3.