### PR TITLE
Invoked abilities with a prompt and resolved targets require confirmation instead of silently casting

### DIFF
--- a/DrawSteelActionBar/DrawSteelActionBar.lua
+++ b/DrawSteelActionBar/DrawSteelActionBar.lua
@@ -5121,8 +5121,25 @@ CreateAbilityController = function()
             --instantCast means the invoke already resolved its targets (AI prompt
             --handler or scripted resolution): cast as soon as targeting is satisfied
             --instead of waiting for a manual press of the cast button.
+            --Exception: an invoke that arrives with token targets already packaged
+            --AND a prompt question attached (promptText -> promptOverride) has no
+            --further input to collect, so instant-casting would fire it with ZERO
+            --player interaction -- the prompt text is never seen and any resource
+            --cost (e.g. "2 Malice: ...") is spent silently. Require the confirm
+            --press for those. Destination-style invokes (no packaged token targets)
+            --keep instant cast: their remaining input is the destination pick, and
+            --the prompt shows as instructions during it.
             if options.instantCast then
-                ability.castImmediately = true
+                local packagedTokenTargets = false
+                for _, target in ipairs(options.targets or {}) do
+                    if target.token ~= nil then
+                        packagedTokenTargets = true
+                        break
+                    end
+                end
+                if not (packagedTokenTargets and ability:try_get("promptOverride") ~= nil) then
+                    ability.castImmediately = true
+                end
             end
             CharacterPanel.DisplayAbility(casterToken, ability)
             CharacterPanel.HighlightAbilitySection{


### PR DESCRIPTION
## Problem

Invoke behaviors using `inherit` targeting arrive at the action bar with token targets fully resolved and `instantCast` set, so they cast with **zero player interaction**. When the invoke also carries a `promptText`, that text is never shown and any resource cost on the invoked ability is spent silently.

Hit in practice on the Angulotl Needler's Blowgun "2 Malice" rider (ticket WRVSWTH7), and an audit found the same silent-cast on the Rival Fury signature riders (all four variants), Manticore Tail Spike (innate + the copy nested in Cornered Predator), and `promptText` being dead text on ~30 other shipped `inherit` invokes.

## Fix

The action bar's `invokeAbility` handler now only honors `instantCast` when the invoke either has no prompt question or still has player input to collect:

- **Packaged token targets + promptText** -> wait for the confirm press. The prompt shows with the inherited targets locked and preselected: confirm-with-cost / skip.
- **No promptText** (scripted chains like Trample's per-target strikes) -> instant cast, exactly as before.
- **Destination-style invokes** (no packaged token targets, e.g. prompted shifts) -> instant cast as before; their remaining input is the destination pick, with the prompt text shown as instructions.

## Design rationale

This keeps the targeting modes meaning what they say:

- `inherit` = the invoked ability gets exactly the parent's targets; `promptText` decides whether there's a confirm/skip gate before it fires.
- `prompt_inherit` = the player genuinely picks a subset of the inherited targets ("1 of the 4 hit") -- untouched by this PR.

(An earlier revision of this PR instead added target preselection to `prompt_inherit`; that blurred the two modes and was dropped in favor of this action-bar-side gate.)

## Testing

The silent-cast reproduction was confirmed live on Needler Blowgun and Rival Fury Brutal Impact (console shows the invoked rider casting and applying its condition with no prompt). The corresponding data fix re-authors those riders as `inherit` + malice-gated promptText with target-typed invoked abilities; live retest of the confirm/skip flow under this change is in progress and results will be noted in a comment.