### PR TITLE
Fix blank journal template list at Font Size above 100% (report CMNP4HZU)

### DIFF
--- a/DocumentSystem/MarkdownDocCreate.lua
+++ b/DocumentSystem/MarkdownDocCreate.lua
@@ -107,7 +107,7 @@ function MarkdownDocument:ShowCreateDialog()
                     textOverflow = "ellipsis",
                     textWrap = false,
                     width = "100%",
-                    height = 20,
+                    height = 30,
                 },
                 {
                     selectors = {"label", "hover"},


### PR DESCRIPTION
**Symptom:** In the journal's Create Document dialog, every entry in the "Choose Template" list on the left renders with no text at all - the rows and the selection highlight paint, but zero glyphs are drawn.

**Root cause:** `DocumentSystem/MarkdownDocCreate.lua` styles the template rows with a fixed `height = 20` alongside `fontSize = 16`, `textWrap = false` and `textOverflow = "ellipsis"`. `SheetLabel.UpdateLabelStyle` multiplies the point size by `GameConfig.fontMagnification` (the Settings -> General -> Font Size preference divided by 100), and the theme's label font (Berlingske Slab) has a 1.20 em line box. The single line's height is therefore `1.20 * 16 * magnification`, which must fit the 20px row:

- at 100%: 19.2px <= 20 -> renders (only 0.8px of headroom, which is why a default install looks fine)
- at 110%: 21.1px > 20 -> vertical overflow

On vertical overflow with `TextOverflowModes.Ellipsis`, TMP hits the "no ellipsis insertion candidate" branch, because the *first* line is already the one that does not fit, and sets `m_characterCount = 0`. The whole string is dropped - not even an ellipsis is drawn. This blanks the list for every Font Size option above 100% (110/120/130/140).

**Fix:** Raise the row height in that one style rule from `20` to `30`. The worst case is the 140% setting at `1.20 * 16 * 1.40 = 26.9px`, so 30 clears it with headroom while staying a fixed, bounded row height. The rows sit in a vertical-flow scroll panel, so taller rows simply flow. `textAlignment = "left"` is vertically middle-aligned, so the extra space distributes evenly above and below the text rather than shifting it. `textOverflow = "ellipsis"` is deliberately kept - its horizontal truncation is still wanted for long template names in the 200px-wide column.

One line changed; no other properties and no neighbouring style rules were touched.

**Note:** the same fixed-height-just-above-1.2x-fontSize pattern appears in a few other panels and is likely to blank out at some Font Size step too; a general helper that sizes such rows from `fontSize * 1.2 * fontMagnification` would close the class. That is deliberately out of scope here.

Report `CMNP4HZU`. This PR originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
