### PR TITLE
Floors: auto-hide on selection, floor up/down keybinds, and player look-up

### DIFF
--- a/DMHub Core Panels/Commands.lua
+++ b/DMHub Core Panels/Commands.lua
@@ -179,6 +179,24 @@ Commands.RegisterMacro{
 }
 
 Commands.RegisterMacro{
+    name = "floorup",
+    summary = "go up a floor",
+    doc = "Switches the active floor to the next floor up. If the 'Auto-hide floors above the selected floor' setting is on, reveals floors up to it and hides floors above it.",
+    command = function()
+        FloorNavigation.ChangeFloorRelative(1)
+    end,
+}
+
+Commands.RegisterMacro{
+    name = "floordown",
+    summary = "go down a floor",
+    doc = "Switches the active floor to the next floor down. If the 'Auto-hide floors above the selected floor' setting is on, reveals floors up to it and hides floors above it.",
+    command = function()
+        FloorNavigation.ChangeFloorRelative(-1)
+    end,
+}
+
+Commands.RegisterMacro{
     name = "next",
     summary = "cycle between tokens",
     doc = "Cycles between controllable tokens. Prioritizes tokens whose turn it is in initiative.",

--- a/DMHub Core Panels/Commands.lua
+++ b/DMHub Core Panels/Commands.lua
@@ -181,7 +181,7 @@ Commands.RegisterMacro{
 Commands.RegisterMacro{
     name = "floorup",
     summary = "go up a floor",
-    doc = "Switches the active floor to the next floor up. If the 'Auto-hide floors above the selected floor' setting is on, reveals floors up to it and hides floors above it.",
+    doc = "For the director, switches the active floor to the next floor up; if the 'Auto-hide floors above the selected floor' setting is on, reveals floors up to it and hides floors above it. For a player, looks up one more floor (Forward -> Up 1 -> Up 2 ...), as far as the map's Look Up rules allow.",
     command = function()
         FloorNavigation.ChangeFloorRelative(1)
     end,
@@ -190,7 +190,7 @@ Commands.RegisterMacro{
 Commands.RegisterMacro{
     name = "floordown",
     summary = "go down a floor",
-    doc = "Switches the active floor to the next floor down. If the 'Auto-hide floors above the selected floor' setting is on, reveals floors up to it and hides floors above it.",
+    doc = "For the director, switches the active floor to the next floor down; if the 'Auto-hide floors above the selected floor' setting is on, reveals floors up to it and hides floors above it. For a player, looks down one floor back toward Forward (Up 2 -> Up 1 -> Forward).",
     command = function()
         FloorNavigation.ChangeFloorRelative(-1)
     end,

--- a/DMHub Core Panels/Floors.lua
+++ b/DMHub Core Panels/Floors.lua
@@ -53,6 +53,164 @@ local function FindMapObjectForFloor(floor)
 	return nil
 end
 
+--Setting: when on (the default), selecting or navigating to a floor auto-reveals it and
+--everything below it and hides everything above it. When off, switching floors leaves
+--floor visibility untouched (the classic behaviour).
+setting{
+	id = "autofloorvisibility",
+	description = "Auto-hide floors above the selected floor",
+	help = "When you select a floor (or use the floor up/down keys), automatically reveal that floor and every floor below it and hide every floor above it. Turn this off to leave floor visibility unchanged when you switch floors.",
+	storage = "preference",
+	section = "Map",
+	editor = "check",
+	default = true,
+}
+
+--Floor navigation and auto-visibility, shared by the Floors & Layers panel (floor row
+--clicks) and the floor up/down keybinds (macros in Commands.lua, key bindings in
+--Keybinds.lua). Registered as a game type so it is a well-formed global namespace in every
+--load context (a bare global assignment trips the strict-global guard on some reload paths).
+RegisterGameType("FloorNavigation")
+
+--The live Floors & Layers list panel, if one is open. The panel registers itself here when
+--built (see CreateLayersPanel) so keybind-driven navigation can refresh its eye icons the
+--same way a floor-row click does. Forward-declared here so both ChangeFloorRelative (below)
+--and CreateLayersPanel (further down) close over the same upvalue.
+local g_floorsListPanel = nil
+
+--Refresh the open Floors & Layers list (eye icons, selection, etc.) if there is one.
+local function RefreshFloorsListPanel()
+	if g_floorsListPanel ~= nil and g_floorsListPanel.valid then
+		g_floorsListPanel:FireEventTree("refreshGame")
+	end
+end
+
+--Whether the auto-hide-on-select behaviour is currently enabled.
+function FloorNavigation.AutoVisibilityEnabled()
+	return dmhub.GetSettingValue("autofloorvisibility") ~= false
+end
+
+--Reveal selectedFloor and every floor BELOW it and hide every floor ABOVE it. Floors are
+--stored in currentMap.floors in ascending altitude order (a higher array index is a
+--higher floor), so "below" is a lower index and "above" is a higher index. Only top-level
+--floors (parentFloor == nil) carry the visibility toggle, so those are the only rows
+--changed; if the selection is a layer we compare against its parent floor's position.
+--Floors whose visibility already matches are left untouched, so no redundant uploads are
+--made. Editing floor visibility is a director capability, so this no-ops for players.
+function FloorNavigation.ApplyVisibility(currentMap, selectedFloor)
+	if not dmhub.isDM then
+		return
+	end
+
+	if currentMap == nil or selectedFloor == nil then
+		return
+	end
+
+	local floors = currentMap.floors
+	if floors == nil then
+		return
+	end
+
+	--The selected floor's top-level identity (a layer maps to its parent floor).
+	local refId = selectedFloor.floorid
+	if selectedFloor.parentFloor ~= nil then
+		refId = selectedFloor.parentFloor
+	end
+
+	local selIndex = nil
+	for i, f in ipairs(floors) do
+		if f.floorid == refId then
+			selIndex = i
+			break
+		end
+	end
+
+	if selIndex == nil then
+		return
+	end
+
+	for i, f in ipairs(floors) do
+		if f.parentFloor == nil then
+			--At or below the selection -> visible; above -> hidden.
+			local shouldHide = i > selIndex
+			if f.floorInvisible ~= shouldHide then
+				f.floorInvisible = shouldHide
+			end
+		end
+	end
+end
+
+--Move the active floor up (offset +1) or down (offset -1) among the top-level floors,
+--clamping at the top and bottom. Applies the auto-hide behaviour when the setting is on.
+--Used by the floor up/down keybinds. Floor management is a director tool, so this is a
+--no-op for players.
+function FloorNavigation.ChangeFloorRelative(offset)
+	if not dmhub.isDM then
+		return
+	end
+
+	local currentMap = game.currentMap
+	if currentMap == nil then
+		return
+	end
+
+	local floors = currentMap.floors
+	if floors == nil then
+		return
+	end
+
+	--Top-level floors in ascending altitude order.
+	local topFloors = {}
+	for _, f in ipairs(floors) do
+		if f.parentFloor == nil then
+			topFloors[#topFloors + 1] = f
+		end
+	end
+
+	if #topFloors == 0 then
+		return
+	end
+
+	local cf = game.currentFloor
+	if cf == nil then
+		return
+	end
+
+	--The current floor's top-level identity (a layer maps to its parent floor).
+	local refId = cf.floorid
+	if cf.parentFloor ~= nil then
+		refId = cf.parentFloor
+	end
+
+	local curPos = nil
+	for pos, f in ipairs(topFloors) do
+		if f.floorid == refId then
+			curPos = pos
+			break
+		end
+	end
+
+	if curPos == nil then
+		return
+	end
+
+	local newPos = curPos + offset
+	if newPos < 1 or newPos > #topFloors then
+		--Already at the top or bottom floor.
+		return
+	end
+
+	local targetFloor = topFloors[newPos]
+	game.ChangeMap(currentMap, targetFloor)
+
+	if FloorNavigation.AutoVisibilityEnabled() then
+		FloorNavigation.ApplyVisibility(currentMap, targetFloor)
+		--Redraw the panel's eye icons to match the new visibility (the click path does the
+		--same). Without this the icons go stale when navigating by keybind.
+		RefreshFloorsListPanel()
+	end
+end
+
 --Custom themed styling for the map-appearance gallery tiles. Hover/selected states live in the style
 --cascade (not inline) so they can flip on mouse-over and recolor with the active scheme. Colors use
 --@tokens so the highlight tracks the user's color scheme.
@@ -1760,6 +1918,11 @@ CreateLayersPanel = function()
 
 								if game.currentFloor.actualFloor ~= floor.floorid then
 									game.ChangeMap(game.currentMap, floor)
+									--Reveal this floor and everything below it; hide everything above.
+									if FloorNavigation.AutoVisibilityEnabled() then
+										FloorNavigation.ApplyVisibility(game.currentMap, floor)
+										floorsList:FireEventTree("refreshGame")
+									end
 									element:FindParentWithClass("dockablePanel"):FireEventTree("refreshFloorSelection")
 								end
 							end,
@@ -1831,6 +1994,9 @@ CreateLayersPanel = function()
 			floorItems = newFloorItems
 		end,
 	}
+
+	--Expose this list so keybind-driven floor navigation can refresh its eye icons.
+	g_floorsListPanel = floorsList
 
 	local resultPanel
 

--- a/DMHub Core Panels/Floors.lua
+++ b/DMHub Core Panels/Floors.lua
@@ -140,12 +140,61 @@ function FloorNavigation.ApplyVisibility(currentMap, selectedFloor)
 	end
 end
 
+--When a player uses the floor up/down keybind they do not move the active floor (that is a
+--director tool). Instead they "look up" through the floors above their selected token -- the
+--same Forward / Up 1 / Up 2 control offered by the eye icon on the character panel, driven by
+--the transient "lookup" setting (0 = Forward, 1 = Up 1, ...). Offset +1 looks one floor
+--higher, offset -1 drops back toward Forward. The view is clamped between Forward (0) and the
+--number of floors the token may look up, which mirrors the character panel: it depends on the
+--map's "Can Look Up" (canlookup) and "Max Look Up" (maxlookup) settings and, under "opening",
+--whether there is a hole above the token.
+function FloorNavigation.LookRelative(offset)
+	local tok = dmhub.currentToken
+	if tok == nil then
+		return
+	end
+
+	local canLookup = dmhub.GetSettingValue("canlookup")
+	if canLookup == "never" then
+		return
+	end
+
+	local maxLookup
+	if canLookup == "always" then
+		maxLookup = tok.countFloorsAbove
+	else
+		maxLookup = tok.countFloorsWithVisionAbove
+	end
+
+	local maxLookupSetting = dmhub.GetSettingValue("maxlookup")
+	if maxLookupSetting >= 0 then
+		maxLookup = math.min(maxLookup, maxLookupSetting)
+	end
+
+	if maxLookup <= 0 then
+		return
+	end
+
+	local cur = dmhub.GetSettingValue("lookup")
+	local newValue = cur + offset
+	if newValue < 0 then
+		newValue = 0
+	elseif newValue > maxLookup then
+		newValue = maxLookup
+	end
+
+	if newValue ~= cur then
+		dmhub.SetSettingValue("lookup", newValue)
+	end
+end
+
 --Move the active floor up (offset +1) or down (offset -1) among the top-level floors,
 --clamping at the top and bottom. Applies the auto-hide behaviour when the setting is on.
---Used by the floor up/down keybinds. Floor management is a director tool, so this is a
---no-op for players.
+--Used by the floor up/down keybinds. Moving the active floor is a director tool; for players
+--the same keybind instead adjusts the "look up" view (see LookRelative above).
 function FloorNavigation.ChangeFloorRelative(offset)
 	if not dmhub.isDM then
+		FloorNavigation.LookRelative(offset)
 		return
 	end
 

--- a/DMHub Game Hud/Keybinds.lua
+++ b/DMHub Game Hud/Keybinds.lua
@@ -384,9 +384,13 @@ Keybinds.Register{
     section = "system",
 }
 
+--Rows in each keybind section sort by "ord" (falling back to name). "Go Down a Floor"
+--would otherwise sort above "Go Up a Floor" alphabetically, so give them explicit ords to
+--list Up above Down.
 Keybinds.Register{
     command = "floorup",
     name = tr("Go Up a Floor"),
+    ord = "Go 1",
     dmonly = true,
     section = "camera",
 }
@@ -394,6 +398,7 @@ Keybinds.Register{
 Keybinds.Register{
     command = "floordown",
     name = tr("Go Down a Floor"),
+    ord = "Go 2",
     dmonly = true,
     section = "camera",
 }

--- a/DMHub Game Hud/Keybinds.lua
+++ b/DMHub Game Hud/Keybinds.lua
@@ -384,6 +384,61 @@ Keybinds.Register{
     section = "system",
 }
 
+Keybinds.Register{
+    command = "floorup",
+    name = tr("Go Up a Floor"),
+    dmonly = true,
+    section = "camera",
+}
+
+Keybinds.Register{
+    command = "floordown",
+    name = tr("Go Down a Floor"),
+    dmonly = true,
+    section = "camera",
+}
+
+Keybinds.Register{
+    command = "toggle vision:shared",
+    name = tr("Toggle Players Shared Vision"),
+    dmonly = true,
+    section = "gameplay",
+}
+
+Keybinds.Register{
+    command = "toggle autofloorvisibility",
+    name = tr("Toggle Auto-hide Floors"),
+    dmonly = true,
+    section = "camera",
+}
+
+--Internal flag tracking whether the one-time default floor-navigation keybindings have
+--been applied. Sectionless/editorless so it does not appear in the settings UI.
+setting{
+    id = "floornav:defaultbindingsapplied",
+    description = "Floor navigation default keybindings applied",
+    storage = "preference",
+    default = false,
+}
+
+--Apply the default Page Up / Page Down bindings for floor navigation once. Doing it once
+--(guarded by the flag above) means a user's later customisation -- including deliberately
+--clearing these -- is not overwritten on subsequent launches. Page Up / Page Down are
+--bound to diagonal token movement out of the box; floor navigation intentionally takes
+--them over (both remain rebindable in the keybinds UI). We still skip the assignment if
+--floor navigation is already bound, so an existing user choice is never overwritten.
+if dmhub.GetSettingValue("floornav:defaultbindingsapplied") ~= true then
+    dmhub.SetSettingValue("floornav:defaultbindingsapplied", true)
+
+    if dmhub.GetCommandBinding("floorup") == nil then
+        dmhub.SetCommandBinding("page up", "floorup")
+    end
+
+    if dmhub.GetCommandBinding("floordown") == nil then
+        dmhub.SetCommandBinding("page down", "floordown")
+    end
+end
+
 
 local g_KeybindStyles = {
     {

--- a/DMHub Game Hud/Keybinds.lua
+++ b/DMHub Game Hud/Keybinds.lua
@@ -417,33 +417,6 @@ Keybinds.Register{
     section = "camera",
 }
 
---Internal flag tracking whether the one-time default floor-navigation keybindings have
---been applied. Sectionless/editorless so it does not appear in the settings UI.
-setting{
-    id = "floornav:defaultbindingsapplied",
-    description = "Floor navigation default keybindings applied",
-    storage = "preference",
-    default = false,
-}
-
---Apply the default Page Up / Page Down bindings for floor navigation once. Doing it once
---(guarded by the flag above) means a user's later customisation -- including deliberately
---clearing these -- is not overwritten on subsequent launches. Page Up / Page Down are
---bound to diagonal token movement out of the box; floor navigation intentionally takes
---them over (both remain rebindable in the keybinds UI). We still skip the assignment if
---floor navigation is already bound, so an existing user choice is never overwritten.
-if dmhub.GetSettingValue("floornav:defaultbindingsapplied") ~= true then
-    dmhub.SetSettingValue("floornav:defaultbindingsapplied", true)
-
-    if dmhub.GetCommandBinding("floorup") == nil then
-        dmhub.SetCommandBinding("page up", "floorup")
-    end
-
-    if dmhub.GetCommandBinding("floordown") == nil then
-        dmhub.SetCommandBinding("page down", "floordown")
-    end
-end
-
 
 local g_KeybindStyles = {
     {

--- a/DMHub Game Hud/Keybinds.lua
+++ b/DMHub Game Hud/Keybinds.lua
@@ -387,11 +387,13 @@ Keybinds.Register{
 --Rows in each keybind section sort by "ord" (falling back to name). "Go Down a Floor"
 --would otherwise sort above "Go Up a Floor" alphabetically, so give them explicit ords to
 --list Up above Down.
+--Not dmonly: the director uses these to move the active floor, and a player uses the same
+--keybind to look up/down through the floors above their token (see FloorNavigation in
+--Floors.lua). The command itself branches on dmhub.isDM.
 Keybinds.Register{
     command = "floorup",
     name = tr("Go Up a Floor"),
     ord = "Go 1",
-    dmonly = true,
     section = "camera",
 }
 
@@ -399,7 +401,6 @@ Keybinds.Register{
     command = "floordown",
     name = tr("Go Down a Floor"),
     ord = "Go 2",
-    dmonly = true,
     section = "camera",
 }
 


### PR DESCRIPTION
## Summary

Adds auto floor visibility on floor selection, floor up/down keybinds for the director, and a player "look up" binding, plus a toggle setting and a couple of newly bindable commands.

## What's included

- **Auto-hide floors on selection** (setting `autofloorvisibility`, default on, in the Map settings section). Selecting a floor, or using the floor up/down keys, reveals that floor and every floor below it and hides every floor above it. Turn it off for the classic behavior.
- **Floor up/down keybinds** (`floorup` / `floordown`, "Go Up a Floor" / "Go Down a Floor" in the Camera section). For the **director** they move the active floor (applying the auto-hide behavior when the setting is on). For a **player** the same keybind drives the existing "Look up" view, the same Forward / Up 1 / Up 2 control offered by the eye icon on the character panel: `FloorNavigation.LookRelative` steps the transient `lookup` setting and clamps between Forward and the token's allowed max (governed by the map's `canlookup` / `maxlookup` settings and `countFloorsAbove` / `countFloorsWithVisionAbove`).
- **Eye icons stay in sync** when navigating floors by keybind (the open Floors & Layers panel registers itself so keybind-driven navigation refreshes its icons the same way a row click does).
- **Newly bindable commands**: "Toggle Players Shared Vision" (`toggle vision:shared`) and "Toggle Auto-hide Floors" (`toggle autofloorvisibility`).
- Floor up/down ship **unbound** so the engine can set its own default.

## Notes

- `FloorNavigation` is registered via `RegisterGameType` so it is a well-formed global namespace in every load context.
- Editing floor visibility is a director capability, so `ApplyVisibility` no-ops for players; the player path only adjusts their own `lookup` view.

## Testing

Verified live in DMHub: no load errors on reload; auto-hide reveals/hides the correct floors on both row click and keybind, with eye icons updating; player look-up clamps correctly (Forward -> Up 1 -> Up 2 -> clamp, then back down to Forward -> clamp).

Generated with Claude Code
