### PR TITLE
Warn when shift-dragging a token that cannot shift (Shift Disabled)

### DIFF
--- a/Draw Steel UI/DSHud.lua
+++ b/Draw Steel UI/DSHud.lua
@@ -170,6 +170,17 @@ function GameHud.TokenMoving(self, token, path)
     elseif creature ~= nil and path.shifting then
 		text = string.format(tr('%s\n%s moves %s %s per round when using <b>disengage</b> to shift'), text, creature.GetTokenDescription(token), MeasurementSystem.NativeToDisplayString(creature:CarefulMovementSpeed()), string.lower(MeasurementSystem.UnitName()))
 
+        if (creature:CalculateNamedCustomAttribute("Shift Disabled") or 0) > 0 then
+            local reason = nil
+            for _,modification in ipairs(creature:DescribeModificationsToNamedCustomAttribute("Shift Disabled")) do
+                reason = modification.key
+            end
+            if reason ~= nil then
+                statusText = statusText .. "\n" .. string.format(tr("<color=#ff0000><b>You cannot shift.</b> (%s)</color>"), reason)
+            else
+                statusText = statusText .. "\n" .. tr("<color=#ff0000><b>You cannot shift.</b></color>")
+            end
+        end
 	end
 
     local hazards = path:CalculateHazards(token)


### PR DESCRIPTION
## What this does

When a player holds **shift** while dragging a token (free-form shift movement), the movement tooltip now shows a red **"You cannot shift."** warning if the creature currently has the **Shift Disabled** custom attribute active, including the source of the restriction, e.g.:

> **You cannot shift.** (Ever So Hungry)

Previously this warning only appeared when shifting through the rules engine (e.g. the **Disengage** move ability, which already refuses with red text via the action bar's shift controller). The drag path gave no feedback at all, so a player could shift-drag out of a lockdown zone without ever learning the move was illegal.

## Gameplay rules this supports

In Draw Steel, **shifting** is careful movement: a creature that shifts doesn't provoke free strikes from adjacent enemies. A number of effects take that option away by saying a creature **"can't shift"**, which the codex models with the **Shift Disabled** custom attribute. Examples from the bestiary:

- **Ghoul Craver -- Ever So Hungry:** "Any enemy adjacent to three or more ghoul cravers can't shift." (implemented as a radius-1 aura that sets Shift Disabled when 3+ cravers are adjacent -- the trait that motivated this change)
- **Frost giants (sleeter / wind sprinter / storm hurler / snowblaster):** an enemy that starts their turn within 2 squares of the snowstorm can't shift.
- **Vampire knave / bruxer:** enemies adjacent to the monster can't shift.
- Various ability riders: "the target can't shift until the end of their next turn", etc.

The tactical point of these effects is to pin a hero in place: leaving the monster's reach requires normal movement, which triggers free strikes. If the VTT lets a player shift-drag away silently, that entire cost is bypassed without anyone noticing.

## Implementation

One block in `GameHud.TokenMoving` (`Draw Steel UI/DSHud.lua`), inside the existing `path.shifting` branch that already prints the disengage speed line:

- Checks `creature:CalculateNamedCustomAttribute("Shift Disabled") > 0` -- the same gate the action bar's shift controller and the rules-engine shift command use, so all three paths agree.
- Looks up the restriction's source name via `DescribeModificationsToNamedCustomAttribute("Shift Disabled")`, mirroring the existing "Can Shift In Difficult Terrain" reason display a few lines above.
- Appends to `statusText` with the same wording/format as the existing Disengage warning.

Like the neighbouring "Cannot shift through difficult terrain" message, this is an **advisory**: free-form drag movement is director-trusted and is not hard-blocked. It makes the illegal move visible to the player and the table rather than preventing it outright.