### PR TITLE
Fix inverted Persistent Magic prompt instruction (report TZM974A6)

### DIFF
--- a/Draw Steel Ability Behaviors/AbilityPersistentCast.lua
+++ b/Draw Steel Ability Behaviors/AbilityPersistentCast.lua
@@ -167,7 +167,7 @@ function ActivatedAbilityPersistenceControlBehavior:Cast(ability, casterToken, t
 
     mainChildren[#mainChildren+1] = gui.Label{
         classes = {"persist-instruction"},
-        text = "Select abilities to end.",
+        text = "Highlighted abilities will continue. Click one to deselect it and end it.",
     }
 
     mainChildren[#mainChildren+1] = gui.Label{


### PR DESCRIPTION
**Symptom:** An Elementalist player deselected a chip in the start-of-turn Persistent Magic prompt in order to keep "Flesh, a Crucible" active, and the effect ended instead.

**Root cause:** In `ActivatedAbilityPersistenceControlBehavior:Cast` (`Draw Steel Ability Behaviors/AbilityPersistentCast.lua`), the dialog's selection semantics are *highlighted = keep*: `keepAbilities` is pre-populated with every active persistent ability, the `create` handler applies `persist-chip-selected` to chips in that set, the chip `press` handler toggles membership, and Submit calls `EndPersistentAbilityById` for every ability **not** in `keepAbilities`. The instruction label, however, read "Select abilities to end." - the exact inverse of what the highlight means. Following the label costs the player the effect they were trying to maintain.

**The fix:** One string. The instruction now reads "Highlighted abilities will continue. Click one to deselect it and end it." No logic, styles, or other lines change. The label style is `width = "100%", height = "auto"`, so the longer text wraps.

The report also suggested a larger two-box "continue / end" redesign plus essence-overspend enforcement; that is deliberately out of scope here.

Report id: TZM974A6

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)