### PR TITLE
Fix Lua error storm from lobby hud missing GetCurrentlyPresentedDialog (report FXMRPRPU)

### DIFF
--- a/DMHub Game Hud/GameHud.lua
+++ b/DMHub Game Hud/GameHud.lua
@@ -927,6 +927,14 @@ local function CreateLobbyHud(dialog, tokenInfo)
 
 	GameHud.instance = gamehud
 
+	--The lobby hud has no present-to-players machinery, but callers such as
+	--DocumentSystem's present button poll this on every think. Reading an
+	--undefined field on a Hud userdata raises a Lua error, so define the
+	--accessor here; nothing is ever presented in the lobby.
+	gamehud.GetCurrentlyPresentedDialog = function()
+		return nil
+	end
+
 	local mainDialogPanel = gamehud:MainDialogPanel()
 
     local m_recordedPopup = nil


### PR DESCRIPTION
**Symptom:** In a player's own lobby game, opening a document floods the log with `Attempt to read unknown field GetCurrentlyPresentedDialog in type Hud` at roughly five errors per second.

**Root cause:** `DMHub Game Hud/GameHud.lua` has two hud-construction paths. The full campaign hud defines an instance accessor `gamehud.GetCurrentlyPresentedDialog` (~line 1131), but the lobby hud built by `CreateLobbyHud` never does -- even though it builds `gamehud:CreateDocumentsPanel()`, so documents are openable there.

`DocumentSystem/DocumentSystem.lua`'s "Present to Players" button (`thinkTime = 0.2`) calls `hud.GetCurrentlyPresentedDialog()` on every think whenever a document dialog is open and `dmhub.isDM` is true -- always true in one's own lobby game. Because `DMHub Core UI/Hud.lua:431` does `RegisterGameType("GameHud", "Hud")`, hud instances are backed by engine `Hud` userdata, and *reading* an undefined field on that userdata raises a Lua error rather than returning nil. That is why the existing `local hud = GameHud and GameHud.instance; if not hud then return end` guard does not help, and why a defensive `if hud.GetCurrentlyPresentedDialog == nil` test at the call site would also throw. The fix therefore has to live on the lobby hud.

**What this changes:** Adds the missing accessor to `CreateLobbyHud`, returning `nil`. Eight added lines, no other change.

- Returning nil is semantically correct: there is nobody to present to in the lobby.
- `GetCurrentlyPresentedDialog` has exactly one caller in the repo (`DocumentSystem/DocumentSystem.lua:1207`), and it already handles a nil return: `if presentedDialog ~= nil and presentedDialog.dialog == "document" and ... then`.
- The full campaign hud still assigns its own version and is untouched.
- The class-level helpers the same button uses (`GameHud.PresentDialogToUsers`, `GameHud.HidePresentedDialog`) are plain class-table functions and already resolve fine on the lobby hud.

**Related / possible follow-up:** This is the same family of defect as the known `createItemDialog`-missing-on-lobby-hud issues. A broader sweep for other campaign-hud-only *instance* fields that are polled from shared code would be a sensible follow-up, but is out of scope here.

**Scope note:** Report FXMRPRPU's main subject is a separate connectivity failure (game server reachable but snapshot never arrives, from a censored region). This PR addresses only the secondary Lua error spam visible in the same report and deliberately touches no networking or engine code.

Report id: FXMRPRPU. Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
