### PR TITLE
Fix anthem preview ignoring anthem volume in Appearance tab (report ZGG5K45P)

### DIFF
--- a/DMHub CharacterSheet Base/CharacterSheetAppearance.lua
+++ b/DMHub CharacterSheet Base/CharacterSheetAppearance.lua
@@ -2697,6 +2697,10 @@ function CharSheet.AppearancePanel()
                     hmargin = 32,
                     autoplay = true,
                     refreshAppearance = function(element, info)
+                        --apply the token's configured anthem volume BEFORE assigning value:
+                        --setting value runs the AudioEditor's SetValue -> UpdateAutoplay, which
+                        --starts the preview at autoplayVolume, which defaults to 1 (max).
+                        element:FireEvent("volume", CharacterSheet.instance.data.info.token.anthemVolume or 1)
                         element.value = CharacterSheet.instance.data.info.token.anthem
                     end,
                     change = function(element)


### PR DESCRIPTION
**Symptom:** Opening the character sheet's Appearance tab auto-previews the character's anthem at maximum volume, ignoring the Anthem volume slider right below it (the reporter's saved `anthemVolume` was 0.075, so the preview was ~13x louder than the anthem ever is in play).

**Root cause:** The anthem `gui.AudioEditor` in `DMHub CharacterSheet Base/CharacterSheetAppearance.lua` is built with `autoplay = true`, but its `refreshAppearance` handler only did `element.value = ...token.anthem`. Assigning `value` runs the control's `SetValue` -> `UpdateAutoplay` (`DMHub Core UI/Gui.lua`), which does `autoplayInstance = asset:Play(); autoplayInstance.volume = autoplayVolume`. Since the caller passes no `autoplayvolume` and never fired the control's `volume` event, `autoplayVolume` was still at its default of `1`. The Anthem slider's `change`/`confirm` handlers do fire `volume` on the anthem panel tree, which is why dragging the slider corrects a playing preview - and why the level resets to max on every freshly built sheet.

**Fix:** In that `refreshAppearance`, fire the AudioEditor's existing `volume` event with the token's `anthemVolume` *before* assigning `element.value`, so `autoplayVolume` is already correct at the moment `UpdateAutoplay` calls `asset:Play()`. This reuses the control's existing, already-exercised event path - no API or signature changes. If the same anthem is already previewing, `UpdateAutoplay` early-returns and the `volume` event has still corrected the live instance. `anthemVolume` defaults to 1 for tokens that never touched the slider, so their behaviour is unchanged.

Not included (tracked separately, lower priority): the preview instance has no `mixGroupId`, so unlike a real in-game anthem it also bypasses the "Anthem" category fader. That needs an addition to the shared `gui.AudioEditor` control and is deliberately out of scope here.

Report: `ZGG5K45P`. Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
