### PR TITLE
Squad minion death handling: squadminiondeaths trigger, confirmation-gated batching, summon extensions

### DIFF
--- a/DMHub Game Rules/AbilitySummon.lua
+++ b/DMHub Game Rules/AbilitySummon.lua
@@ -31,6 +31,25 @@ ActivatedAbilitySummonBehavior.shareHeroicResourceWithSummoner = false
 ActivatedAbilitySummonBehavior.choosePlacement = false
 ActivatedAbilitySummonBehavior.summonRange = "1"
 
+--optional context text prepended to the "Place minion N of M" placement
+--prompt, e.g. "Lingering Hunger Trait:" so the user knows which ability or
+--trait is asking them to place creatures. "" (the default) shows no prefix.
+ActivatedAbilitySummonBehavior.placementPrompt = ""
+
+--GoblinScript: damage_taken applied to each summoned creature right after it
+--spawns, letting a summon start below its maximum Stamina. Applied as a
+--direct property set (NOT InflictDamage), so no damage triggers fire.
+--"0" (the default) or "" means summons spawn at full Stamina. Clamped so a
+--summon never spawns already dead (at least 1 Stamina remains).
+ActivatedAbilitySummonBehavior.initialDamageTaken = "0"
+
+--When a non-summoner caster summons minions (no squad-selection UI), the
+--minions of one cast join a single FRESH squad by default so their shared
+--stamina pool never silently merges with an unrelated same-type squad
+--already on the map. Set true to restore the old behavior of falling into
+--the default "<monster type> Squad 1" squad (reinforcement-style content).
+ActivatedAbilitySummonBehavior.joinExistingSquad = false
+
 --tweak placement: summons are auto-placed around each target (hidden from
 --players), then the user rearranges them within tweakRadius of the anchor and
 --presses Continue to reveal them. See AbilityTweakCreaturePlacement.lua.
@@ -132,6 +151,15 @@ end
 --- @param token CharacterToken
 --- @param lookKey string
 function ActivatedAbilitySummonBehavior.ApplySummonLook(casterToken, token, lookKey)
+    --A summon cast by a since-removed caster: a defunct token handle still
+    --answers simple getters (.charid, .description) but its .properties reads
+    --nil. Both the custom-look read below and the frame-copy fallback at the
+    --bottom need a live caster, so skip look copying entirely rather than
+    --crash.
+    if casterToken == nil or casterToken.properties == nil then
+        return
+    end
+
     local custom = casterToken.properties:GetSummonAppearance(lookKey)
     if custom ~= nil then
         if custom.portrait ~= nil and custom.portrait ~= "" then
@@ -1138,7 +1166,15 @@ end
 --- @param squadCtx table|nil persistent squad-selection state (see Cast()).
 --- @param creatureCtx table|nil persistent creature-selection state with .choices and .selectedCreature.
 --- @return Loc|nil pickedLoc, table|nil squadResult, table|nil pickedCreature.
-function ActivatedAbilitySummonBehavior.PromptPlacementLoc(casterToken, rangeTiles, index, total, isMinion, squadCtx, creatureCtx, ability)
+function ActivatedAbilitySummonBehavior.PromptPlacementLoc(casterToken, rangeTiles, index, total, isMinion, squadCtx, creatureCtx, ability, promptPrefix)
+    --optional context text shown before "Place minion N of M", e.g.
+    --"Lingering Hunger Trait:". Normalized here so every prompt variant
+    --below can just concatenate it.
+    if promptPrefix == nil or promptPrefix == "" then
+        promptPrefix = ""
+    else
+        promptPrefix = promptPrefix .. " "
+    end
     local SQUAD_CAP = 8
 
     --measure range from the token's full footprint, not just its anchor square.
@@ -1189,7 +1225,7 @@ function ActivatedAbilitySummonBehavior.PromptPlacementLoc(casterToken, rangeTil
             height = "auto",
             bold = true,
             fontSize = 16,
-            text = string.format("Place %s %d of %d (Esc to cancel)", isMinion and "minion" or "creature", index, total),
+            text = promptPrefix .. string.format("Place %s %d of %d (Esc to cancel)", isMinion and "minion" or "creature", index, total),
         }
     else
         local headerLabel
