### PR TITLE
Fix Lua error when editing a minion's current Stamina (report 7VZJ6BN8)

### DIFF
--- a/Draw Steel Core Rules/MCDMCreature.lua
+++ b/Draw Steel Core Rules/MCDMCreature.lua
@@ -4371,6 +4371,14 @@ end
 
 local g_creatureSetCurrentHitpoints = creature.SetCurrentHitpoints
 function creature.SetCurrentHitpoints(self, amount, note)
+    if type(amount) == 'string' then
+        amount = tonumber(amount)
+    end
+
+    if type(amount) ~= 'number' then
+        return
+    end
+
     if (not mod.unloaded) and self.minion and self:has_key("_tmp_minionSquad") then
         local token = dmhub.LookupToken(self)
         if token ~= nil then


### PR DESCRIPTION
**Symptom:** Editing the *current* Stamina box of a minion on the character sheet does nothing and throws a Lua error (`attempt to sub a 'number' with a 'string'`).

**Root cause:** `Draw Steel Core Rules/MCDMCreature.lua` overrides `creature.SetCurrentHitpoints` to add minion-squad handling. The minion branch uses `amount` arithmetically (`local damage_taken = self:MaxHitpoints() - amount`) before any validation, and returns without ever reaching the base implementation it wraps. The base `creature.SetCurrentHitpoints` in `DMHub Game Rules/Creature.lua` starts by coercing a string `amount` via `tonumber` and bailing out if the result is not a number -- and callers rely on that: the character sheet passes the raw edit-box text (`creature:SetCurrentHitpoints(element.text)` in `Draw Steel V/DrawSteelChararcterSheet.lua`). For a minion, a non-numeric string (e.g. an emptied or partially typed box) therefore reached the subtraction and raised.

**Fix:** Insert the base implementation's two guards as the first statements of the override, before the minion-squad test. Numeric strings behave exactly as before (Lua was already coercing them implicitly in the subtraction); non-numeric or nil input now silently no-ops on the minion path, matching what the non-minion path already does today. The fall-through call to the base function now receives a number, so its own coercion becomes a no-op. The three internal call sites in `MCDMCreature.lua` already pass numbers.

**Scope note:** This addresses only the Lua error. The separate "value jumps and gains a digit" runaway reported in the same ticket comes from the max-Stamina `modifierDelta` back-solve in `Draw Steel V/DrawSteelChararcterSheet.lua` and is deliberately left alone -- it needs design work.

Report id: 7VZJ6BN8

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
