### PR TITLE
Fix stale "Playing in Campaign" banner on emptied hero slots (report TRTW2425)

### DIFF
--- a/Codex Titlescreen/CodexTitlescreen.lua
+++ b/Codex Titlescreen/CodexTitlescreen.lua
@@ -4347,7 +4347,7 @@ local function MakeHeroPanel(heroIndex)
         -- playingInCampaignBanner class supplies @bgAlt bgcolor via the
         -- Heroes column's MergeStyles extras. The {banner} class stays
         -- for the existing hover-brightness rules below.
-        classes = { "collapsed", "banner", "playingInCampaignBanner" },
+        classes = { "collapsed", "banner", "playingInCampaignBanner", "hiddenWithNoCharacter" },
         width = "94%",
         height = "20% width",
         bgimage = true,


### PR DESCRIPTION
**Symptom:** On the titlescreen HEROES roster, deleting a hero leaves the deleted hero's "Playing in Campaign / <campaign name>" banner painted on the now-empty slot.

**Root cause:** In `MakeHeroPanel` (`Codex Titlescreen/CodexTitlescreen.lua`), the slot's `characters` handler does `element:SetClassTree("nocharacter", c == nil)` and then fires `refreshCharacter` **only when a character is present**. Every other element in the slot (avatar, name, details, join button, delete button) carries the `hiddenWithNoCharacter` class, which the slot's own style rule (`selectors = { "hiddenWithNoCharacter", "nocharacter" }, hidden = 1`) hides as soon as the slot empties. The campaign banner was the sole exception: its visibility was driven purely by `refreshCharacter` setting `collapsed`, an event that never runs for an empty slot, so the banner kept whatever state its previous occupant left behind. Because heroes are sorted and mapped to fixed slots 1..8, deleting heroes compacts the list and strands the banner on the tail slots.

Secondary consequence: the stale banner also kept `element.data.game` set, so pressing the banner strip of an apparently empty slot called `lobby:EnterGame(...)` instead of starting hero creation.

**Fix:** Add `"hiddenWithNoCharacter"` to the banner's class list so it follows the same empty-slot rule as every other element in the slot. One line, no logic changes.

The style rule requires *both* selectors, so this is inert whenever a hero occupies the slot (`nocharacter` is false then) and the existing `collapsed` logic continues to govern that case unchanged. When a slot is later refilled, `SetClassTree("nocharacter", false)` runs before `FireEventTree("refreshCharacter", ...)`, and `FireEventTree` (unlike `FireEventTreeVisible`) dispatches regardless of hidden state, so the banner reactivates and re-collapses correctly.

**Report:** `TRTW2425`

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
