### PR TITLE
Fix crash when splitting a creature into an initiative grouping (report CE6YRTH4)

### DIFF
--- a/Draw Steel Core Rules/MCDMCreature.lua
+++ b/Draw Steel Core Rules/MCDMCreature.lua
@@ -6671,9 +6671,9 @@ local function GroupingHud(groupid)
             end,
         }
 
-        m_sheet:FireEvent("think")
-
         sheetParent.sheet = m_sheet
+
+        m_sheet:FireEvent("think")
     end
 end
 


### PR DESCRIPTION
**Symptom:** "everytime you split the slime it crashes my ggame lol" - splitting a Creeping Sludge hard-crashes the client.

**Root cause:** Splitting summons a duplicate, which runs `game.UpdateCharacterTokens()` -> `creature:RefreshToken` -> `RefreshInitiativeGrouping` -> `GroupingHud`. `GroupingHud` built the grouping sheet and fired its `think` event *before* attaching the sheet to the world-space container:

```lua
m_sheet:FireEvent("think")

sheetParent.sheet = m_sheet
```

That `think` handler calls `sheetParent:DestroySelf()` and returns whenever its recount reaches `count <= 1`. `LuaSheetContainer.Destroy()` sets `rectTransform` to null, so the very next line's `sheetParent.sheet` setter called `SheetPanel.PlaceWithinParent(null)` and dereferenced `parentRt.rect` -> NullReferenceException. In the shipped 0.0.787 client that managed exception unwinds through native lua54 frames and takes down the process (the crash log shows the NRE at `LuaSheetContainer.set_sheet` -> `SheetPanel.PlaceWithinParent` immediately before `Crash!!!`).

**Fix:** Swap the two statements so the sheet is attached to the container before the first `think` fires. If that first `think` does destroy the container, the container's own `DestroySheet()` now disposes the already-attached panel - the same path taken every steady-state frame once the HUD is mounted - so nothing is orphaned and no NRE occurs. Both statements still run in the same Lua call before the frame renders, so there is no visual change. This also matches the order the sibling squad HUD in `Draw Steel Core Rules/MCDMMinion.lua` already uses.

Report id: CE6YRTH4

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
