### PR TITLE
feat(monsters): monster modes system with character panel mode switcher

### DIFF
--- a/Draw Steel Ability Editor/AbilityEditorModifierPicker.lua
+++ b/Draw Steel Ability Editor/AbilityEditorModifierPicker.lua
@@ -263,6 +263,11 @@ local MODIFIER_METADATA = {
     },
 
     -- Monster Specific
+    monstermodes = {
+        description = "Give the monster multiple modes (e.g. before/after its True Name is spoken); other modifiers gate on Monster Mode.",
+        tags = {"mode", "modes", "monster", "stance", "true name"},
+        group = "monster",
+    },
     modrider = {
         description = "Modify mount-rider configurations.",
         tags = {"mount", "rider", "monster", "modify"},

--- a/Draw Steel Core Rules/MCDMCharacterPanel.lua
+++ b/Draw Steel Core Rules/MCDMCharacterPanel.lua
@@ -1418,6 +1418,21 @@ TacPanelStyles.Routines = ThemeEngine.MergeTokens{
         borderColor = "@border",
     },
 
+    -- Monster-mode chip: exactly one mode is always selected, so the selected
+    -- state gets a full accent fill (the drag-target pairing: @accent bg,
+    -- @fgInverse text) rather than the routine chip's border-only selection.
+    {
+        selectors = {"panel", "mm-chip", "selected"},
+        priority = 5,
+        bgcolor = "@accent",
+        borderColor = "@accent",
+    },
+    {
+        selectors = {"label", "mm-chip", "parent:selected"},
+        priority = 5,
+        color = "@fgInverse",
+    },
+
     -- Routine chip label
     {
         selectors = {"label", "rt-chip"},
@@ -4841,6 +4856,137 @@ function TacPanel.Routines()
             end
 
             element.data.routinePanels = newPanels
+            element:FireEventTree("setContent", children)
+        end,
+        refreshToken = function(element, token)
+            element:FireEvent("refreshCharacter", token)
+        end,
+        setToken = function(element, token)
+            element:FireEvent("refreshCharacter", token)
+        end,
+
+        gui.Panel{
+            classes = {"rt-container"},
+            wrap = true,
+            setContent = function(element, newChildren)
+                element.children = newChildren
+            end,
+        },
+    }
+end
+
+--- The monster modes section: shows only for creatures with a Monster Modes
+--- modifier (see the monstermodes system in MCDMCreature.lua) and lets the
+--- Director switch the creature's current mode. Chips mirror the Routines
+--- section's look; exactly one mode is always selected (mode 1 by default).
+--- The header takes the granting modifier's name (e.g. TRUE NAME) so the
+--- section speaks the statblock's language rather than engine language.
+--- @return Panel
+function TacPanel.MonsterMode()
+    return TacPanel.CollapsiblePanel{
+        sectionId = "monstermode",
+        classes = {"collapsed"},
+        altBg = false,
+        title = "MODES",
+        data = { signature = nil },
+        setCollapse = function(element)
+            element:FireEvent("refreshCharacter", element.data.token)
+        end,
+        refreshCharacter = function(element, token)
+            if token == nil or not token.valid or token.properties == nil then
+                element:SetClass("collapsed", true)
+                element.data.signature = nil
+                return
+            end
+
+            element.data.token = token
+
+            local modes, sectionTitle = token.properties:GetMonsterModes()
+            if modes == nil then
+                element:SetClass("collapsed", true)
+                element.data.signature = nil
+                return
+            end
+
+            element:SetClass("collapsed", false)
+
+            --header takes the granting trait's name (updates even while the
+            --section is collapsed, since the title bar stays visible).
+            local titleText = string.upper(sectionTitle or "Modes")
+            local titleBar = element.children[1]
+            if titleBar ~= nil then
+                for _,child in ipairs(titleBar.children) do
+                    if child:HasClass("panel-title") then
+                        if child.text ~= titleText then
+                            child.text = titleText
+                        end
+                        break
+                    end
+                end
+            end
+
+            if element.data.collapsed then
+                return
+            end
+
+            local selected = token.properties:GetMonsterMode()
+            if selected > #modes then
+                selected = 1
+            end
+
+            --only rebuild the chips when the modes or selection actually change.
+            local sigParts = {}
+            for _,mode in ipairs(modes) do
+                sigParts[#sigParts+1] = string.format("%s/%s", mode.name or "", mode.description or "")
+            end
+            local signature = string.format("%s#%d#%s", table.concat(sigParts, "|"), selected, token.charid)
+            if signature == element.data.signature then
+                return
+            end
+            element.data.signature = signature
+
+            local children = {}
+            for i,mode in ipairs(modes) do
+                local classes = {"rt-chip", "mm-chip"}
+                if i == selected then
+                    classes[#classes+1] = "selected"
+                end
+
+                local hover = nil
+                if mode.description ~= nil and mode.description ~= "" then
+                    hover = gui.Tooltip(mode.description)
+                end
+
+                children[#children+1] = gui.Panel{
+                    classes = classes,
+                    hover = hover,
+                    press = function(el)
+                        if i == selected then
+                            --the creature is always in exactly one mode; no deselect.
+                            return
+                        end
+
+                        local tok = element.data.token
+                        if tok == nil or not tok.valid then
+                            return
+                        end
+
+                        tok:ModifyProperties{
+                            description = tr("Set Monster Mode"),
+                            execute = function()
+                                tok.properties:SetMonsterMode(i)
+                            end,
+                        }
+
+                        element:FireEvent("refreshCharacter", tok)
+                    end,
+                    gui.Label{
+                        classes = {"rt-chip", "mm-chip"},
+                        text = mode.name or string.format("Mode %d", i),
+                    },
+                }
+            end
+
             element:FireEventTree("setContent", children)
         end,
         refreshToken = function(element, token)
@@ -8848,6 +8994,7 @@ end
 
 local TACPANEL_DEFAULT_ORDER = {
     "statistics",
+    "monstermode",
     "summoner",
     "routines",
     "persistentabilities",
@@ -8862,6 +9009,7 @@ local TACPANEL_DEFAULT_ORDER = {
 
 local TACPANEL_FACTORIES = {
     statistics = TacPanel.Statistics,
+    monstermode = TacPanel.MonsterMode,
     routines = TacPanel.Routines,
     persistentabilities = TacPanel.PersistentAbilities,
     heroicresources = TacPanel.HeroicResources,

--- a/Draw Steel Core Rules/MCDMCreature.lua
+++ b/Draw Steel Core Rules/MCDMCreature.lua
@@ -6802,3 +6802,205 @@ end
 dmhub.RegisterEventHandler("ClearTemporaryState", function()
     print("CLEARSTATE:: CLEARING STATE", #dmhub.allTokens)
 end)
+
+
+----------------------------------------------------------------------
+-- Monster Modes
+----------------------------------------------------------------------
+-- A monster can have multiple "monster modes" (e.g. a devil before/after its
+-- True Name is spoken). Modes are declared by a "monstermodes" CharacterModifier
+-- on the monster which lists the mode names. The current mode is stored on the
+-- creature as monsterMode (1-based; 1 is the default). Other modifiers gate
+-- themselves on the mode with a filterCondition like "Monster Mode = 2".
+--
+-- The symbol is deliberately named "Monster Mode", NOT "Mode": "Mode" already
+-- exists in ability contexts (an ability's multi-mode selection) and the two
+-- must not be conflated.
+--
+-- The Director switches modes from the MONSTER MODE section of the character
+-- panel (TacPanel.MonsterMode in MCDMCharacterPanel.lua), which only shows for
+-- creatures that have a monstermodes modifier.
+--
+-- Limitation (by design): one mode dimension per monster. A monster cannot have
+-- e.g. tactical stances AND true-name modes at the same time; the first active
+-- monstermodes modifier wins.
+
+creature.monsterMode = 1
+
+--- The list of modes declared by this creature's monstermodes modifier, each
+--- a {name, description} table, or nil if the creature has no modes (the
+--- normal case). The description is optional and shows as a tooltip on the
+--- mode's chip in the character panel.
+--- Second return: the player-facing section title -- the modifier's name (by
+--- convention the granting trait's name, e.g. "True Name"), so the panel
+--- header echoes the statblock language. Falls back to "Modes" when the
+--- modifier is unnamed or still has the default type name.
+--- @return {name: string, description: nil|string}[]|nil, string|nil
+function creature:GetMonsterModes()
+    local mods = self:GetActiveModifiers()
+    for _,mod in ipairs(mods) do
+        if mod.mod.behavior == "monstermodes" then
+            local modes = mod.mod:try_get("modes")
+            if modes ~= nil and #modes >= 2 then
+                local title = mod.mod:try_get("name")
+                if title == nil or title == "" or title == "Monster Modes" then
+                    title = "Modes"
+                end
+                return modes, title
+            end
+        end
+    end
+
+    return nil
+end
+
+--- The creature's current monster mode (1-based). Always at least 1; clamped to
+--- the declared mode count when the creature has modes.
+--- @return number
+function creature:GetMonsterMode()
+    local mode = self.monsterMode
+    if type(mode) ~= "number" or mode < 1 then
+        return 1
+    end
+
+    return math.floor(mode)
+end
+
+--- Set the current monster mode. Callers outside the character sheet must wrap
+--- this in token:ModifyProperties{}.
+--- @param mode number
+function creature:SetMonsterMode(mode)
+    self.monsterMode = mode
+end
+
+GameSystem.RegisterGoblinScriptField{
+    target = creature,
+    name = "Monster Mode",
+    type = "number",
+    desc = "The monster's current mode (1-based) as chosen in the MONSTER MODE panel. 1 is the default mode. Only meaningful for monsters with a Monster Modes modifier; always 1 otherwise. Distinct from an ability's Mode.",
+    seealso = {},
+    examples = {"Monster Mode = 1", "Monster Mode = 2"},
+    calculate = function(c)
+        return c:GetMonsterMode()
+    end,
+}
+
+CharacterModifier.RegisterType("monstermodes", "Monster Modes")
+
+--a "monstermodes" modifier has the following properties:
+--  - modes: a list of {name, description} tables (at least 2 to be meaningful).
+--    The description is optional; it shows as a tooltip on the mode's chip in
+--    the MONSTER MODE panel.
+--The modifier declares that its bearer has multiple monster modes; it has no
+--direct mechanical effect itself. Do not put a filterCondition on this modifier
+--that references Monster Mode (the mode picker must exist in every mode).
+CharacterModifier.TypeInfo.monstermodes = {
+    init = function(modifier)
+        modifier.modes = {
+            { name = "Mode 1" },
+            { name = "Mode 2" },
+        }
+    end,
+
+    autoDescribe = function(modifier)
+        local modes = modifier:try_get("modes", {})
+        if #modes == 0 then
+            return nil
+        end
+
+        local names = {}
+        for _,mode in ipairs(modes) do
+            names[#names+1] = mode.name or "?"
+        end
+
+        return string.format("Monster Modes: %s", pretty_join_list(names))
+    end,
+
+    createEditor = function(modifier, element)
+        local Refresh
+        local firstRefresh = true
+        Refresh = function()
+            if firstRefresh then
+                firstRefresh = false
+            else
+                element:FireEvent("refreshModifier")
+            end
+
+            local children = {}
+
+            local modes = modifier:try_get("modes", {})
+
+            for i,mode in ipairs(modes) do
+                children[#children+1] = gui.Panel{
+                    classes = {"formPanel"},
+                    gui.Label{
+                        classes = {"formLabel"},
+                        text = string.format("Mode %d:", i),
+                    },
+                    gui.Input{
+                        classes = {"formInput"},
+                        characterLimit = 40,
+                        text = mode.name or "",
+                        change = function(element)
+                            mode.name = element.text
+                            Refresh()
+                        end,
+                    },
+                    gui.DeleteItemButton{
+                        width = 16,
+                        height = 16,
+                        halign = "right",
+                        valign = "center",
+                        click = function()
+                            table.remove(modifier.modes, i)
+                            Refresh()
+                        end,
+                    },
+                }
+
+                children[#children+1] = gui.Panel{
+                    classes = {"formPanel"},
+                    gui.Label{
+                        classes = {"formLabel"},
+                        text = "Description:",
+                    },
+                    gui.Input{
+                        classes = {"formInput"},
+                        multiline = true,
+                        characterLimit = 256,
+                        width = 320,
+                        height = "auto",
+                        minHeight = 40,
+                        maxHeight = 100,
+                        textAlignment = "topleft",
+                        text = mode.description or "",
+                        change = function(element)
+                            if element.text == "" then
+                                mode.description = nil
+                            else
+                                mode.description = element.text
+                            end
+                        end,
+                    },
+                }
+            end
+
+            children[#children+1] = gui.PrettyButton{
+                text = "Add Mode",
+                width = 140,
+                height = 30,
+                fontSize = 16,
+                halign = "left",
+                click = function()
+                    modifier.modes = modifier:try_get("modes", {})
+                    modifier.modes[#modifier.modes+1] = { name = string.format("Mode %d", #modifier.modes+1) }
+                    Refresh()
+                end,
+            }
+
+            element.children = children
+        end
+
+        Refresh()
+    end,
+}


### PR DESCRIPTION
﻿## Summary Adds a generic "monster modes" system: a monster can declare multiple modes (e.g. a devil before/after its True Name is spoken, tactical stances, forms) and the Director switches between them from the character panel. Other modifiers and ability modes gate on the current mode via GoblinScript. Built as the shared mechanism for the Devil band's True Name trait; the Devil Jurist YAML that uses it ships separately in draw-steel-data once this is released.  ## Changes - New `monstermodes` CharacterModifier type (MCDMCreature.lua): declares a list of modes, each a name plus an optional description shown as a chip tooltip. - `creature:GetMonsterModes()/GetMonsterMode()/SetMonsterMode()`; the current mode is stored on the creature as `monsterMode` (default 1). - New GoblinScript symbol `Monster Mode` (number, 1-based) on creature, so modifiers can gate with `filterCondition: Monster Mode = 2` and ability modes with `modeList[].condition`. Named deliberately to avoid colliding with an ability's `Mode`. - New character panel section (MCDMCharacterPanel.lua): routine-style chips, only visible when the creature has a monstermodes modifier. The header takes the granting modifier's name (e.g. TRUE NAME) so it reads as statblock language; the selected chip gets an accent fill; mode descriptions show on hover. - Modifier picker entry under Monster Specific (AbilityEditorModifierPicker.lua).  ## Testing Live-tested over the MCP bridge on a Devil Jurist implementing True Name: mode switching via real chip clicks (press -> ModifyProperties -> restyle -> GoblinScript reads the new value), filterCondition gating verified in both directions on resistance and suppressabilities modifiers, ability modeList conditions verified end-to-end through the cast bar and roll dialog. Cleanly hot-reloads.  ## Notes for reviewer - One mode dimension per monster by design (first active monstermodes modifier wins). - The data-side pattern is documented in draw-steel-data (MONSTERS.md, MONSTER_PATTERNS.md, GOBLINSCRIPT-SYMBOLS.md) in the commit that implements the Jurist. - The panel section id is `monstermode` for ordering prefs regardless of the displayed header.  🤖 Generated with [Claude Code](https://claude.com/claude-code)