### PR TITLE
Fix "Add Features..." dropdown breaking on a scalar internal clipboard (report CM7QZ83C)

### DIFF
--- a/Draw Steel UI/DSClassEditor.lua
+++ b/Draw Steel UI/DSClassEditor.lua
@@ -18,7 +18,14 @@ local g_validFeatureTypes = {
 }
 
 local IsCharacterFeatureType = function(item)
-	return item ~= nil and g_validFeatureTypes[item.typeName] == true
+	-- The internal clipboard is a single app-wide value which can legitimately hold a
+	-- scalar (e.g. GoblinScriptEditor's "Copy" copies a numeric result value), so we
+	-- can only index it after checking it is indexable.
+	local t = type(item)
+	if t ~= "table" and t ~= "userdata" then
+		return false
+	end
+	return g_validFeatureTypes[item.typeName] == true
 end
 
 -- Class/ancestry editor search filter. The shared Search.MatchesObject caps its
@@ -157,7 +164,7 @@ local CreateFeatureSummary = function(feature, featuresList, index, parentPanel,
 
 			rightClick = function(element)
 				local clipboardItem = dmhub.GetInternalClipboard()
-				if clipboardItem ~= nil then
+				if type(clipboardItem) == "table" then
 					clipboardItem.guid = dmhub.GenerateGuid()
 				end
 
@@ -386,7 +393,7 @@ local CreateChoiceEditor = function(feature, featuresList, index, parentPanel, c
 		rightClick = function(element)
 
 			local clipboardItem = dmhub.GetInternalClipboard()
-			if clipboardItem ~= nil then
+			if type(clipboardItem) == "table" then
 				clipboardItem.guid = dmhub.GenerateGuid()
 			end
 


### PR DESCRIPTION
**Symptom:** The "Add Features..." dropdown in the Titles / Class / Ancestry compendium editor stops opening entirely -- for every title, in every such editor, until the app is restarted -- throwing `DSClassEditor:21: attempt to index a number value (local 'item')`.

**Root cause:** `IsCharacterFeatureType` indexed anything non-`nil`:

```lua
return item ~= nil and g_validFeatureTypes[item.typeName] == true
```

It is called with `dmhub.GetInternalClipboard()` from the paste option's `text` and `hidden` callbacks. The internal clipboard is a single app-wide value that can legitimately hold a scalar -- e.g. GoblinScriptEditor's "Copy" copies a numeric result value. Indexing a number throws, and the throw happens inside `DMHub Core UI/Dropdown.lua:278` while the `press` handler is building the popup's children. The popup is therefore never attached, which is also why the six already-built option labels appear in the log as orphaned-panel errors. Because the clipboard is app-wide and persistent, every title/class/ancestry editor stays broken for the rest of the session.

The reporter attributed this to deleting a title's last feature, but that is a coincidence -- the failing callback never touches the features list.

Two sibling sites (`clipboardItem.guid = dmhub.GenerateGuid()` in the feature-label and choice-editor `rightClick` handlers) throw the same way on a scalar, which is what blocked the obvious in-app workaround of copying a feature to overwrite the bad clipboard value.

**What this changes** (`Draw Steel UI/DSClassEditor.lua`, three guards):

1. `IsCharacterFeatureType` returns `false` for non-indexable values instead of throwing.
2. / 3. The two `rightClick` handlers guard their `.guid` write with `type(clipboardItem) == "table"` -- already the established idiom elsewhere in this same file.

Behaviour is unchanged for every input that previously worked: a real copied feature is a Lua table and returns the identical value; `nil` and strings already returned false; `userdata` is still treated as indexable. Only genuine scalars change from "throw" to "false", i.e. the paste option is hidden -- the intended state when the clipboard holds no feature. No data migration or user-data repair is needed.

**Deliberately out of scope:** the same `item ~= nil` -> `item.typeName` pattern exists in six other files and is left as a follow-up: `DMHub Compendium/ClassEditor.lua:753`, `Draw Steel Ability Editor/AbilityEditor.lua:5293`/`:5301`, `NewTriggeredAbilityEditor.lua:1663`/`:6646`, `DMHub Game Rules/CharacterFeature.lua:846`, `Draw Steel V/DrawSteelChararcterSheet.lua:8292`. The GoblinScriptEditor copy site is correct as-is and is untouched, as is the engine-side clipboard handling.

Report id: **CM7QZ83C** (client v0.0.795). Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
