### PR TITLE
fix(audio): remove load gate that blocked game-mode music bindings from saving

### DIFF
--- a/DMHub Core Panels/Audio.lua
+++ b/DMHub Core Panels/Audio.lua
@@ -759,7 +759,10 @@ end
 -- Shape: doc.data = { enabled = bool, modes = { <modeid> = <playlistid> } }.
 -- WRITE-ONLY-ON-EXPLICIT-DM-ACTION: there is NO seed and no normalize-on-load, so
 -- an empty read is always safe (default "nothing bound") and the seed-on-empty PUT
--- trap cannot occur. Writes are still gated on gameLoadingProgress >= 1.
+-- trap cannot occur. Every write below is a DM click in a panel that cannot even be
+-- opened while the game is loading, so they carry NO load gate -- see the note on the
+-- dropdown handler for why gating them on dmhub.gameLoadingProgress broke saving
+-- outright (report 6UMTQEEE).
 local audioPlaylistBindingsDocId = "audioPlaylistBindings"
 mod:RegisterDocumentForCheckpointBackups(audioPlaylistBindingsDocId)
 
@@ -9895,8 +9898,16 @@ local function CreateGameModeMusicBody()
 					valign = "center",
 					options = SortedPlaylistOptions(),
 					idChosen = (bindings.modes or {})[modeid] or "none",
+					--NO load gate here. This used to early-out on
+					--dmhub.gameLoadingProgress < 1, which silently dropped every
+					--binding the DM set (report 6UMTQEEE). gameLoadingProgress is not
+					--a state flag: it is a smoothed value that only advances 10% per
+					--READ (GameController.loadingProgress), and the only thing that
+					--reads it is the loading screen's think. That screen is destroyed
+					--~0.4s after the Complete milestone -- often before the value has
+					--had the ~21 reads it needs to cross the 0.99 clamp -- after which
+					--nothing reads it again and it sits below 1 for the whole session.
 					change = function(element)
-						if (dmhub.gameLoadingProgress or 0) < 1 then return end
 						local doc = GetBindingsDoc()
 						doc:BeginChange()
 						if doc.data.modes == nil then
@@ -9938,8 +9949,8 @@ local function CreateGameModeMusicBody()
 		gui.Check{
 			text = "Change music with the game mode",
 			value = bindings.enabled == true,
+			--No load gate -- same reasoning as the mode dropdowns above.
 			change = function(element)
-				if (dmhub.gameLoadingProgress or 0) < 1 then return end
 				local doc = GetBindingsDoc()
 				doc:BeginChange()
 				doc.data.enabled = element.value


### PR DESCRIPTION
## Summary

The Audio Studio's "Game mode music" bindings never saved: playlists assigned to game modes and the auto-play checkbox reset to defaults on reopen, and changing game modes never started music. Both write handlers were gated on `dmhub.gameLoadingProgress >= 1`, which can sit below 1 for an entire session, so every DM click silently no-op'd. This removes both gates.

## Changes

- Remove the `dmhub.gameLoadingProgress` early-return from the game-mode dropdown `change` handler and from the "Change music with the game mode" checkbox (`DMHub Core Panels/Audio.lua`)
- Update the `audioPlaylistBindings` banner comment, which still claimed writes were load-gated, and document why the gate was wrong so it doesn't get re-added

## Root cause

`dmhub.gameLoadingProgress` is not a boolean-ish state flag. `GameController.loadingProgress` is a smoothed value that advances 10% *per read*, and the only consumer pumping it is the loading screen's `think`. That screen is destroyed ~0.4s after the `Complete` milestone -- frequently before the value has had the ~21 reads it needs to cross the `0.99` clamp. If it comes up short, nothing ever reads it again and it stays below 1 for the whole session.

The titlescreen's other uses are safe because they poll *until* the value satisfies them, so they pump it themselves. The rule: safe to wait on in a loop, never safe to branch on once.

The gate was carried over from `e1f18458 fix(audio): gate starter-playlist seeding on game fully loaded`, where it protected an *automatic* on-load write. Seeding was removed in the object-table refactor, and these two sites are explicit DM clicks in a panel that cannot be opened during load -- so the gate protected nothing and only blocked legitimate writes.

## Verification

- Confirmed against a reporter's live game: the `audioPlaylistBindings` document does not exist, while `audioPlaylistState` and `audioMix` -- same file, same mod, same `BeginChange`/`CompleteChange` mechanism -- persist correctly. So the storage layer is fine.
- Their client log shows 88 `PutData` + 16 `PatchData` operations with zero mentioning `audioPlaylistBindings`, and no Lua error from `Audio.lua`. The write was never attempted, not rejected.
- Manually: bind playlists to modes, tick auto-play, close and reopen the popover (values persist), then change game mode and confirm playback starts and the previous audio restores on leaving. Deleting a bound playlist still clears its binding.

## Notes for reviewer

Lua-only; F5 picks it up. No data repair needed for affected games -- the document was never created, so DMs just re-set their bindings.

Two engine-side follow-ups came out of this that are **not** in this PR: (1) `GameController.loadingProgress` should return a hard `1.0` once the `Complete` milestone is reached rather than relying on ~21 more polls, and (2) `Game`-storage settings don't bump `nupdates` on a remote patch, so `monitor`/`onchange` never fire for changes made by another client -- which is why the ducking checkbox next door has to `think`-poll. Happy to raise those separately.

Fixes report `6UMTQEEE`.
