### PR TITLE
fix(actionbar): refresh the ability card when a multi-mode ability switches modes

### DIFF
--- a/Draw Steel Core Rules/MCDMActivatedAbility.lua
+++ b/Draw Steel Core Rules/MCDMActivatedAbility.lua
@@ -554,6 +554,14 @@ end
 
 --- @return boolean Whether this ability's tooltip render changes depending on the mode.
 function ActivatedAbility:RenderVariesWithDifferentModes()
+    --a mode that carries a full variation ability replaces the whole render
+    --(name, tiers, description) when switched to, not just a behavior subset.
+    for _, mode in ipairs(self:try_get("modeList", {})) do
+        if mode.variation ~= nil then
+            return true
+        end
+    end
+
     for _, behavior in ipairs(self.behaviors) do
         if behavior.typeName == "ActivatedAbilityPowerRollBehavior" and #behavior:try_get("modesSelected", {}) > 0 then
             return true

--- a/DrawSteelActionBar/DrawSteelActionBar.lua
+++ b/DrawSteelActionBar/DrawSteelActionBar.lua
@@ -4526,10 +4526,16 @@ CreateAbilityController = function()
                             g_forcedMovementTypePanel:FireEvent("refreshForcedMovement")
                             g_channeledResourcePanel:FireEventTree("focusspell")
 
-                            --If the spell's tooltip varies depending on the mode, then refresh it.
+                            --If the spell's render varies depending on the mode (a
+                            --variation swap or mode-gated power rolls), re-display the
+                            --ability card so it shows the switched mode's content
+                            --rather than the mode it was first displayed with. This
+                            --also covers the auto-switch when the previously selected
+                            --mode's condition fails (see the ScheduleEvent press
+                            --below), which otherwise leaves a stale card up through
+                            --the whole targeting phase.
                             if g_currentAbility ~= nil and g_currentAbility:RenderVariesWithDifferentModes() then
-                                --TODO: refresh tooltip.
-                                --m_currentSpellPanel.data.tooltipSource:FireEvent("showtooltip")
+                                CharacterPanel.DisplayAbility(g_token, g_currentAbility, g_currentSymbols)
                             end
                         end,
                     }


### PR DESCRIPTION
﻿## Summary
Fixes a stale ability card during targeting for multi-mode abilities. When a mode switch happened after the card was first displayed - in particular the automatic switch to the first available mode when the previously selected mode's condition fails (e.g. a monster-mode-gated signature ability) - the pre-cast card kept showing the original mode's name, tiers, and effect text, and only corrected itself once the roll dialog opened.

## Changes
- DrawSteelActionBar.lua: implements the existing `TODO: refresh tooltip` in the mode chip press handler by re-displaying the ability card with the switched ability (also covers the scheduled auto-press path).
- MCDMActivatedAbility.lua: `RenderVariesWithDifferentModes()` now also returns true when a modeList entry carries a full `variation` ability - previously it only detected `modesSelected` behaviors, so the refresh gate could never fire for variation swaps.

## Testing
Live-tested over the MCP bridge: cast a variation-carrying multi-mode ability (Devil Jurist Fire and Brimstone with its True Name variation) in the gated mode; the targeting card now shows the variation's name, tiers, and effect text instead of the base mode's. Manual mode switching on `modesSelected`-style abilities re-renders the card as well. Cleanly hot-reloads.

## Notes for reviewer
Independent of the monster modes PR (#197) - this benefits any multi-mode ability, including existing malice-variant monsters, though the auto-switch path is most visible with condition-gated modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)