### PR TITLE
fix(search): deep-link opens the live item, not a soft-deleted namesake

### DIFF
--- a/DMHub Compendium/Compendium.lua
+++ b/DMHub Compendium/Compendium.lua
@@ -437,6 +437,7 @@ local CreateListItem = function(options)
 
 			data = {
 				ord = options.ord,
+				key = options.key,
                 RepeatSearch = function(element)
                     if m_search ~= nil then
                         local libraryPanel = element:FindParentWithClass('library-panel')
@@ -5423,11 +5424,25 @@ local LibraryPanel = function()
 				searchBox:FireEvent("edit")
 			end
 		else
-			local targetName = item.name
-			if targetName ~= nil then
-				target = contentPanel:FindChildRecursive(function(e)
-					return e.valid and e:HasClass("list-item") and not e:HasClass("list-heading") and e.text == targetName
-				end)
+			-- Select the row by its exact key, not its display text. A
+			-- soft-deleted (hidden) item keeps its row in the list (rendered
+			-- collapsed) and, if it shares a name with a live item, a text
+			-- match can press that stale row and open the deleted item. The key
+			-- is unique, so it always selects the row the search result pointed
+			-- at. Fall back to a name match (skipping collapsed/deleted rows)
+			-- for any list page whose rows do not carry a key.
+			target = contentPanel:FindChildRecursive(function(e)
+				return e.valid and e:HasClass("list-item") and not e:HasClass("list-heading")
+					and e.data ~= nil and e.data.key == targetKey
+			end)
+			if target == nil then
+				local targetName = item.name
+				if targetName ~= nil then
+					target = contentPanel:FindChildRecursive(function(e)
+						return e.valid and e:HasClass("list-item") and not e:HasClass("list-heading")
+							and not e:HasClass("collapsed") and e.text == targetName
+					end)
+				end
 			end
 		end
 


### PR DESCRIPTION
## Summary
Global search's compendium deep-link could open a soft-deleted item instead of the live one when the two shared a name. Reported for ongoing effects: delete an effect, create a new one with the same name, search it, and clicking the result kept opening the deleted effect. This selects the target row by its exact table key instead of its display text.

## Changes
- `CreateListItem` now stores the item's table key on each list row's `data` (`key = options.key`).
- `SelectTargetItem`'s non-gear branch matches the row by `e.data.key == targetKey` (the exact key the search result already carried), falling back to a name + `not collapsed` text match only for list pages whose rows don't carry a key.
- The `tbl_Gear` branch already matched by key (`e.data.item.id`) and is unchanged.

## Root cause
Soft delete sets `item.hidden = true`; the row stays in the list rendered `collapsed` but remains a valid child in the panel tree with the same `.text`. The old selector matched by text, so `FindChildRecursive` could return the stale collapsed row first and press it, opening the deleted item. The search result itself was always correct (providers enumerate via `unhidden_pairs` and carry the live item's exact key) - only the final row-selection step discarded that key.

## Testing
Manual, in-app: two ongoing effects named "Vex Test", one deleted. Before: the deep-link opened the deleted one. After: it opens the live one. Verified live in a running Codex after hot-reload.

## Notes for reviewer
Affects any standard `CreateListItem` compendium page reached by deep-link when a soft-deleted entry shares a name with a live one (ongoing effects, conditions, etc.). Pre-existing, unchanged behaviour left alone: `ShowCustomFieldsPanel` (`contentType = "customfields"`) builds raw rows outside `CreateListItem`'s key path, so it still uses the text fallback - harmless there (single entry, no name collisions).