### PR TITLE
Monster modes: a squad minion's mode change applies to its whole squad

### DIFF
--- a/Draw Steel Core Rules/MCDMCharacterPanel.lua
+++ b/Draw Steel Core Rules/MCDMCharacterPanel.lua
@@ -4971,12 +4971,18 @@ function TacPanel.MonsterMode()
                             return
                         end
 
-                        tok:ModifyProperties{
-                            description = tr("Set Monster Mode"),
-                            execute = function()
-                                tok.properties:SetMonsterMode(i)
-                            end,
-                        }
+                        --a squad minion's mode change applies to its whole
+                        --squad (never the captain); one combined undo step.
+                        local squadToks = creature.GetMonsterModeChangeTokens(tok, i)
+                        for _,squadTok in ipairs(squadToks) do
+                            squadTok:ModifyProperties{
+                                description = tr("Set Monster Mode"),
+                                combine = true,
+                                execute = function()
+                                    squadTok.properties:SetMonsterMode(i)
+                                end,
+                            }
+                        end
 
                         element:FireEvent("refreshCharacter", tok)
                     end,

--- a/Draw Steel Core Rules/MCDMCreature.lua
+++ b/Draw Steel Core Rules/MCDMCreature.lua
@@ -6821,6 +6821,12 @@ end)
 -- panel (TacPanel.MonsterMode in MCDMCharacterPanel.lua), which only shows for
 -- creatures that have a monstermodes modifier.
 --
+-- Squad rule (designer-specified): changing the mode on a minion in a minion
+-- squad changes the mode of every minion in that squad -- a squad acts as a
+-- single unit. Only that squad is affected (not other squads of the same
+-- monster type), and never the captain, who changes modes independently. See
+-- creature.GetMonsterModeChangeTokens.
+--
 -- Limitation (by design): one mode dimension per monster. A monster cannot have
 -- e.g. tactical stances AND true-name modes at the same time; the first active
 -- monstermodes modifier wins.
@@ -6871,6 +6877,41 @@ end
 --- @param mode number
 function creature:SetMonsterMode(mode)
     self.monsterMode = mode
+end
+
+--- The tokens whose monster mode changes together when tok's mode is set.
+--- Mode changes on a minion in a squad are squad-wide by design (a squad acts
+--- as a single unit), so for a squad minion this is the minion plus every
+--- other minion in its squad. The captain is a non-minion and is never
+--- included; a captain's own mode changes independently. Squadmates that do
+--- not declare a mode at the target index are skipped. For a non-minion, or a
+--- minion with no squad, this is just tok.
+--- @param tok CharacterToken
+--- @param mode number The target mode (1-based).
+--- @return CharacterToken[]
+function creature.GetMonsterModeChangeTokens(tok, mode)
+    local result = {tok}
+
+    local props = tok.properties
+    if props == nil or (not props.minion) then
+        return result
+    end
+
+    local squad = props:MinionSquad()
+    if squad == nil then
+        return result
+    end
+
+    for _,other in ipairs(dmhub.allTokens) do
+        if other.charid ~= tok.charid and other.properties ~= nil and other.properties.minion and other.properties:MinionSquad() == squad then
+            local modes = other.properties:GetMonsterModes()
+            if modes ~= nil and mode <= #modes then
+                result[#result+1] = other
+            end
+        end
+    end
+
+    return result
 end
 
 GameSystem.RegisterGoblinScriptField{


### PR DESCRIPTION
## Summary
Designer-specified update to the monster modes system (#197): minions in a squad act as a single unit, so changing the monster mode on one squad minion now changes it for every minion in that squad.

## Changes
- New helper `creature.GetMonsterModeChangeTokens(tok, mode)` in `MCDMCreature.lua`: for a squad minion, returns the minion plus every other minion sharing its `MinionSquad()` name; for any other creature, just the token itself. The captain is never included (captains are non-minions), and other squads of the same monster type are unaffected (distinct squad names). Squadmates that do not declare a mode at the target index are skipped (mixed-squad safety).
- The mode-chip press handler in `MCDMCharacterPanel.lua` now loops that list with `combine = true` `ModifyProperties`, so the whole squad flips as one undoable step.
- Squad rule documented in the Monster Modes section comment.

## Testing
Smoke-tested over the MCP bridge with two Devil Clerk squads plus a Devil Jurist captain assigned to squad A: flipping a squad-A clerk to True Name Spoken flipped all squad-A clerks only (squad B and the captain untouched); flipping back worked the same; changing the captain's mode affected only the captain. Human-verified in the character panel UI: chip press flips the squad, one undo reverts it.

## Notes for reviewer
Captain mode changes stay independent in both directions per the designer spec ("just the members of the squad"). If a captain flip should ever carry its squad, that is a one-line change in the same helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
