### PR TITLE
Heals post a visible action-log card (HealChatMessage + HealBehavior.chatMessage)

### DIFF
--- a/DMHub Game Rules/AbilityReplenish.lua
+++ b/DMHub Game Rules/AbilityReplenish.lua
@@ -136,6 +136,59 @@ function ResourceChatMessage:Undo(message)
     message:UploadProperties(self)
 end
 
+--- @class HealChatMessage
+--- @field tokenid string
+--- @field amount number
+--- @field text string
+HealChatMessage = RegisterGameType("HealChatMessage")
+
+HealChatMessage.tokenid = ""
+HealChatMessage.amount = 0
+HealChatMessage.text = ""
+
+--- Gets the token for this message.
+--- @return nil|CharacterToken
+function HealChatMessage:GetToken()
+    return dmhub.GetCharacterById(self.tokenid)
+end
+
+function HealChatMessage.Render(selfInput, message)
+    local token = selfInput:GetToken()
+    if token == nil or (not token.valid) then
+        return gui.Panel{
+            width = 0, height = 0,
+        }
+    end
+
+    local detailLabel = gui.Label{
+        classes = {"action-log-detail", "sizeXs", "fg"},
+        text = string.format("Regained %d Stamina", selfInput.amount),
+    }
+
+    local reasonLabel = nil
+    if selfInput.text ~= "" then
+        reasonLabel = gui.Label{
+            classes = {"action-log-subtext", "sizeXxs", "fgMuted"},
+            text = selfInput.text,
+        }
+    end
+
+    local card = CreateActionLogCard{
+        token = token,
+        content = {detailLabel, reasonLabel},
+    }
+
+    return gui.Panel{
+        classes = {"chat-message-panel"},
+        flow = "vertical",
+        width = "100%",
+        height = "auto",
+        refreshMessage = function(element, message)
+        end,
+        card,
+    }
+end
+
 ActivatedAbilityReplenishBehavior.summary = 'Replenish Resources'
 ActivatedAbilityReplenishBehavior.mode = 'replenish'
 ActivatedAbilityReplenishBehavior.quantity = '1'

--- a/DMHub Game Rules/ActivatedAbility.lua
+++ b/DMHub Game Rules/ActivatedAbility.lua
@@ -3970,6 +3970,9 @@ function ActivatedAbilityBehavior:DescribeRoll(casterCreature, ability, options)
 	return dmhub.EvalGoblinScript(self.roll, casterCreature:LookupSymbol((options or {}).symbols), "Ability or spell roll")
 end
 
+--optional message posted to the chat/action log when this behavior heals a nonzero amount.
+ActivatedAbilityHealBehavior.chatMessage = ""
+
 function ActivatedAbilityHealBehavior:Cast(ability, casterToken, targets, options)
 
     --filter out any targets that cannot heal.
@@ -4029,6 +4032,7 @@ function ActivatedAbilityHealBehavior:Cast(ability, casterToken, targets, option
 			finished = true
             ability:CommitToPaying(casterToken, options)
 			options.symbols.cast.healroll = rollInfo.total
+			local totalHealed = 0
 			for i,target in ipairs(targets) do
 				local targetCreature = target.token.properties
 				for catName,value in pairs(rollInfo.categories) do
@@ -4049,6 +4053,7 @@ function ActivatedAbilityHealBehavior:Cast(ability, casterToken, targets, option
 					}
 
 					options.symbols.cast.healing = options.symbols.cast.healing + healAmount
+					totalHealed = totalHealed + healAmount
 
 					local overheal = math.max(0, healAmount - damageBefore)
 					local healParams = {
@@ -4076,6 +4081,25 @@ function ActivatedAbilityHealBehavior:Cast(ability, casterToken, targets, option
 						healParams.overheal = overheal
 					end
 					track("healing_done", healParams)
+				end
+			end
+
+			--optional chat note, only when we actually healed something.
+			--<<total>> in the message is replaced with the total stamina actually regained.
+			if totalHealed > 0 and self:try_get("chatMessage", "") ~= "" then
+				local msg = string.gsub(self.chatMessage, "<<total>>", tostring(totalHealed))
+				--Post an action-log card showing the healed creature and amount.
+				--tokenMessages on the cast card only render as hover tooltips (and
+				--not at all for the caster), so this is the visible record.
+				chat.SendCustom(HealChatMessage.new{
+					tokenid = targets[1].token.charid,
+					amount = totalHealed,
+					text = msg,
+				})
+				--Also surface the note on the cast's action-log card (no-op when the
+				--cast has no card, e.g. Hidden helper abilities).
+				for _,target in ipairs(targets) do
+					ability.RecordTokenMessage(target.token, options, msg)
 				end
 			end
 


### PR DESCRIPTION
## What this does

Heals never visibly appeared in the Action Log: `HealBehavior` recorded "Regained N Stamina" via `RecordTokenMessage`, but the cast card renders those only as hover tooltips on **target** portraits - and heals applied to the **caster** (`applyto: caster`) produced no visible record anywhere. This PR makes regained Stamina a first-class Action Log event:

- **`HealChatMessage`** - a new action-log card type (modeled on `ResourceChatMessage`): healed creature's portrait, a "Regained N Stamina" detail line, and the ability's message as subtext.
- **`HealBehavior.chatMessage`** - opt-in field on the heal behavior. `<<total>>` in the message is replaced with the Stamina actually regained (post "Stamina Regain Halved", summed across targets). Guarded so a zero heal posts nothing.
- The note is still recorded on the cast card's hover tooltip as before, and works from Hidden helper abilities (which never create a cast card of their own - previously their heals were completely silent).

## Gameplay rules this supports

Ability "Effect" lines that restore Stamina, which the table previously could not see happening:

- **Troll Crack Trooper - Charging Chomp** and **Troll Ravager - Dine and Dash** (Book Two, L9 minions): *"The [crack trooper's/ravager's] squad's Stamina pool regains Stamina equal to half the damage dealt."* The squad-pool heal now posts "Regained N Stamina" with the troll's portrait every strike - central to the trolls-regenerate-unless-burned feel of the encounter, and to players understanding why the squad is not wearing down.
- **Troll Butcher / Troll Glutton - Savoring Bite malice rider**: *"Spend 1 Malice: The [butcher/glutton] regains Stamina equal to the damage dealt."* The invoked Heal Self helper can stay `Hidden` (no duplicate cast card) while the heal itself still logs visibly.
- Generally: any monster or hero heal whose amount the table should witness (regeneration traits, leech effects, malice-fueled recovery) can opt in with one YAML field.

Directors get an auditable record of enemy regeneration; players get the feedback loop the rules text assumes ("the trolls keep healing - stop hitting them with swords").

## Testing

Exercised live: Charging Chomp and Dine and Dash post "The squad's Stamina pool regains N Stamina." cards routed to the squad pool; the Glutton's malice heal posts while its helper ability is Hidden; zero heals post nothing; card renders verified against a live token (theme classes match the resource gain/spend cards).
