### PR TITLE
Fix minion squad effect attribution

### DIFF
--- a/DMHub Game Rules/AbilityInvokeAbility.lua
+++ b/DMHub Game Rules/AbilityInvokeAbility.lua
@@ -463,7 +463,34 @@ function ActivatedAbilityInvokeAbilityBehavior:Cast(ability, casterToken, target
                         end
 
                         print("Invoke:: Execute...")
-                        local invokerToken = cond(self.invokeOnCaster, casterToken, target.token)
+                        --invokeOnCaster: in a squad coordinated strike the "caster" for THIS
+                        --target's invoke is the main minion for that creature (invokeSource,
+                        --computed above via MainAttackerForTarget), not the cast's lead minion.
+                        --Without squad pairing invokeSource IS casterToken, so this is a no-op.
+                        --
+                        --When the behavior's applyto is "caster" or "caster_including_squad",
+                        --ApplyToTargets has already resolved each entry in `targets` to the
+                        --caster-side token that should act (the per-unique-target main
+                        --attackers, or each squad member). That token IS the intended caster
+                        --of the invoke: re-deriving it via MainAttackerForTarget would look
+                        --the minion up on the target side of targetPairs, find nothing, and
+                        --fall back to the cast lead -- making the lead cast every copy. For
+                        --a non-squad caster both values equal casterToken, so this is a
+                        --no-op there. Deliberately NOT applied to the other caster_* mappings
+                        --(caster_summoner, caster_companion, caster_riders, caster_minions,
+                        --caster_and_targets): for those the mapped token is a DIFFERENT
+                        --creature than the caster, and invokeOnCaster keeps its meaning of
+                        --"the caster casts it, once per mapped creature".
+                        local invokerToken
+                        if self.invokeOnCaster then
+                            if self.applyto == "caster" or self.applyto == "caster_including_squad" then
+                                invokerToken = target.token
+                            else
+                                invokerToken = invokeSource
+                            end
+                        else
+                            invokerToken = target.token
+                        end
                         self.ExecuteInvoke(invokeSource, abilityClone, invokerToken, self.targeting, symbols, options)
                     end
                 end

