### PR TITLE
Fix vertical forced movement treating altitude deltas as absolute (report 6QDKM5SD)

### DIFF
--- a/DMHub Game Rules/ActivatedAbility.lua
+++ b/DMHub Game Rules/ActivatedAbility.lua
@@ -1112,7 +1112,7 @@ function ActivatedAbility:TargetLocMaxElevationChangeFunction(casterToken, symbo
     --Teleport targeting: distance is Chebyshev -- max(|dx|, |dy|, |dz|) -- so a
     --"teleport 5" may end up to 5 squares above or below the creature's current
     --altitude, independently of the horizontal component (which the radius marker
-    --already bounds). Unlike the forced-movement calculators below, this returns
+    --already bounds). Like the forced-movement calculators below, this returns
     --ABSOLUTE altitudes; landing on the ground at the target tile is the lowest
     --possible landing spot.
     if (self.targetType == "emptyspace" or self.targetType == "anyspace") and self:try_get("behaviors") ~= nil and self:GetMovementType(casterToken, symbols) == "teleport" then
@@ -1156,6 +1156,12 @@ function ActivatedAbility:TargetLocMaxElevationChangeFunction(casterToken, symbo
  
                 local distanceStart = math.max(startingAltitudeDelta, originLoc:DistanceInTiles(casterToken.loc))
 
+                --The vertical calculators below work in deltas internally but must
+                --return ABSOLUTE altitudes, since the action bar's altitude controller
+                --feeds the result straight into loc:WithAltitude. Anchor them on the
+                --altitude of the creature being moved.
+                local casterAlt = casterToken.loc.altitude
+
                 if forcedMovement == "vertical_push" or forcedMovement == "vertical_pull" then
                     return function(loc)
                         local min = nil
@@ -1183,11 +1189,11 @@ function ActivatedAbility:TargetLocMaxElevationChangeFunction(casterToken, symbo
                             end
 
                         end
-                        return (min or 0), (max or 0)
+                        return casterAlt + (min or 0), casterAlt + (max or 0)
                     end
                 elseif forcedMovement == "vertical_slide" then
                     return function(loc)
-                        return -symbols.range, symbols.range
+                        return casterAlt - symbols.range, casterAlt + symbols.range
                     end
                 end
             end


### PR DESCRIPTION
**Symptom:** A creature grabbed and held aloft at altitude 7, given a vertical slide of 6, was moved to altitude 6 -- one square DOWN instead of six up -- and then took 12 falling damage.

## Root cause

`ActivatedAbility:TargetLocMaxElevationChangeFunction` (`DMHub Game Rules/ActivatedAbility.lua`) returns altitude **deltas** from its two vertical forced-movement branches:

- `vertical_push` / `vertical_pull`: `return (min or 0), (max or 0)` -- `min`/`max` are loop indices in `-range..range`
- `vertical_slide`: `return -symbols.range, symbols.range`

Every consumer treats the returned `(min, max)` pair as **absolute** altitudes. Both `DrawSteelActionBar/DrawSteelActionBar.lua` and `Draw Steel UI/DSActionBar.lua` do `alt = maxAltitude` (the default target is `"max"`) or `math.clamp(target, minAltitude, maxAltitude)` and then `info.loc = info.loc:WithAltitude(alt)`. The teleport branch at the top of the same function already returns absolute altitudes.

The offered altitude therefore equalled the range exactly, ignoring the target's own altitude. This was harmless while the vertical variants only ran on targets standing on the ground (altitude 0, where delta == absolute). It became visible once forced movement started auto-converting push/pull/slide to the vertical variants for flying targets and targets grabbed by a flyer -- i.e. exactly the targets that are above altitude 0.

## What this changes

Anchors both vertical branches on the moved creature's current altitude (`casterToken` in this function is the creature being force-moved; the forced-movement ability clone's caster is the target):

- `vertical_push` / `vertical_pull`: `return casterAlt + (min or 0), casterAlt + (max or 0)`
- `vertical_slide`: `return casterAlt - symbols.range, casterAlt + symbols.range`

plus one `local casterAlt` and a comment; the stale "Unlike the forced-movement calculators below" note on the teleport branch is corrected now that the function's contract is uniform.

Deliberately **not** changed:

- The push/pull loop body is untouched -- `i` must stay a delta there, and `altitudeDelta = (casterToken.loc.altitude + i) - invoker.loc.altitude` was already correct.
- No ground clamp is added to the minimum. The push/pull loop's allowed set can be narrower than `+-range`, and clamping the min up to the hovered tile's ground altitude could make min > max and break the consumers' `math.clamp`.

Because the shift is uniform, min <= max still holds. For a target at altitude 0 the returned values are identical to today's, so no existing on-the-ground behavior changes.

Report: `6QDKM5SD`. Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
