### PR TITLE
feat(goblinscript): add Cast.TargetsAdjacent symbol

### DIFF
--- a/DMHub Game Rules/ActivatedAbilityCast.lua
+++ b/DMHub Game Rules/ActivatedAbilityCast.lua
@@ -279,6 +279,13 @@ ActivatedAbilityCast.helpSymbols = {
             "Any Target Has(\"Mark\", Triggerer)",
         },
     },
+
+    targetsadjacent = {
+        name = "Targets Adjacent",
+        type = "boolean",
+        desc = "True if this cast currently has two or more targets and every pair of targets is adjacent to each other (within 1 square, accounting for the full space occupied by larger tokens). False if the cast has fewer than two targets.",
+        examples = {"Cast.TargetCount = 2 and Cast.TargetsAdjacent"},
+    },
 }
 
 ActivatedAbilityCast.lookupSymbols = {
@@ -525,6 +532,50 @@ ActivatedAbilityCast.lookupSymbols = {
 
 		return result
 	end,
+
+    -- True if this cast has 2 or more targets and every pair of targets is
+    -- adjacent (within 1 square, using token:Distance which accounts for the
+    -- full space occupied by multi-square tokens). Works for creature and
+    -- object targets alike; a target whose token has despawned falls back to
+    -- its recorded loc, and a target with neither a live token nor a loc is
+    -- skipped. Returns false when fewer than 2 measurable targets remain.
+    targetsadjacent = function(c)
+        local points = {}
+        for _, target in ipairs(c:try_get("targets", {})) do
+            if target.token ~= nil and target.token.valid then
+                points[#points+1] = { token = target.token }
+            elseif target.loc ~= nil then
+                points[#points+1] = { loc = target.loc }
+            end
+        end
+
+        if #points < 2 then
+            return false
+        end
+
+        for i = 1, #points-1 do
+            for j = i+1, #points do
+                local a = points[i]
+                local b = points[j]
+                local dist
+                if a.token ~= nil and b.token ~= nil then
+                    dist = a.token:Distance(b.token)
+                elseif a.token ~= nil then
+                    dist = a.token:Distance(b.loc)
+                elseif b.token ~= nil then
+                    dist = b.token:Distance(a.loc)
+                else
+                    dist = a.loc:DistanceInTiles(b.loc)
+                end
+
+                if dist == nil or dist > 1 then
+                    return false
+                end
+            end
+        end
+
+        return true
+    end,
 
 	spacesmoved = function(c)
 		return c.spacesMoved


### PR DESCRIPTION
## Summary
Adds a new GoblinScript cast symbol, `Cast.TargetsAdjacent`, that reports whether all of a cast's current targets are adjacent to each other. This lets data authors automate "if the targets are adjacent to each other" ability riders, which previously could not self-detect (power-roll modifiers evaluate per target and had no view of the relationship between targets).

## Changes
- `DMHub Game Rules/ActivatedAbilityCast.lua`: new `targetsadjacent` entry in `helpSymbols` (shows in the Character Inspector help) and `lookupSymbols`.
- Semantics: true when the cast has 2+ targets and every pair is within 1 square; false with fewer than two measurable targets. Distance uses `token:Distance`, so multi-square tokens measure edge-to-edge, and object targets work the same as creatures. A target whose token has despawned falls back to its recorded loc; a target with neither is skipped.

## Testing
- Live-tested in the Codex on the Devil Legate's Infernal Pike (2-target melee strike with a "+3 damage if the targets are adjacent to each other" rider, `displayCondition: Cast.TargetCount = 2 and Cast.TargetsAdjacent`): rider appears/ticks for both targets when they are adjacent, hidden otherwise. Verified adjacent, non-adjacent, and single-target casts.
- Formula evaluation also exercised over the scripting bridge against a constructed cast.

## Notes for reviewer
- Symbol returns false for 0/1 targets by design; a duplicate-target cast (same creature twice) would measure distance 0 and count as adjacent, so authors should not use it on `repeatTargets` abilities without considering that.
- First data consumer is the Devil Legate in draw-steel-data; the YAML degrades gracefully (rider row simply hidden) on clients without this symbol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