--- a/Draw Steel Core Rules/MCDMAbilityBehavior.lua
+++ b/Draw Steel Core Rules/MCDMAbilityBehavior.lua
@@ -98,9 +98,18 @@ function ActivatedAbilityDrawSteelCommandBehavior:Cast(ability, casterToken, tar
                 -- Cast.Memory("StartX") set by an earlier RememberBehavior.
                 local ruleSymbols = table.shallow_copy(options.symbols or {})
                 ruleSymbols.target = GenerateSymbols(target.token.properties)
-                local rule = StringInterpolateGoblinScript(self.rule, casterToken.properties:LookupSymbol(ruleSymbols))
+                --For applyto=caster, ApplyToTargets has already mapped each squad
+                --coordinated-strike target to its main attacker (the first minion
+                --to attack that creature); that minion is the actor for caster-pass
+                --rules like "shift 1", not the cast's lead minion. Without squad
+                --pairing the mapped target IS the caster, so this is a no-op.
+                local commandCaster = casterToken
+                if self.applyto == "caster" then
+                    commandCaster = target.token
+                end
+                local rule = StringInterpolateGoblinScript(self.rule, commandCaster.properties:LookupSymbol(ruleSymbols))
                 --print("INTERPOLATE::", self.rule, "->", rule)
-                self:ExecuteCommand(ability, casterToken, target.token, options, rule)
+                self:ExecuteCommand(ability, commandCaster, target.token, options, rule)
             end
         end
     until promptWhenResolving == false or targetChoices == nil or #targetChoices == 0
@@ -162,6 +171,17 @@ local function InvokeAbility(ability, abilityClone, targetToken, casterToken, op
     abilityClone.keywords = ability.keywords
     abilityClone.notooltip = true
     abilityClone.skippable = true
+
+    --The parent's keywords are copied above, so an invoke from a Strike (e.g. a
+    --minion signature's "shift 1" effect) carries the "Strike" keyword. If the
+    --creature casting the invoked ability is a minion in a squad, that makes
+    --UsesSquadCoordination/UsesSquadStrike fire on the clone, and GetNumTargets
+    --multiplies the target count by the squad's minion count -- the action bar
+    --then waits for N destination spaces ("1/4 targets") instead of 1. Invoked
+    --effect abilities (shift, teleport, etc.) are always per-creature, never
+    --squad-coordinated, so opt out explicitly. Same fix as the forced-movement
+    --pattern's abilityAttr.disableSquadCoordination below.
+    abilityClone.disableSquadCoordination = true
 
     local casting = false
 

--- a/Draw Steel Core Rules/MCDMAbilityRollBehavior.lua
+++ b/Draw Steel Core Rules/MCDMAbilityRollBehavior.lua
@@ -1273,7 +1273,13 @@ function ActivatedAbilityPowerRollBehavior:Cast(ability, casterToken, targets, o
     local m_canceled = false
 
     local tiers = DeepCopy(self.tiers)
-    if ability.description ~= "" and ability:try_get("implementation", 3) ~= 3 and ActivatedAbilityDrawSteelCommandBehavior.ValidateRule(ability.description) == true then
+    --Below Silver, a rule-parseable description (the ability's "Effect:" line) is
+    --auto-appended to every tier so it executes as part of the roll -- the
+    --auto-parse IS the implementation at that level. At Silver and above the
+    --effect is expected to be implemented with explicit behaviors, so appending
+    --would execute it twice (confirmed live with the Devil Scrivener's "shift 1"
+    --at Gold-eligible settings). Gate is < Silver, not ~= Silver.
+    if ability.description ~= "" and ability:try_get("implementation", 3) < gui.ImplementationStatus.Silver and ActivatedAbilityDrawSteelCommandBehavior.ValidateRule(ability.description) == true then
         --append the rule to the tiers if it is a valid rule that could
         --appear on a power roll.
         for i=1,#tiers do

--- a/Draw Steel Core Rules/MCDMActivatedAbility.lua
+++ b/Draw Steel Core Rules/MCDMActivatedAbility.lua
@@ -1216,7 +1216,11 @@ function ActivatedAbility:Render(options, params)
     end
 
     local description = self.description
-    if description ~= "" and self:try_get("implementation", 3) ~= 3 and ActivatedAbilityDrawSteelCommandBehavior.ValidateRule(description) ~= true then
+    --Display twin of the tier-append gate in MCDMAbilityRollBehavior: below
+    --Silver, a description that does NOT parse as a rule is dimmed to signal it
+    --will not execute. At Silver and above the effect is implemented with
+    --explicit behaviors, so the description is normal prose -- never dimmed.
+    if description ~= "" and self:try_get("implementation", 3) < gui.ImplementationStatus.Silver and ActivatedAbilityDrawSteelCommandBehavior.ValidateRule(description) ~= true then
         description = string.format("<alpha=#55>%s<alpha=#ff>", description)
     end
 
@@ -2938,9 +2942,12 @@ local g_prevTargetingRays = nil
 
 -- Explicit player locks: minion->target hard commitments set by the action
 -- bar (click a squad minion, then a target). Entries are {a = minionTokenId,
--- b = targetTokenId}, newest first, so the most recent lock on a creature
--- claims its first slot and becomes its main attacker (see
--- ActivatedAbilityCast:MainAttackerForTarget). One lock per minion.
+-- b = targetTokenId}, oldest first, so the FIRST minion locked onto a
+-- creature claims its first slot and becomes its main attacker (see
+-- ActivatedAbilityCast:MainAttackerForTarget) -- the one that makes the
+-- power roll and receives caster-side effects. Later locks on the same
+-- creature gang up as extra attackers. One lock per minion; re-locking a
+-- minion moves its entry to the end (its new choice is the newest).
 -- Cleared by the action bar at targeting start and cancel.
 --- @type {a: string, b: string}[]
 local g_squadLocks = {}
@@ -2949,12 +2956,13 @@ local g_squadLocks = {}
 -- minion. Returns the number of locks now aimed at targetToken so the UI can
 -- make sure the target has a slot per lock.
 function ActivatedAbility.LockSquadTargetingPair(minionToken, targetToken)
-    local newLocks = { { a = minionToken.id, b = targetToken.id } }
+    local newLocks = {}
     for _, lock in ipairs(g_squadLocks) do
         if lock.a ~= minionToken.id then
             newLocks[#newLocks + 1] = lock
         end
     end
+    newLocks[#newLocks + 1] = { a = minionToken.id, b = targetToken.id }
     g_squadLocks = newLocks
 
     local count = 0


### PR DESCRIPTION
## Summary

- Preserve the first minion assigned to a target as that target's main attacker.
- Execute caster-side command and invoke effects from the mapped minion instead of the squad's initiating token.
- Prevent parser-generated power-table effect abilities from re-entering squad coordination.
- Auto-append rule-parsed description effects only below Silver, preventing Silver and Gold abilities with explicit behaviors from executing the effect twice.

## Why

Squad targeting correctly mapped each unique target to a main attacker, but later effect execution could fall back to whichever minion initiated the squad action. Target locks were also stored newest-first, allowing later extra attackers to displace the player's intended main attacker. Invoked effect abilities inherited the parent Strike keyword and could therefore incorrectly multiply their own targets through squad coordination.

The implementation-status gate also treated Gold differently from Silver, causing rule-parsed descriptions to be appended at Gold even though explicit behaviors already implemented the effect.

## Verification

- Live-tested the Devil Scrivener so each unique-target main attacker performs its own shift once.
- Live-tested a four-minion Decrepit Skeleton squad against two heroes; the first minion assigned to each hero received the extra-damage selection.
- Live-tested the Wode Elf Runner's charge shift per unique-target attacker.
- Verified the explicit Invoke Ability `useSquadCoordination` path remains intact and the companion, summoner, rider, and minion caster mappings retain their previous semantics.
- Confirmed all four Lua files are ASCII-only and the staged diff passes the repository's CRLF-aware whitespace check.

## Files

- `DMHub Game Rules/AbilityInvokeAbility.lua`
- `Draw Steel Core Rules/MCDMAbilityBehavior.lua`
- `Draw Steel Core Rules/MCDMAbilityRollBehavior.lua`
- `Draw Steel Core Rules/MCDMActivatedAbility.lua`

No monster YAML or `data/` changes are included.
