### PR TITLE
Fix ability customisation dialog: section order + per-variation range bonuses

### DIFF
--- a/Draw Steel Core Rules/MCDModifyPowerRolls.lua
+++ b/Draw Steel Core Rules/MCDModifyPowerRolls.lua
@@ -2938,6 +2938,8 @@ CharacterModifier.TypeInfo.abilitycustomisation = {
         local potencyBonus       = data.potencyBonus      or 0
         local damageTypeMappings = data.damageTypeMappings or {}
         local rangeBonus         = data.rangeBonus        or 0
+        local meleeRangeBonus    = data.meleeRangeBonus   or 0
+        local rangedRangeBonus   = data.rangedRangeBonus  or 0
         local burstBonus         = data.burstBonus        or 0
         local cubeBonus          = data.cubeBonus         or 0
         local cubeWithinBonus    = data.cubeWithinBonus   or 0
@@ -2950,7 +2952,8 @@ CharacterModifier.TypeInfo.abilitycustomisation = {
         local hasChange =
             displayName ~= "" or flavorText ~= "" or #variations > 0
             or damageBonus ~= 0 or potencyBonus ~= 0 or hasDamageTypeMappings
-            or rangeBonus ~= 0 or burstBonus ~= 0
+            or rangeBonus ~= 0 or meleeRangeBonus ~= 0 or rangedRangeBonus ~= 0
+            or burstBonus ~= 0
             or cubeBonus ~= 0 or cubeWithinBonus ~= 0
             or lineLengthBonus ~= 0 or lineWidthBonus ~= 0 or lineWithinBonus ~= 0
         if not hasChange then return ability end
@@ -3056,7 +3059,27 @@ CharacterModifier.TypeInfo.abilitycustomisation = {
             end
         else
             -- Melee, ranged, self, etc.: standard range field.
-            if rangeBonus ~= 0 then
+            --
+            -- An ability with both the Melee and Ranged keywords gets bifurcated
+            -- (ActivatedAbility:BifurcateIntoMeleeAndRanged) into separate melee
+            -- and ranged variations for the action bar, each carrying its own
+            -- range. Modifiers run once on the merged ability and once on each
+            -- variation (variation objects are already temporary clones, so
+            -- MakeTemporaryClone -- and the mutations below -- apply in place
+            -- even though the per-variation call's return value is discarded by
+            -- the caller). Prefer the variation-specific bonus so melee and
+            -- ranged can be tuned independently; the merged (non-split) ability
+            -- and any ability without both keywords keeps using the plain
+            -- rangeBonus.
+            if ability:try_get("isMeleeVariation", false) then
+                if meleeRangeBonus ~= 0 then
+                    ability.range = AddBonus(ability.range, meleeRangeBonus * ups, ups)
+                end
+            elseif ability:try_get("isRangedVariation", false) then
+                if rangedRangeBonus ~= 0 then
+                    ability.range = AddBonus(ability.range, rangedRangeBonus * ups, ups)
+                end
+            elseif rangeBonus ~= 0 then
                 ability.range = AddBonus(ability.range, rangeBonus * ups, ups)
             end
         end
@@ -3239,6 +3262,8 @@ function ActivatedAbility:ShowCustomisationDialog(token, parentPanel)
         potencyBonus     = srcData.potencyBonus      or 0,
         damageTypeMappings = DeepCopy(srcData.damageTypeMappings or {}),
         rangeBonus       = srcData.rangeBonus        or 0,
+        meleeRangeBonus  = srcData.meleeRangeBonus   or 0,
+        rangedRangeBonus = srcData.rangedRangeBonus  or 0,
         burstBonus       = srcData.burstBonus        or 0,
         cubeBonus        = srcData.cubeBonus         or 0,
         cubeWithinBonus  = srcData.cubeWithinBonus   or 0,
@@ -3248,6 +3273,12 @@ function ActivatedAbility:ShowCustomisationDialog(token, parentPanel)
     }
 
     local targetType = self:try_get("targetType", "")
+
+    -- An ability with both keywords gets bifurcated into separate melee/ranged
+    -- variations for the action bar (ActivatedAbility:BifurcateIntoMeleeAndRanged),
+    -- each with its own range. When that applies, offer melee- and ranged-specific
+    -- range bonuses instead of one bonus shared by both variations.
+    local isMeleeAndRanged = self:HasKeyword("Melee") and self:HasKeyword("Ranged")
 
     -- Forward declarations (closures below capture these upvalues).
     local dialog
@@ -3271,7 +3302,9 @@ function ActivatedAbility:ShowCustomisationDialog(token, parentPanel)
             and #wd.variations == 0
             and wd.damageBonus == 0 and wd.potencyBonus == 0
             and next(wd.damageTypeMappings) == nil
-            and wd.rangeBonus == 0 and wd.burstBonus == 0
+            and wd.rangeBonus == 0
+            and wd.meleeRangeBonus == 0 and wd.rangedRangeBonus == 0
+            and wd.burstBonus == 0
             and wd.cubeBonus == 0 and wd.cubeWithinBonus == 0
             and wd.lineLengthBonus == 0 and wd.lineWidthBonus == 0
             and wd.lineWithinBonus == 0
@@ -3426,6 +3459,17 @@ function ActivatedAbility:ShowCustomisationDialog(token, parentPanel)
         rangeRows[#rangeRows+1] = s1.panel
         rangeRows[#rangeRows+1] = s2.panel
         rangeRows[#rangeRows+1] = s3.panel
+    elseif isMeleeAndRanged then
+        -- Split into melee- and ranged-specific bonuses so each action-bar
+        -- variation (see BifurcateIntoMeleeAndRanged) can be tuned separately.
+        local s1 = MakeSpinner("Melee Range Bonus:",
+            function() return wd.meleeRangeBonus end, function(v) wd.meleeRangeBonus = v end)
+        local s2 = MakeSpinner("Ranged Range Bonus:",
+            function() return wd.rangedRangeBonus end, function(v) wd.rangedRangeBonus = v end)
+        spinnerSyncs[#spinnerSyncs+1] = s1.sync
+        spinnerSyncs[#spinnerSyncs+1] = s2.sync
+        rangeRows[#rangeRows+1] = s1.panel
+        rangeRows[#rangeRows+1] = s2.panel
     else
         local s = MakeSpinner("Range Bonus:",
             function() return wd.rangeBonus end, function(v) wd.rangeBonus = v end)
@@ -3445,6 +3489,8 @@ function ActivatedAbility:ShowCustomisationDialog(token, parentPanel)
         wd.potencyBonus     = 0
         wd.damageTypeMappings = {}
         wd.rangeBonus       = 0
+        wd.meleeRangeBonus  = 0
+        wd.rangedRangeBonus = 0
         wd.burstBonus       = 0
         wd.cubeBonus        = 0
         wd.cubeWithinBonus  = 0

--- a/Draw Steel Core Rules/MCDModifyPowerRolls.lua
+++ b/Draw Steel Core Rules/MCDModifyPowerRolls.lua
@@ -3736,13 +3736,17 @@ function ActivatedAbility:ShowCustomisationDialog(token, parentPanel)
         },
     }
 
-    -- Construct the dialog panel from the assembled children list.
-    local dialogProps = {
+    -- Construct the framed panel from the assembled children list.
+    --
+    -- Centering (halign/valign) and floating live on an OUTER wrapper, NOT on
+    -- this framed panel. Setting halign on a panel scrambles the order of that
+    -- panel's own children in the engine's layout (an ordering side-effect that
+    -- pushed sections like the range spinners or Character Speech below the
+    -- action buttons). Keeping halign off the framed panel preserves the child
+    -- order; the wrapper positions the dialog on screen instead.
+    local framedProps = {
         styles    = ThemeEngine.GetStyles(),
         classes   = {"framedPanel"},
-        floating  = true,
-        halign    = "center",
-        valign    = "center",
         width     = 540,
         height    = "auto",
         flow      = "vertical",
@@ -3750,9 +3754,18 @@ function ActivatedAbility:ShowCustomisationDialog(token, parentPanel)
         borderBox = true,
     }
     for i, child in ipairs(dChildren) do
-        dialogProps[i] = child
+        framedProps[i] = child
     end
-    dialog = gui.Panel(dialogProps)
+    local framedPanel = gui.Panel(framedProps)
+
+    dialog = gui.Panel{
+        floating = true,
+        halign   = "center",
+        valign   = "center",
+        width    = "auto",
+        height   = "auto",
+        framedPanel,
+    }
 
     return dialog
 end


### PR DESCRIPTION
This PR contains two related fixes to the ability **Customize** dialog (`ActivatedAbility:ShowCustomisationDialog`).

## 1. Fix section order in the dialog

### Problem

One section (the Range spinners, or the Character Speech input) rendered **below** the Save / Cancel / Reset All buttons instead of in its list position. Which section drifted depended on the ability's target type.

### Root cause

The dialog set `halign="center"` on the same framed panel that held all its sections. Setting `halign` on a panel scrambles the order of that panel's own children in the engine's layout, so a section got pushed past the action buttons.

Isolated by bisecting the dialog's panel properties live: removing `halign` was the only change that restored correct child order.

### Fix

Move the centering (`halign`/`valign`) and `floating` onto a thin **outer wrapper** panel. The framed content panel no longer sets `halign`, so its child order is preserved; the wrapper positions the dialog on screen.

### Testing

Verified live in a running Codex. Child order read back from the real dialog, with the button row confirmed last in every case:

| Ability | Target type | Result |
|---|---|---|
| Flamebelcher (War Dog) | line | Range -> Length / Width / Within -> Character Speech -> buttons |
| Toxic Winds (Stinker) | cube | Range -> Cube Size / Within -> Character Speech -> buttons |
| Ranged Free Strike (Assassin) | ranged | Range -> Range Bonus -> Character Speech -> buttons |

Screenshot confirmed the dialog still renders centered with the buttons anchored at the bottom.

## 2. Separate melee/ranged range bonuses for dual-keyword abilities

### Problem

An ability with both the **Melee** and **Ranged** keywords gets bifurcated (`ActivatedAbility:BifurcateIntoMeleeAndRanged`) into separate melee and ranged variations for the action bar, each with its own range -- but the customisation dialog only offered a single "Range Bonus" shared by both.

### Fix

When an ability has both keywords, the dialog now shows **"Melee Range Bonus"** and **"Ranged Range Bonus"** instead of one shared control, so each split action-bar entry can be tuned independently. Abilities without both keywords are unaffected and keep the single shared "Range Bonus" control.

In `modifyAbility`, the bonus applied is chosen by which variation is being processed (`isMeleeVariation`/`isRangedVariation`); the merged (non-split) ability and any ability without both keywords still uses the plain `rangeBonus`.

### Testing

Verified live:
- Melee/ranged bonuses land independently on each variation through the real bifurcate + modifier pipeline (e.g. `+2`/`+10` on a `1`/`5` base -> `3`/`15`).
- The dialog shows the correct spinner(s) for dual-keyword vs single-keyword abilities.
- The save/reload round-trip through `token.properties.abilityCustomisations` restores the values correctly.
- Both changes verified together: dialog child order is correct (buttons last) with the new melee/ranged spinners in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)