@@ -1394,7 +1430,7 @@ function ActivatedAbilitySummonBehavior.PromptPlacementLoc(casterToken, rangeTil
                 statusLabel.text = statusText
             end
             if headerLabel ~= nil and headerLabel.valid then
-                headerLabel.text = string.format("Place %s %d of %d", CurrentCreatureName(), index, total)
+                headerLabel.text = promptPrefix .. string.format("Place %s %d of %d", CurrentCreatureName(), index, total)
             end
         end
 
@@ -1452,7 +1488,7 @@ function ActivatedAbilitySummonBehavior.PromptPlacementLoc(casterToken, rangeTil
             bold = true,
             fontSize = 16,
             textAlignment = "center",
-            text = string.format("Place %s %d of %d", CurrentCreatureName(), index, total),
+            text = promptPrefix .. string.format("Place %s %d of %d", CurrentCreatureName(), index, total),
             vmargin = 2,
         }
         statusLabel = gui.Label{
@@ -1586,14 +1622,25 @@ function ActivatedAbilitySummonBehavior.PromptPlacementLoc(casterToken, rangeTil
 
     gamehud.popupPanel:AddChild(picker)
 
-    while pickedLoc == nil and not cancelled do
+    while pickedLoc == nil and not cancelled and picker.valid do
         coroutine.yield(0.1)
     end
 
-    picker:DestroySelf()
+    --the picker being destroyed externally (not by our own DestroySelf below)
+    --means the placement UI was torn down under us, e.g. a HUD rebuild or the
+    --caster being removed mid-cast. Report it distinctly from a user cancel
+    --so the caller can auto-place instead of stranding the summons.
+    local abandoned = (pickedLoc == nil) and (not cancelled) and (not picker.valid)
+
+    if picker.valid then
+        picker:DestroySelf()
+    end
 
     if cancelled then
-        return nil, nil, nil
+        return nil, nil, nil, "cancelled"
+    end
+    if abandoned then
+        return nil, nil, nil, "abandoned"
     end
     return pickedLoc, pickedSquadResult, pickedCreature
 end
@@ -1636,9 +1683,7 @@ function ActivatedAbilitySummonBehavior:Cast(ability, casterToken, targets, args
         local choices = {}
         if self.monsterType == "custom" then
             for k,monster in pairs(assets.monsters) do
-                --GetMonsterNode can return nil mid-import/reload; skip rather than throw.
-                local node = assets:GetMonsterNode(k)
-                if node ~= nil and not node.hidden and monster.properties ~= nil then
+                if not assets:GetMonsterNode(k).hidden then
                     args.symbols.beast = GenerateSymbols(monster.properties)
                     if monster.properties:has_key("monster_type") and ExecuteGoblinScript(self.bestiaryFilter, GenerateSymbols(casterToken.properties, args.symbols), 0, string.format("Bestiary filter for %s summons filter %s", ability.name, monster.properties.monster_type)) ~= 0 then
                         choices[#choices+1] = monster
@@ -1761,6 +1806,21 @@ function ActivatedAbilitySummonBehavior:Cast(ability, casterToken, targets, args
         local warningExceededMinions = false
         local warningExceededSquads = false
 
+        --set when the placement UI is torn down externally mid-cast: the
+        --remaining summons auto-place near the target/caster instead of
+        --prompting, so the summons are never stranded.
+        local autoPlaceSummons = false
+
+        --minions summoned with no squad-selection UI (non-summoner casters)
+        --all join ONE fresh squad opened for this cast, so they never merge
+        --into an unrelated same-type squad's shared stamina pool.
+        local freshSquadName = nil
+
+        --fresh-squad minion spawns with their evaluated initial damage; used
+        --to seed the new squad's shared pool after the spawn loop, once the
+        --final member count is known.
+        local freshSquadSpawns = {}
+
         -- For Summoner casters with manual placement, fold the creature-type choice
         -- into the inline placement picker so it can change per-summon.
         local creatureChoiceInline = isSummoner and manualPlacement and self.casterChoosesCreatures and #choices > 1 and self.changeCreatureWhileCasting
@@ -1852,12 +1912,38 @@ function ActivatedAbilitySummonBehavior:Cast(ability, casterToken, targets, args
                     creatureCtxArg = placementCreatureCtx
                 end
                 local isMinion = chosenOption ~= nil and chosenOption.properties ~= nil and chosenOption.properties:try_get("minion", false)
-                local pickedLoc, squadResult, pickedCreature = ActivatedAbilitySummonBehavior.PromptPlacementLoc(casterToken, rangeTiles, j, numSummons, isMinion, squadCtxArg, creatureCtxArg, ability)
-                if pickedLoc == nil then
-                    --user cancelled; stop placing further summons but keep what's already there.
-                    break
+                local pickedLoc = nil
+                local squadResult = nil
+                local pickedCreature = nil
+                if not autoPlaceSummons then
+                    local promptResult
+                    pickedLoc, squadResult, pickedCreature, promptResult = ActivatedAbilitySummonBehavior.PromptPlacementLoc(casterToken, rangeTiles, j, numSummons, isMinion, squadCtxArg, creatureCtxArg, ability, self.placementPrompt)
+                    if pickedLoc == nil then
+                        if promptResult == "abandoned" then
+                            --the placement UI was torn down externally (e.g.
+                            --the caster was removed mid-cast): never strand
+                            --the summons. Auto-place this and every remaining
+                            --summon near the target/caster instead; the spawn
+                            --uses fitLocation so they settle on free squares
+                            --and can be dragged afterward.
+                            autoPlaceSummons = true
+                        else
+                            --user cancelled; stop placing further summons but keep what's already there.
+                            break
+                        end
+                    end
                 end
-                loc = pickedLoc
+                if autoPlaceSummons then
+                    loc = target.loc
+                    if loc == nil and casterToken.valid then
+                        loc = casterToken.loc
+                    end
+                    if loc == nil then
+                        break
+                    end
+                else
+                    loc = pickedLoc
+                end
                 if pickedCreature ~= nil then
                     chosenOption = pickedCreature
                     args.symbols.summon = GenerateSymbols(chosenOption.properties)
@@ -1932,6 +2018,27 @@ function ActivatedAbilitySummonBehavior:Cast(ability, casterToken, targets, args
                     squad = squadNameForSpawn,
                     monsterType = chosenOption.properties.monster_type,
                 }
+            elseif token.properties.minion and (not self.joinExistingSquad) then
+                --minion spawned with no squad-selection UI (non-summoner
+                --caster): creature:MinionSquad() would default it into
+                --"<type> Squad 1", silently merging it -- and its shared
+                --stamina pool -- with any unrelated same-type squad already
+                --on the map. Open ONE fresh squad for this cast's minions
+                --instead. Set joinExistingSquad on the behavior to restore
+                --the old merging for content that wants reinforcements to
+                --join an existing squad.
+                if freshSquadName == nil then
+                    local monsterType = token.properties:try_get("monster_type", "Minion")
+                    local findFresh = rawget(monster, "FindFreshSquadName")
+                    if findFresh ~= nil then
+                        freshSquadName = findFresh(monsterType)
+                    else
+                        --game systems without squad-name bookkeeping still get
+                        --a unique squad per cast.
+                        freshSquadName = string.format("%s Squad %s", monsterType, string.sub(dmhub.GenerateGuid(), 1, 8))
+                    end
+                end
+                token.properties.minionSquad = freshSquadName
             end
 
             if initiativeGrouping ~= nil then
@@ -1944,6 +2051,34 @@ function ActivatedAbilitySummonBehavior:Cast(ability, casterToken, targets, args
                 text = string.format("Summoned by %s", casterToken.description),
             }
 
+            --optionally start the summon below max Stamina. Direct property
+            --set (before the upload below), so no damage triggers fire.
+            local initialDamageFormula = trim(self:try_get("initialDamageTaken", "0"))
+            if initialDamageFormula ~= "" and initialDamageFormula ~= "0" then
+                local initialDamage = dmhub.EvalGoblinScript(initialDamageFormula, GenerateSymbols(casterToken.properties, args.symbols), 0, string.format("Initial damage taken for %s summons", ability.name))
+                initialDamage = math.floor(tonumber(initialDamage) or 0)
+                if initialDamage > 0 then
+                    --never spawn the summon already dead.
+                    local maxhp = token.properties:MaxHitpoints()
+                    if initialDamage >= maxhp then
+                        initialDamage = maxhp - 1
+                    end
+                end
+                if initialDamage > 0 then
+                    if freshSquadName ~= nil and token.properties.minion and token.properties:try_get("minionSquad") == freshSquadName then
+                        --minions share a squad stamina pool derived from the
+                        --damage_taken_seq fan-out (see RefreshSquadInfo), so
+                        --a bare per-token damage_taken write is invisible to
+                        --it. Collect the amount instead; the fresh squad's
+                        --pool is seeded after the spawn loop, once the final
+                        --member count is known.
+                        freshSquadSpawns[#freshSquadSpawns+1] = { charid = token.charid, damage = initialDamage }
+                    else
+                        token.properties.damage_taken = token.properties.damage_taken + initialDamage
+                    end
+                end
+            end
+
             summonedTokens[#summonedTokens+1] = token
 
             if self.casterControls then
@@ -1952,12 +2087,53 @@ function ActivatedAbilitySummonBehavior:Cast(ability, casterToken, targets, args
                 ActivatedAbilitySummonBehavior.ApplySummonLook(casterToken, token, lookKey)
                 summonedMonsterids[lookKey] = true
 
-                --if the caster controls the summoned tokens then they inherit the caster's party.
-                token.partyid = casterToken.partyid
+                --if the caster controls the summoned tokens then they inherit
+                --the caster's party. Skipped when the caster token went
+                --defunct mid-cast (e.g. a minion removed while its triggered
+                --summon was still resolving).
+                if casterToken.valid then
+                    token.partyid = casterToken.partyid
+                end
             end
 
             token:UploadToken("Summon Creature")
             game.UpdateCharacterTokens()
+        end
+
+        --seed the fresh squad's shared stamina pool with the summons' initial
+        --damage. Squad stamina is derived from the member carrying the
+        --highest damage_taken_seq (see RefreshSquadInfo in MCDMCreature.lua),
+        --so every member gets the pool total, a seq of 1 and the member
+        --count -- exactly the shape real squad damage fans out.
+        if #freshSquadSpawns > 0 then
+            local poolDamage = 0
+            for _,entry in ipairs(freshSquadSpawns) do
+                poolDamage = poolDamage + entry.damage
+            end
+
+            local memberCount = 0
+            for _,tok in ipairs(summonedTokens) do
+                if tok.valid and tok.properties ~= nil and tok.properties.minion and tok.properties:try_get("minionSquad") == freshSquadName then
+                    memberCount = memberCount + 1
+                end
+            end
+
+            if poolDamage > 0 and memberCount > 0 then
+                for _,tok in ipairs(summonedTokens) do
+                    if tok.valid and tok.properties ~= nil and tok.properties.minion and tok.properties:try_get("minionSquad") == freshSquadName then
+                        tok:ModifyProperties{
+                            description = "Initial summon damage",
+                            undoable = false,
+                            combine = true,
+                            execute = function()
+                                tok.properties.damage_taken = poolDamage
+                                tok.properties.damage_taken_seq = 1
+                                tok.properties.damage_taken_minion_count = memberCount
+                            end,
+                        }
+                    end
+                end
+            end
         end
 
         --remember every token summoned for this outer target so we can inject them
@@ -1984,7 +2160,15 @@ function ActivatedAbilitySummonBehavior:Cast(ability, casterToken, targets, args
         end
 
         if #summonedTokens > 0 then
-            if ability:RequiresConcentration() and casterToken.properties:HasConcentration() then
+            --the caster can be removed mid-cast (e.g. a minion skull-killed
+            --while its triggered summon resolves): a defunct token still
+            --answers simple getters (.charid, .description) but .properties
+            --reads nil. Skip caster-side bookkeeping in that case while still
+            --finishing the cast; CommitToPaying self-guards against a defunct
+            --caster inside FireUseAbility.
+            local casterAlive = casterToken ~= nil and casterToken.valid and casterToken.properties ~= nil
+
+            if casterAlive and ability:RequiresConcentration() and casterToken.properties:HasConcentration() then
                 casterToken:ModifyProperties{
                     description = "Concentrate on summons",
                     execute = function()
@@ -1997,7 +2181,7 @@ function ActivatedAbilitySummonBehavior:Cast(ability, casterToken, targets, args
                 }
             end
 
-            if isSummoner and #summonerEntries > 0 then
+            if casterAlive and isSummoner and #summonerEntries > 0 then
                 casterToken:ModifyProperties{
                     description = "Register summons",
                     execute = function()
@@ -2008,24 +2192,26 @@ function ActivatedAbilitySummonBehavior:Cast(ability, casterToken, targets, args
                 }
             end
 
-            --add newly summoned creature types to the caster's summon history.
-            local newHistory = {}
-            local existingHistory = casterToken.properties:try_get("summonHistory")
-            for monsterid,_ in pairs(summonedMonsterids) do
-                if existingHistory == nil or existingHistory[monsterid] == nil then
-                    newHistory[#newHistory+1] = monsterid
+            if casterAlive then
+                --add newly summoned creature types to the caster's summon history.
+                local newHistory = {}
+                local existingHistory = casterToken.properties:try_get("summonHistory")
+                for monsterid,_ in pairs(summonedMonsterids) do
+                    if existingHistory == nil or existingHistory[monsterid] == nil then
+                        newHistory[#newHistory+1] = monsterid
+                    end
                 end
-            end
-            if #newHistory > 0 then
-                casterToken:ModifyProperties{
-                    description = "Record summon history",
-                    undoable = false,
-                    execute = function()
-                        for _,monsterid in ipairs(newHistory) do
-                            casterToken.properties:RecordSummonHistory(monsterid)
-                        end
-                    end,
-                }
+                if #newHistory > 0 then
+                    casterToken:ModifyProperties{
+                        description = "Record summon history",
+                        undoable = false,
+                        execute = function()
+                            for _,monsterid in ipairs(newHistory) do
+                                casterToken.properties:RecordSummonHistory(monsterid)
+                            end
+                        end,
+                    }
+                end
             end
 
             if warningExceededMinions then
@@ -2041,7 +2227,7 @@ function ActivatedAbilitySummonBehavior:Cast(ability, casterToken, targets, args
             --we summoned, so consume resources.
             ability:CommitToPaying(casterToken, args)
 
-            if self.replaceCaster then
+            if self.replaceCaster and casterAlive then
                 casterToken:ModifyProperties{
                     description = "Replace caster",
                     execute = function()
@@ -2350,6 +2536,39 @@ function ActivatedAbilityBehavior:SummonEditor(parentPanel, list, options)
 			},
 		}
 
+		list[#list+1] = gui.Panel{
+			classes = "formPanel",
+			gui.Label{
+				classes = "formLabel",
+				text = "Initial Dmg Taken:",
+			},
+			gui.GoblinScriptInput{
+				value = self:try_get("initialDamageTaken", "0"),
+				change = function(element)
+					self.initialDamageTaken = element.value
+				end,
+
+				documentation = {
+					domains = parentPanel.data.parentAbility.domains,
+					help = string.format("This GoblinScript determines how much damage each summoned creature has already taken when it appears, letting a summon start below its maximum Stamina. It is applied as a direct stat change (not an attack), so no damage triggers fire. Clamped so the summon never spawns dead. Leave as 0 to spawn at full Stamina."),
+					output = "number",
+					examples = {
+						{
+							script = "0",
+							text = "Summons appear at full Stamina.",
+						},
+						{
+							script = "4",
+							text = "Each summon appears with 4 damage already taken (e.g. at 4 Stamina for an 8 Stamina creature).",
+						},
+					},
+					subject = creature.helpSymbols,
+					subjectDescription = "The creature using the ability",
+					symbols = numSummonsHelpSymbols,
+				},
+			},
+		}
+
 		list[#list+1] = gui.Check{
 			text = "Choose placement for each creature",
 			value = self.choosePlacement,
@@ -2393,6 +2612,26 @@ function ActivatedAbilityBehavior:SummonEditor(parentPanel, list, options)
 					subjectDescription = "The creature using the ability",
 					symbols = ActivatedAbility.helpCasting,
 				},
+			},
+		}
+
+		list[#list+1] = gui.Panel{
+			classes = {"formPanel", cond(not self.choosePlacement, "hidden")},
+			refreshChoosePlacement = function(element)
+				element:SetClass("hidden", not self.choosePlacement)
+			end,
+			gui.Label{
+				classes = "formLabel",
+				text = "Prompt Prefix:",
+			},
+			gui.Input{
+				classes = "formInput",
+				text = self.placementPrompt,
+				placeholderText = "e.g. Lingering Hunger Trait:",
+				characterLimit = 120,
+				change = function(element)
+					self.placementPrompt = element.text
+				end,
 			},
 		}
 

--- a/Draw Steel Core Rules/MCDMCreature.lua
+++ b/Draw Steel Core Rules/MCDMCreature.lua
@@ -230,11 +230,9 @@ end
 
 function creature:CalculateNamedCustomAttribute(id)
     local cacheKey = id
-    --keyed to tablesUpdateId so values derived from compendium tables/assets are
-    --recalculated after a reload rather than memoized for the whole session.
     local cache = self:try_get("_tmp_calculatedAttributes")
-    if cache == nil or cache.__tablesUpdateId ~= dmhub.tablesUpdateId then
-        cache = { __tablesUpdateId = dmhub.tablesUpdateId }
+    if cache == nil then
+        cache = {}
         self._tmp_calculatedAttributes = cache
     end
 
@@ -632,9 +630,136 @@ function creature:HeroicResourceHighWaterMarkForTurn()
     return quantity
 end
 
+local g_conditionHiddenId = "31daf7f6-f77c-4f73-8eab-43e2d0f123c0"
+
+--While a director-controlled creature has the Hidden condition, its token can
+--optionally be made invisible to players. Heroes never auto-vanish: their
+--enemies are director-run and the director must always see everything, so for
+--heroes the Hidden benefit is enforced at targeting time instead.
+--(forward-declared: SyncHiddenInvisibility reads it, the setting's onchange
+--calls SyncHiddenInvisibility)
+local g_settingHiddenInvisible
+
+--charids with a deferred invisibility sync pending, so a burst of refreshes
+--only schedules one write.
+local g_hiddenInvisPending = {}
+
+--Keeps token.invisibleToPlayers in step with the Hidden condition for
+--director-controlled creatures. We only act on TRANSITIONS, recorded in the
+--serialized hiddenInvisibilityApplied field: invisibility we did not apply
+--(e.g. encounter groups staged invisible by the director) is never touched,
+--and a director who manually reveals a still-hidden monster is not fought.
+--The write is deferred out of the refresh path to avoid re-entrant uploads.
+local function SyncHiddenInvisibility(token)
+    --Only the director's client manages this.
+    if not dmhub.isDM then
+        return
+    end
+
+    local c = token.properties
+    if c == nil then
+        return
+    end
+
+    local shouldHide = g_settingHiddenInvisible:Get() and (not token.playerControlled)
+        and (c:HasCondition(g_conditionHiddenId) ~= false)
+    local applied = c:try_get("hiddenInvisibilityApplied", false)
+    if shouldHide == applied then
+        return
+    end
+
+    local charid = token.charid
+    if g_hiddenInvisPending[charid] then
+        return
+    end
+    g_hiddenInvisPending[charid] = true
+
+    --Vanishing is delayed so the "Hidden" float text and status animation get
+    --time to play over the still-visible token before it disappears; players
+    --need a beat to register what happened. Revealing is near-instant so
+    --players are never late seeing a monster that is no longer hidden.
+    local delay = 0.05
+    if shouldHide then
+        delay = 2.0
+    end
+
+    dmhub.Schedule(delay, function()
+        g_hiddenInvisPending[charid] = nil
+        if mod.unloaded then
+            return
+        end
+
+        local tok = dmhub.GetTokenById(charid)
+        if tok == nil or (not tok.valid) or tok.properties == nil then
+            return
+        end
+
+        local cr = tok.properties
+        local hideNow = g_settingHiddenInvisible:Get() and (not tok.playerControlled)
+            and (cr:HasCondition(g_conditionHiddenId) ~= false)
+        local appliedNow = cr:try_get("hiddenInvisibilityApplied", false)
+        if hideNow == appliedNow then
+            return
+        end
+
+        tok.invisibleToPlayers = hideNow
+        tok:ModifyProperties{
+            description = "Hidden condition visibility",
+            undoable = false,
+            execute = function()
+                cr.hiddenInvisibilityApplied = hideNow
+
+                if not hideNow then
+                    --On reveal, clients that couldn't see the token missed the
+                    --sheet's own local "crossed out Hidden" status float (it
+                    --fires from icon diffing at condition-removal time, while
+                    --the token was still invisible to them). Re-fire the same
+                    --visual through the networked animation channel now that
+                    --the token is visible again.
+                    local conditionsTable = dmhub.GetTable(CharacterCondition.tableName)
+                    local conditionInfo = conditionsTable[g_conditionHiddenId]
+                    if conditionInfo ~= nil then
+                        cr:AddAnimation{
+                            animType = "statusDestroy",
+                            info = {
+                                icon = conditionInfo.iconid,
+                                statusText = (string.gsub(conditionInfo.name, "%s+$", "")),
+                                --floatstatus mutates info.style, so pass a copy.
+                                style = DeepCopy(conditionInfo:try_get("display", {})),
+                            },
+                        }
+                    end
+                end
+            end,
+        }
+    end)
+end
+
+g_settingHiddenInvisible = setting{
+    id = "strict:hiddeninvisible",
+    description = "Hidden Monsters Invisible to Players",
+    help = "While a creature the director controls has the Hidden condition, its token is invisible to players. Heroes always remain visible.",
+    storage = "game",
+    editor = "check",
+    default = false,
+    section = "GameStrictRules",
+    onchange = function()
+        --RefreshToken only runs on game-state changes, so re-evaluate every
+        --token directly when the setting flips (in particular, revealing
+        --monsters when it is toggled off).
+        for _, tok in ipairs(dmhub.allTokens) do
+            SyncHiddenInvisibility(tok)
+        end
+    end,
+}
+
 function creature:RefreshToken(token)
     if (not mod.unloaded) and self.minion then
         self:RefreshSquadInfo(token)
+    end
+
+    if not mod.unloaded then
+        SyncHiddenInvisibility(token)
     end
 
     if (not mod.unloaded) then
@@ -749,12 +874,7 @@ function creature:RefreshInitiativeInfo(token)
         if initiativeEntry ~= nil and initiativeEntry.initiativeid == initiativeid then
             self._tmp_initiativeStatus = "OurTurn"
         elseif not q:HasInitiative(initiativeid) then
-            if self:try_get("treatAsObject", false) then
-                --Object-tagged creatures are scenery, not skipped combatants; don't grey them out.
-                self._tmp_initiativeStatus = nil
-            else
-                self._tmp_initiativeStatus = "NonCombatant"
-            end
+            self._tmp_initiativeStatus = "NonCombatant"
         elseif q:HasHadTurn(initiativeid) then
             self._tmp_initiativeStatus = "Done"
         elseif q:ChoosingTurn() and q:IsPlayersTurn() == q:IsEntryPlayer(initiativeid) and (q:has_key("priorityids") == false or q:EntriesUnmoved()[initiativeid]) then
@@ -848,10 +968,25 @@ function monster.OnCreateFromBestiary(self, token, groupid)
 end
 
 function monster.FindFreshSquadName(monster_type)
+    --The g_minionSquadTables registry is client-local and wiped by a Lua
+    --reload, so also consult the squads live tokens actually occupy (including
+    --the implicit "<type> Squad 1" default for squadless minions) or a freshly
+    --reloaded client can hand out a name an existing squad is already using.
+    local usedNames = {}
+    for _,tok in ipairs(dmhub.GetTokens{haveProperties = true}) do
+        if tok.valid and tok.properties.minion then
+            local squadName = nil
+            pcall(function() squadName = tok.properties:MinionSquad() end)
+            if squadName ~= nil then
+                usedNames[squadName] = true
+            end
+        end
+    end
+
     for i = 1, 1000 do
         local squadid = string.format("%s Squad %d", monster_type, i)
         local minionSquad = g_minionSquadTables[squadid]
-        if minionSquad == nil then
+        if minionSquad == nil and usedNames[squadid] == nil then
             g_minionSquadTables[squadid] = {
                 name = squadid,
             }
@@ -2324,6 +2459,15 @@ end
 
 --- @return boolean
 function monster:IsDead()
+    --Death-gated squad minions (e.g. Group Appetite trolls): the shared pool
+    --reaching 0 does not kill them, so a minion only reads as dead once its
+    --death is actually confirmed (director skull click or a trait trigger
+    --removing it). Without this, a negative pool paints every member with the
+    --dead-token overlay and gets the squad skipped in initiative, so the
+    --end-of-turn death trigger could never fire.
+    if self.minion and (self:CalculateNamedCustomAttribute("Gated Minion Deaths") or 0) > 0 then
+        return self.minionDead
+    end
     return self:CurrentHitpoints() <= self:KillThresholdStamina()
 end
 
@@ -3495,17 +3639,22 @@ function creature:InflictCondition(conditionid, args)
                 --context-appropriate instead of "I can't be Hidden!". Otherwise
                 --fall back to the per-condition variations table, then a generic
                 --line.
-                local text = self:GetConditionImmunityMessage(conditionid)
-                    or g_conditionImmunitySpeech[string.lower(conditionInfo.name)]
-                    or string.format("I can't be %s!", conditionInfo.name)
                 local language = self:CurrentlySpokenLanguage()
                 if language ~= nil then
+                    --the creature can speak: use its custom immunity line, a
+                    --flavorful per-condition variation, or a generic first-person
+                    --fallback, rendered as an in-character speech bubble.
+                    local text = self:GetConditionImmunityMessage(conditionid)
+                        or g_conditionImmunitySpeech[string.lower(conditionInfo.name)]
+                        or string.format("I can't be %s!", conditionInfo.name)
                     self:CharacterSpeech{
                         text = text,
                         langid = language,
                     }
                 else
-                    self:FloatLabel(text, "white")
+                    --no spoken language: a first-person speech line reads oddly as
+                    --floating text, so show a plain descriptive label instead.
+                    self:FloatLabel(string.format("Cannot be %s", conditionInfo.name), "white")
                 end
             end
         end
@@ -4964,6 +5113,260 @@ creature.minionDamageTime = 0
 --applied to that squad's pool this cast.
 local g_summonerSquadCastDamage = setmetatable({}, {__mode = "k"})
 
+--Batching and confirmation gating for the "squadminiondeaths" trigger.
+--
+--A single cast that hits several minions of a squad applies damage in
+--SEPARATE TakeDamage calls (one per target), each of which can empty one
+--stamina band. A naive per-call dispatch would fire the trigger once per
+--call with 1 kill each, so a condition like "Minions Killed >= 2" could
+--never pass on the canonical area-wipe case. Each application's kills
+--therefore accumulate into a batch keyed by (squad, cast identity).
+--
+--A batch does NOT flush on a timer: squad minion deaths are not real until
+--the director confirms them by clicking the red skulls, which fires the
+--creaturedeath trigger and then calls creature:MinionDeath() on the
+--confirmed minion (see DrawSteelTokenHud.lua). Flushing earlier races that
+--flow: the placement UI of a triggered summon goes up underneath the
+--confirmation clicks and the Monster Death removals tear it down. Instead
+--the batch flushes exactly when the number of CONFIRMED deaths reaches the
+--batch's kill count. Confirmations are observed two ways:
+--  * synchronously, via the creature:MinionDeath() wrapper below, on the
+--    client where the skulls are clicked; and
+--  * by polling, for batches held on a different client than the one
+--    confirming (damage accumulates on the damaging client, confirmation
+--    happens on the director's): a recorded squad member whose token has
+--    been removed or marked minionDead counts as confirmed.
+--If the director never confirms, the batch simply stays pending: deaths
+--that were never confirmed never happened. A batch is dropped if the
+--squad's shared pool is healed back above the killed bands (deaths undone).
+--
+--The flush dispatches the trigger event ONCE per damage type group (2 fire
+--kills + 1 untyped kill in one cast = one dispatch with 2 kills of fire and
+--one dispatch with 1 kill of none), on a single creature so a squad-wide
+--trait fires once, not once per member: a live surviving squad member when
+--one exists (reliable now that confirmations are complete), or on a full
+--squad wipe the last-confirmed minion at its confirmation moment, while its
+--token is still valid (the Monster Death removal lands behind a Delay
+--behavior). Damage with no cast (falling, terrain) gets its own batch per
+--application but is confirmation-gated all the same.
+local g_squadMinionDeathBatches = {}
+local g_squadMinionDeathBatchSeq = 0
+
+--Flushes the batch if enough deaths are confirmed. lastConfirmed is the
+--creature whose confirmation completed the batch (nil on the polling path);
+--it is the dispatch target on a full squad wipe, while its token is still
+--valid.
+local function CheckFlushSquadMinionDeathBatch(key, lastConfirmed)
+    local batch = g_squadMinionDeathBatches[key]
+    if batch == nil then
+        return
+    end
+
+    if batch.confirmedCount < batch.totalKills then
+        return
+    end
+
+    g_squadMinionDeathBatches[key] = nil
+
+    --Prefer dispatching on a squad member that survived: still on the map,
+    --not confirmed, not director-marked dead, shared pool alive. Every
+    --member of the squad carries the same traits, so any live member is an
+    --equivalent dispatch target, and the batch still dispatches exactly
+    --once.
+    local victim = nil
+    for _,tok in ipairs(dmhub.GetTokens()) do
+        if tok.valid and tok.properties ~= nil and tok.properties.minion
+            and (not tok.properties.minionDead)
+            and (not batch.confirmed[tok.charid])
+            and tok.properties:MinionSquad() == batch.squadName
+            and (not tok.properties:IsDead()) then
+            victim = tok.properties
+            break
+        end
+    end
+
+    --Full squad wipe: dispatch from the last-confirmed minion before its
+    --removal lands, falling back to the most recently damaged one. The
+    --summon pipeline tolerates a caster that goes defunct mid-cast (see
+    --ApplySummonLook and the auto-place fallback in AbilitySummon.lua).
+    if victim == nil then
+        victim = lastConfirmed
+    end
+    if victim == nil or dmhub.LookupToken(victim) == nil then
+        victim = batch.victim
+    end
+    if victim == nil or dmhub.LookupToken(victim) == nil then
+        return
+    end
+
+    for damagetype,group in pairs(batch.groups) do
+        victim:DispatchEvent("squadminiondeaths", {
+            minionskilled = group.kills,
+            damage = group.damage,
+            damagetype = damagetype,
+            attacker = group.attacker,
+            hasattacker = group.attacker ~= nil,
+            cast = batch.cast,
+            hascast = batch.cast ~= nil,
+        })
+    end
+end
+
+--Synchronous confirmation hook: called from the creature:MinionDeath()
+--wrapper below at the moment a minion death is confirmed on this client.
+local function NoteSquadMinionDeathConfirmed(minion)
+    if not minion.minion then
+        return
+    end
+    local squadName = minion:MinionSquad()
+    if squadName == nil then
+        return
+    end
+    local token = dmhub.LookupToken(minion)
+    if token == nil then
+        return
+    end
+    local charid = token.charid
+
+    for key,batch in pairs(g_squadMinionDeathBatches) do
+        if batch.squadName == squadName and batch.members[charid] and (not batch.confirmed[charid]) then
+            batch.confirmed[charid] = true
+            batch.confirmedCount = batch.confirmedCount + 1
+            CheckFlushSquadMinionDeathBatch(key, minion)
+        end
+    end
+end
+
+--Polling observer for a pending batch: picks up confirmations that happened
+--on another client (a recorded member's token removed or marked minionDead)
+--and drops the batch if the squad's pool has been healed back above the
+--killed bands. Never fires the trigger on time alone.
+local function PollSquadMinionDeathBatch(key)
+    local batch = g_squadMinionDeathBatches[key]
+    if batch == nil then
+        return
+    end
+
+    for charid,_ in pairs(batch.members) do
+        if not batch.confirmed[charid] then
+            local tok = dmhub.GetTokenById(charid)
+            if tok == nil or (not tok.valid) or tok.properties == nil or tok.properties.minionDead then
+                batch.confirmed[charid] = true
+                batch.confirmedCount = batch.confirmedCount + 1
+            end
+        end
+    end
+
+    --deaths undone: a live member's pool shows more full stamina bands than
+    --the last damage application left behind. Drop the batch.
+    if batch.singleHealth ~= nil and batch.singleHealth > 0 then
+        for _,tok in ipairs(dmhub.GetTokens()) do
+            if tok.valid and tok.properties ~= nil and tok.properties.minion
+                and (not tok.properties.minionDead)
+                and tok.properties:MinionSquad() == batch.squadName then
+                local bands = math.max(0, math.ceil(tok.properties:CurrentHitpoints() / batch.singleHealth))
+                if bands > batch.expectedBands then
+                    g_squadMinionDeathBatches[key] = nil
+                    return
+                end
+                break
+            end
+        end
+    end
+
+    CheckFlushSquadMinionDeathBatch(key, nil)
+
+    if g_squadMinionDeathBatches[key] ~= nil then
+        dmhub.Schedule(0.3, function()
+            if mod.unloaded then
+                return
+            end
+            PollSquadMinionDeathBatch(key)
+        end)
+    end
+end
+
+--Records one damage application's minion kills into the per-cast batch.
+--Counts kills even when there is no attacker. minionsAfter/healthSingle
+--describe the pool state this application left behind; the poll uses them
+--for the healed-back staleness check.
+local function AccumulateSquadMinionDeaths(victim, eventArg, minionsKilled, minionsAfter, healthSingle)
+    local squadName = victim:MinionSquad() or "squad"
+
+    local castKey
+    if eventArg.cast ~= nil then
+        castKey = tostring(eventArg.cast)
+    else
+        --no cast to batch against: each damage application is its own batch.
+        g_squadMinionDeathBatchSeq = g_squadMinionDeathBatchSeq + 1
+        castKey = string.format("nocast-%d", g_squadMinionDeathBatchSeq)
+    end
+
+    local key = string.format("%s|%s", squadName, castKey)
+    local batch = g_squadMinionDeathBatches[key]
+    if batch == nil then
+        --record the squad's live membership now, before any confirmation:
+        --confirmations are counted strictly against this set.
+        local members = {}
+        for _,tok in ipairs(dmhub.GetTokens()) do
+            if tok.valid and tok.properties ~= nil and tok.properties.minion
+                and (not tok.properties.minionDead)
+                and tok.properties:MinionSquad() == squadName then
+                members[tok.charid] = true
+            end
+        end
+
+        batch = {
+            victim = victim,
+            squadName = squadName,
+            cast = eventArg.cast,
+            groups = {},
+            totalKills = 0,
+            members = members,
+            confirmed = {},
+            confirmedCount = 0,
+            expectedBands = 0,
+            singleHealth = healthSingle,
+        }
+        g_squadMinionDeathBatches[key] = batch
+
+        dmhub.Schedule(0.3, function()
+            if mod.unloaded then
+                return
+            end
+            PollSquadMinionDeathBatch(key)
+        end)
+    end
+
+    batch.victim = victim
+    batch.totalKills = batch.totalKills + minionsKilled
+    batch.expectedBands = minionsAfter
+    batch.singleHealth = healthSingle
+
+    local damagetype = eventArg.damagetype or "none"
+    local group = batch.groups[damagetype]
+    if group == nil then
+        group = { kills = 0, damage = 0, attacker = nil }
+        batch.groups[damagetype] = group
+    end
+    group.kills = group.kills + minionsKilled
+    group.damage = group.damage + (eventArg.damage or 0)
+    if group.attacker == nil then
+        group.attacker = eventArg.attacker
+    end
+end
+
+--Confirmation wrapper: DrawSteelTokenHud's skull click calls MinionDeath()
+--on the confirmed minion right after firing its creaturedeath trigger.
+--Count the confirmation (possibly flushing a completed batch) BEFORE the
+--base implementation runs, while the squad bookkeeping is still intact and
+--the minion's token is still valid.
+local g_baseMinionDeath = creature.MinionDeath
+function creature:MinionDeath()
+    NoteSquadMinionDeathConfirmed(self)
+    g_baseMinionDeath(self)
+end
+
 function creature.TakeDamage(self, amount, note, info)
     info = info or {}
     if type(amount) == 'string' then
@@ -5175,16 +5578,18 @@ function creature.TakeDamage(self, amount, note, info)
             attacker:DispatchEvent("dealdamage", args)
         end
 
-        --Per-encounter hero stat: minion kills. Count how many full single-minion
-        --stamina bands this hit emptied in the squad's shared pool (hpBefore ->
-        --hpBefore - amount) and credit the attacker that many. This naturally
-        --handles "multiple minions hit with one blow": area hits reduce the pool
-        --once per minion (summed across calls), and the Strikes-with-Multiple-
-        --Targets clamp leaves amount == 0 on the redundant calls (killed == 0).
-        --Overkill is bounded by minionsBefore, so the pool dropping below zero
-        --never over-counts. TrackHeroStats self-guards to heroes in the live
-        --encounter, so non-hero attackers are dropped. Minions return here and
-        --never reach the regular-monster "kills" path below.
+        --Count how many full single-minion stamina bands this hit emptied in
+        --the squad's shared pool (hpBefore -> hpBefore - amount). This
+        --naturally handles "multiple minions hit with one blow": area hits
+        --reduce the pool once per minion (summed across calls), and the
+        --Strikes-with-Multiple-Targets clamp leaves amount == 0 on the
+        --redundant calls (killed == 0). Overkill is bounded by minionsBefore,
+        --so the pool dropping below zero never over-counts. The count feeds
+        --two consumers: the per-encounter hero kill stat (attacker only;
+        --TrackHeroStats self-guards to heroes in the live encounter) and the
+        --squadminiondeaths trigger batch (counted even with no attacker).
+        --Minions return here and never reach the regular-monster "kills"
+        --path below.
         if minionKillHealthSingle ~= nil and minionKillHealthSingle > 0 and amount > 0 then
             local minionsBefore = math.max(0, math.ceil(minionKillHpBefore / minionKillHealthSingle))
             local minionsAfter = math.max(0, math.ceil((minionKillHpBefore - amount) / minionKillHealthSingle))
@@ -5196,13 +5601,12 @@ function creature.TakeDamage(self, amount, note, info)
                         LiveEncounter.TrackHeroStats(killerToken.charid, "minionKills", minionsKilled)
                     end
                 end
-                --Victim-side: the squad records its own losses (round-bucketed, so
-                --the victory screen can tell a squad wiped in round 1). Recorded
-                --with or without an attacker so environmental deaths count; the
-                --stat routes to the squad's initiative group.
-                local victimToken = dmhub.LookupToken(self)
-                if victimToken ~= nil then
-                    LiveEncounter.TrackHeroStats(victimToken.charid, "deaths", minionsKilled)
+
+                --batch for the squadminiondeaths trigger; see the batching
+                --machinery above TakeDamage. The batch flushes only once the
+                --director confirms the deaths.
+                if not info.doesNotTrigger then
+                    AccumulateSquadMinionDeaths(self, eventArg, minionsKilled, minionsAfter, minionKillHealthSingle)
                 end
             end
         end
@@ -5402,18 +5806,6 @@ function creature.TakeDamage(self, amount, note, info)
                     roundNumber = roundNumber,
                     dailyLimit = 20,
                 })
-
-                --Per-encounter combat stat: the attacker drove a hero to dying.
-                --Read by the victory screen's monster roles (Heartbreaker); the
-                --routing in TrackHeroStats credits a monster attacker's
-                --initiative group. Runs once here on the resolving client, at
-                --the not-dying -> dying transition.
-                if eventArg.attacker ~= nil then
-                    local attackerToken = dmhub.LookupToken(eventArg.attacker)
-                    if attackerToken ~= nil then
-                        LiveEncounter.TrackHeroStats(attackerToken.charid, "heroesDowned")
-                    end
-                end
             end
 
             self:DispatchEvent("dying", eventArg)
@@ -5476,38 +5868,22 @@ function creature.TakeDamage(self, amount, note, info)
             eventArg.usedability = eventArg.ability
             eventArg.hasattacker = eventArg.attacker ~= nil
 
-            --Per-encounter combat stat: a dying monster records its own death for
-            --its initiative group (round-bucketed, so the victory screen can tell
-            --a group that fell entirely in round 1). Recorded with or without an
-            --attacker so environmental deaths count; minions never reach this
-            --path (their squad's losses are recorded in the minion branch above).
-            if not self:IsHero() then
-                local victimToken = dmhub.LookupToken(self)
-                if victimToken ~= nil then
-                    LiveEncounter.TrackHeroStats(victimToken.charid, "deaths")
-                end
-            end
-
             if eventArg.attacker ~= nil then
                 --NOTE: We have to TriggerEvent here not DispatchEvent because
                 --DispatchEvent does not currently have support for dispatching
                 --creature objects and other self-referential objects.
                 eventArg.attacker:TriggerEvent("kill", eventArg)
 
-                --Per-encounter combat stat: credit the killer. A non-hero victim
-                --is a "kill" (for a hero killer this feeds the hero roles; for a
-                --monster killer -- e.g. downing a hero's companion -- it routes to
-                --the monster's initiative group). A HERO victim is instead a
-                --"heroKill", the victory screen's Hero Slayer role. Minions are
-                --counted separately as minionKills and never reach this path.
+                --Per-encounter hero stat: credit the killer with a monster kill.
+                --Guarded to non-hero victims (a dying hero is not a "kill"); minions
+                --are counted separately as minionKills and never reach this path.
                 --This runs once on the resolving client as the victim transitions
-                --to dead.
-                local killerToken = dmhub.LookupToken(eventArg.attacker)
-                if killerToken ~= nil then
-                    if not self:IsHero() then
+                --to dead. TrackHeroStats self-guards to heroes, so a monster killing
+                --a monster is dropped.
+                if not self:IsHero() then
+                    local killerToken = dmhub.LookupToken(eventArg.attacker)
+                    if killerToken ~= nil then
                         LiveEncounter.TrackHeroStats(killerToken.charid, "kills")
-                    else
-                        LiveEncounter.TrackHeroStats(killerToken.charid, "heroKills")
                     end
                 end
             end
@@ -5619,7 +5995,7 @@ function creature.Heal(self, amount, note)
     }
 
 
-    self:DispatchEvent("regainhitpoints", {})
+    self:DispatchEvent("regainhitpoints", {healed = amount})
 end
 
 function creature.SetStaminaDirect(self, amount, note)
@@ -6292,6 +6668,48 @@ creature.RegisterSymbol {
 }
 
 creature.RegisterSymbol {
+    symbol = "distancetoboundcreature",
+    lookup = function(c)
+        return function(effectName)
+            effectName = string.lower(effectName)
+            local selfToken = dmhub.LookupToken(c)
+            if selfToken == nil or (not selfToken.valid) then
+                return 9999
+            end
+
+            local result = 9999
+            local ongoingEffects = c:try_get("ongoingEffects", {})
+            local t = dmhub.GetTable("characterOngoingEffects")
+            for _, ongoingEffect in ipairs(ongoingEffects) do
+                local effectInfo = t[ongoingEffect.ongoingEffectid]
+                if effectInfo ~= nil and string.lower(effectInfo.name) == effectName and ongoingEffect.bondid then
+                    local tokens = creature.GetTokensWithBoundOngoingEffect(ongoingEffect.bondid)
+                    for _, token in ipairs(tokens) do
+                        if token.charid ~= selfToken.charid then
+                            local dist = selfToken:Distance(token)
+                            if dist ~= nil and dist < result then
+                                result = dist
+                            end
+                        end
+                    end
+                end
+            end
+
+            return result
+        end
+    end,
+    help = {
+        name = "DistanceToBoundCreature",
+        type = "function",
+        desc = "The distance in squares to the nearest other creature bound to this creature by the given ongoing effect. 9999 if there is no such creature.",
+        seealso = {},
+        examples = {
+            'DistanceToBoundCreature("Repelling Psihander") <= 1',
+        },
+    }
+}
+
+creature.RegisterSymbol {
     symbol = "complications",
     lookup = function(c)
         local results = {}
@@ -6671,9 +7089,9 @@ local function GroupingHud(groupid)
             end,
         }
 
-        sheetParent.sheet = m_sheet
-
         m_sheet:FireEvent("think")
+
+        sheetParent.sheet = m_sheet
     end
 end
 

--- a/Draw Steel Core Rules/MCDMRules.lua
+++ b/Draw Steel Core Rules/MCDMRules.lua
@@ -1215,8 +1215,22 @@ local friendlyFire = setting{
     default = false,
 }
 
+local g_hiddenConditionId = "31daf7f6-f77c-4f73-8eab-43e2d0f123c0"
+
 function GameSystem.AllowTargeting(casterToken, targetToken, ability)
 	if friendlyFire:Get() == false and ability:HasKeyword("Strike") and ability:HasKeyword("Area") and casterToken:IsFriend(targetToken) then
+		return false
+	end
+
+	-- Hidden: "While you are hidden from another creature, the creature can't
+	-- target you with abilities that don't have the Area keyword." A creature
+	-- with the Hidden condition is treated as hidden from all its enemies:
+	-- enemies lose non-Area targeting (including free strikes), while allies
+	-- can still target them normally. Area abilities are unaffected, so a
+	-- hidden creature standing in a swept area is still hit.
+	if (not targetToken.isObject) and (not ability:HasKeyword("Area"))
+		and (not casterToken:IsFriend(targetToken))
+		and targetToken.properties:HasCondition(g_hiddenConditionId) ~= false then
 		return false
 	end
 
@@ -1592,6 +1606,51 @@ TriggeredAbility.RegisterTrigger{
             desc = "The creature that fell on this creature.",
         },
     }
+}
+
+--Fires on a squad minion when damage kills one or more minions of its squad.
+--Kills from a single cast are batched (see AccumulateSquadMinionDeaths in
+--MCDMCreature.lua): an area ability that empties several stamina bands across
+--separate damage applications fires this ONCE per damage type group with the
+--total number killed, dispatched on one member of the squad (the most
+--recently damaged one), not on every member.
+TriggeredAbility.RegisterTrigger{
+    id = "squadminiondeaths",
+    text = "Squad Minions Killed",
+    symbols = {
+        minionskilled = {
+            name = "Minions Killed",
+            type = "number",
+            desc = "The number of minions of this creature's squad that were killed at the same time.",
+        },
+        damage = {
+            name = "Damage",
+            type = "number",
+            desc = "The total damage of this type the squad's stamina pool took in this batch.",
+        },
+        damagetype = {
+            name = "Damage Type",
+            type = "text",
+            desc = "The type of the damage that killed the minions. Untyped damage reads as 'none'.",
+            valueOptionsSource = "damageTypes",
+        },
+        attacker = {
+            name = "Attacker",
+            type = "creature",
+            desc = "The attacking creature. Only valid if Has Attacker is true.",
+        },
+        hasattacker = {
+            name = "Has Attacker",
+            type = "boolean",
+            desc = "True if the damage has an attacker.",
+        },
+    },
+    examples = {
+        {
+            script = "Minions Killed >= 2 and damage type is not fire",
+            text = "The triggered ability only activates when two or more minions are killed at once by damage that is not fire.",
+        },
+    },
 }
 
 --redefine hitpoints as stamina.

--- a/Draw Steel UI/DrawSteelTokenHud.lua
+++ b/Draw Steel UI/DrawSteelTokenHud.lua
@@ -319,6 +319,15 @@ TokenHud.RegisterPanel{
                 if token.properties.minion and token.properties:has_key("_tmp_minionSquad") then
                     local squad = token.properties._tmp_minionSquad
                     local death = (not squad.damage_time_pending) and squad.damage_taken >= squad.health_single
+
+                    --Traits like Group Appetite: minions never die to ordinary band
+                    --damage, and their real deaths (acid/fire pool-zeroing, ending
+                    --their turn at 0) are fully automated by triggers - never offer
+                    --the manual death-confirmation skull, it reads to players as a
+                    --death being owed.
+                    if death and (token.properties:CalculateNamedCustomAttribute("Gated Minion Deaths") or 0) > 0 then
+                        death = false
+                    end
                     local death_overflows = squad.damage_taken >= (squad.num_recently_damaged+1) * squad.health_single
                     local is_direct_target = token.properties.minionDamageTime == squad.damage_time
                     local has_direct_targets = squad.num_recently_damaged > 0


### PR DESCRIPTION
## What this does

Engine support for traits that react to **multiple squad minions dying at once** — built for the Troll Whelp's *Lingering Hunger* ("whenever two or more whelps are simultaneously reduced to 0 Stamina by damage that isn't acid or fire, half become limbjumbles with 4 Stamina") and the Troll Glutton's *Group Appetite* death gating, but all mechanisms are generic.

### New trigger: `squadminiondeaths` ("Squad Minions Killed")
- Squad minions never fire `zerohitpoints`/`creaturedeath` — the pooled-damage path in `TakeDamage` returns before the death section. This trigger is the first death event that exists for them.
- One area cast kills stamina bands across several per-target damage applications, so kills are **batched per (squad, cast, damage type)** and the trigger fires once per batch. Symbols: `Minions Killed`, `Damage Type`, `Damage`, `attacker`/`hasattacker`; usable in `conditionFormula` and behavior formulas (e.g. `numSummons: floor(Minions Killed / 2)`).

### Confirmation-gated flush (no timers)
A batch fires only when the director's red-skull clicks have confirmed all of the batch's deaths — hooked synchronously at `creature:MinionDeath` (the skull click's sole Lua touchpoint), with a 0.3s poll for cross-client confirmation. Deliberate stances a reviewer may question:
- **No timeout**: deaths that are never confirmed never fire; batches drop if the pool heals back above the killed bands.
- **Confirmations are fungible within a squad**: kill *counts* per batch stay exact (band math per damage type), but which click satisfied which batch is not tracked.
- Dispatch target: a live survivor when one exists; on a full wipe, the last-confirmed minion at the moment of its skull click (token still valid, ahead of the Monster Death removal).
- Known limitation: a player-client full wipe where every squad token is removed before that client's poll runs can drop the dispatch. Director-side play is unaffected.

### Summon behavior extensions (`ActivatedAbilitySummonBehavior`)
- `initialDamageTaken` (GoblinScript): summons spawn below max Stamina. For minions in a fresh squad it is written as **squad-pool damage** (`damage_taken`/`damage_taken_seq`/`damage_taken_minion_count` fan-out — per-token damage is invisible to squad pools). Deliberately not routed through `TakeDamage`: it is spawn state, so no damage triggers, stat-log entries, or kill credit.
- **Fresh-squad default**: minion spawns with no squad-selection UI (non-summoner caster) now open one fresh squad per cast instead of implicitly merging into `"<type> Squad 1"` — which also silently merged damage pools. `joinExistingSquad = true` restores the old merging for reinforcement-style content. *Behavior change for existing death-summon monsters (Gnoll Abyssal Summoner, Kobold Signifier, Hobgoblin Bloodlord): their spawns now form their own squads — please flag if any of those rely on merging.*
- `placementPrompt`: context prefix on the "Place minion N of M" picker ("Lingering Hunger Trait: Place minion 1 of 2").
- Defunct-caster hardening across `Cast` (a caster skull-killed mid-cast no longer crashes look-copy/concentration/history), and the placement picker being externally destroyed now auto-places remaining summons instead of stranding the cast coroutine.

### Death gating + squad naming
- `Gated Minion Deaths` custom attribute: suppresses the manual death skull and pool-based `monster:IsDead` for minions whose deaths are fully trait-driven (Group Appetite).
- `monster.FindFreshSquadName` now consults live map tokens, so a freshly reloaded client (registry is client-local and wiped on Lua reload) cannot hand out a squad name an existing squad already uses.

## Riders
These files carry other tested work interleaved in the same functions/files (separating hunks would produce untested intermediates): **Hide revamp** pieces (Hidden targeting gate in `MCDMRules.lua`, hidden-monster invisibility sync + condition speech in `MCDMCreature.lua`) and the **`DistanceToBoundCreature`** GoblinScript symbol. Happy to split these out if preferred.

## Testing
Exercised live against the Troll Whelp trait: multi-kill single hit (40 dmg / 4 whelps), partial kill (20 dmg / 2 of 4), per-target area batching, fire-damage exclusion, skull-confirmation gating (nothing fires before skulls; trigger fires on the last needed click), fresh-squad naming and 4/8-per-member pool on the spawned limbjumbles, caster killed mid-placement, and placement-picker teardown. Traitless squads see bookkeeping only — no behavior change.
