### PR TITLE
feat(triggers): support nested-ability outcome flows on power roll triggers

### DIFF
--- a/Draw Steel UI/DSRequestRollsDialog.lua
+++ b/Draw Steel UI/DSRequestRollsDialog.lua
@@ -399,6 +399,38 @@ function RollCheck.LoadSkills()
 end
 
 
+--A roll request whose checks carry options.parallelWithRollDialog = true is
+--allowed to surface its prompt while another roll dialog is on screen. Used by
+--triggered tests (e.g. Devilish Charm's Presence test) that must resolve while
+--the roll that triggered them is still open and pending. Everything else keeps
+--the historical behavior of deferring until no roll dialog is shown. pcall
+--guarded so an exotic request payload can never break the listener panel.
+local function RequestAllowsParallelPrompt(request)
+    local result = false
+    pcall(function()
+        if request.info.typeName ~= "RollRequest" then
+            return
+        end
+        for _,check in ipairs(request.info.checks or {}) do
+            local opts = check:try_get("options")
+            if opts ~= nil and opts.parallelWithRollDialog then
+                result = true
+                return
+            end
+        end
+    end)
+    return result
+end
+
+local function HaveParallelPromptRequest()
+    for _,request in pairs(dmhub.GetPlayerActionRequests() or {}) do
+        if RequestAllowsParallelPrompt(request) then
+            return true
+        end
+    end
+    return false
+end
+
 --this is a hidden panel which just listens for required rolls.
 function GameHud:RequireRollListenerPanel()
 
@@ -425,24 +457,36 @@ function GameHud:RequireRollListenerPanel()
 			--Otherwise a table roll (e.g. the Conduit prayer, which routes to the
 			--standalone host) pops on top of an in-flight ability/ongoing-effect
 			--roll shown in the embedded dialog. See CharacterPanel.AnyRollDialogShown.
-			if CharacterPanel.AnyRollDialogShown() then
-				if self.rollDialog.data.IsShown() and showingRollId == gamehud.rollDialog.data.rollid then
-					--we requested the current roll dialog that is shown. See if our reason
-					--for doing so has been canceled, in which case we want to close that dialog.
-					if dmhub.GetPlayerActionRequest(rollRequestId) == nil then
-						self.rollDialog.data.Cancel()
-					end
-				end
+			--Exception: requests flagged parallelWithRollDialog (see
+			--RequestAllowsParallelPrompt above) surface immediately; only the
+			--flagged requests are processed in that state, everything else keeps
+			--deferring until the blocking dialog closes.
+			local dialogShown = CharacterPanel.AnyRollDialogShown()
 
-				--we are currently blocked by a roll dialog. Try again in a little while.
+			if dialogShown and self.rollDialog.data.IsShown() and showingRollId == gamehud.rollDialog.data.rollid then
+				--we requested the current roll dialog that is shown. See if our reason
+				--for doing so has been canceled, in which case we want to close that dialog.
+				if dmhub.GetPlayerActionRequest(rollRequestId) == nil then
+					self.rollDialog.data.Cancel()
+				end
+			end
+
+			if dialogShown then
+				--we are currently blocked by a roll dialog. Try again in a little
+				--while. (Also scheduled in the parallel fall-through, so deferred
+				--non-flagged requests still surface once the dialog closes.)
 				element:ScheduleEvent("refreshGame", 0.2)
 
-				return
+				if not HaveParallelPromptRequest() then
+					return
+				end
 			end
 
 			local requests = dmhub.GetPlayerActionRequests()
 			for k,request in pairs(requests) do
-				if request.info.typeName == 'RestRequest' then
+				if dialogShown and not RequestAllowsParallelPrompt(request) then
+					--still deferred behind the open roll dialog.
+				elseif request.info.typeName == 'RestRequest' then
 					--request for resting, see if we want to handle it and if we do go over to that.
 					if self:TryHandleRestRequest(k, request) then
 						return

--- a/DrawSteelActionBar/DrawSteelTriggerPanel.lua
+++ b/DrawSteelActionBar/DrawSteelTriggerPanel.lua
@@ -38,6 +38,81 @@ local function BuildRetargetCandidates(powerMod, symbols)
     return targets, reasons
 end
 
+-- Opens the retarget picker for a trigger whose triggerBefore flow has
+-- completed and marked the trigger as needing a new-target choice (the
+-- serialized triggerBeforeRetarget flag, set by the trigger's own nested
+-- ability -- e.g. Devilish Charm tier 1). Mirrors the immediate changeTarget
+-- press flow below, but re-fetches the live trigger by id when the choice is
+-- made so a stale snapshot can never be dispatched.
+local function RunTriggerRetargetChoice(element, triggerToken, trigger)
+    local targetToken = nil
+    if #trigger.targets > 0 then
+        targetToken = dmhub.GetTokenById(trigger.targets[1])
+    end
+    local casterToken = nil
+    if trigger.casterid then
+        casterToken = dmhub.GetTokenById(trigger.casterid)
+    end
+    if targetToken == nil or casterToken == nil then
+        return
+    end
+
+    local symbols = {
+        current = targetToken.properties:LookupSymbol{},
+        triggerer = triggerToken.properties:LookupSymbol{},
+        caster = casterToken.properties:LookupSymbol{},
+    }
+    local powerMod = trigger.powerRollModifier.powerRollModifier
+    local targets, retargetReasons = BuildRetargetCandidates(powerMod, symbols)
+
+    local sourceToken = triggerToken
+    local range = tonumber(ExecuteGoblinScript(trigger.powerRollModifier.range, triggerToken.properties:LookupSymbol(symbols), 10))
+    local rangeType = powerMod:try_get("changeTargetRange", "none")
+    if rangeType == "ability" then
+        sourceToken = casterToken
+        range = trigger.originalAbilityRange
+    elseif rangeType == "distance" then
+        range = powerMod:try_get("changeTargetDistance", 10)
+    end
+
+    local controller = element:Get("abilityController")
+    if controller == nil then
+        return
+    end
+
+    local trigid = trigger.id
+    controller:FireEventTree("chooseTarget", {
+        sourceToken = sourceToken,
+        radius = range,
+        targets = targets,
+        reasons = retargetReasons,
+        choose = function(newTargetToken)
+            if triggerToken == nil or not triggerToken.valid then
+                return
+            end
+
+            triggerToken:ModifyProperties{
+                undoable = false,
+                description = "Trigger",
+                execute = function()
+                    local live = triggerToken.properties:GetAvailableTriggers() or {}
+                    local t = live[trigid]
+                    if t == nil then
+                        return
+                    end
+                    t.triggered = true
+                    t.retargetid = newTargetToken.charid
+                    t.triggerBeforeRetarget = false
+                    triggerToken.properties:DispatchAvailableTrigger(t)
+                end,
+            }
+        end,
+
+        cancel = function()
+        end,
+    })
+end
+
 mod.shared.triggerGradient = gui.Gradient{
     type = "radial",
     point_a = {x = 0.5, y = 0.5},
@@ -402,7 +477,7 @@ mod.shared.CreateTriggerPanel = function()
                                     audio.DispatchSoundEvent("Notify.TriggerUse", {})
 
 
-                                    if (not trigger.triggered) and #trigger.targets > 0 and trigger.powerRollModifier and trigger.powerRollModifier.powerRollModifier:try_get("changeTarget") then
+                                    if (not trigger.triggered) and #trigger.targets > 0 and trigger.powerRollModifier and trigger.powerRollModifier.powerRollModifier:try_get("changeTarget") and not trigger.powerRollModifier.powerRollModifier:try_get("hasTriggerBefore") then
                                         --this changes the target of the trigger.
 								        local targetToken = dmhub.GetTokenById(trigger.targets[1])
                                         local casterToken = dmhub.GetTokenById(trigger.casterid)
@@ -511,6 +586,23 @@ mod.shared.CreateTriggerPanel = function()
                                                             }
                                                         end
                                                     end
+
+                                                    --If the trigger-before flow marked this trigger as needing a
+                                                    --new-target choice (the serialized triggerBeforeRetarget flag,
+                                                    --set by the nested ability's own logic -- e.g. Devilish Charm
+                                                    --tier 1), open the retarget picker now. Read the live trigger
+                                                    --from the token: the panel's availableTriggers snapshot may
+                                                    --predate the nested ability's dispatch.
+                                                    if triggerToken.valid then
+                                                        local live = triggerToken.properties:GetAvailableTriggers() or {}
+                                                        local freshTrigger = live[key]
+                                                        if freshTrigger ~= nil and freshTrigger:try_get("triggerBeforeRetarget", false)
+                                                                and freshTrigger.powerRollModifier
+                                                                and freshTrigger.powerRollModifier.powerRollModifier:try_get("changeTarget")
+                                                                and not freshTrigger.retargetid then
+                                                            RunTriggerRetargetChoice(parentElement, triggerToken, freshTrigger)
+                                                        end
+                                                    end
                                                 end
                                             end,
                                         })
@@ -543,7 +635,15 @@ mod.shared.CreateTriggerPanel = function()
 								end,
 							}
 
-							local enhancementOptions = trigger:EnhancementOptions(g_token)
+							--hideEnhancementOptions (on the powertabletrigger modifier) is an
+							--opt-in for triggers whose outcome is decided by a nested
+							--trigger-before ability (e.g. Devilish Charm's Presence test):
+							--the additional cost modifiers still exist as outcome data, but
+							--they are not offered as manually pressable options.
+							local enhancementOptions = {}
+							if not (trigger.powerRollModifier and trigger.powerRollModifier:try_get("hideEnhancementOptions", false)) then
+								enhancementOptions = trigger:EnhancementOptions(g_token)
+							end
 							for index,option in ipairs(enhancementOptions) do
 								buttons[#buttons+1] = gui.Label{
 									classes = {"triggerButton"},
@@ -553,7 +653,7 @@ mod.shared.CreateTriggerPanel = function()
 
                                         audio.DispatchSoundEvent("Notify.TriggerUse", {})
 
-                                        if (not trigger.triggered) and #trigger.targets > 0 and trigger.powerRollModifier and trigger.powerRollModifier.powerRollModifier:try_get("changeTarget") then
+                                        if (not trigger.triggered) and #trigger.targets > 0 and trigger.powerRollModifier and trigger.powerRollModifier.powerRollModifier:try_get("changeTarget") and not trigger.powerRollModifier.powerRollModifier:try_get("hasTriggerBefore") then
                                             --this changes the target of the trigger.
                                             local targetToken = dmhub.GetTokenById(trigger.targets[1])
                                             local casterToken = dmhub.GetTokenById(trigger.casterid)
@@ -772,7 +872,7 @@ mod.shared.CreateTriggerPanel = function()
 
                                     audio.DispatchSoundEvent("Notify.TriggerUse", {})
 
-                                    if (not trigger.triggered) and #trigger.targets > 0 and trigger.powerRollModifier and trigger.powerRollModifier.powerRollModifier:try_get("changeTarget") then
+                                    if (not trigger.triggered) and #trigger.targets > 0 and trigger.powerRollModifier and trigger.powerRollModifier.powerRollModifier:try_get("changeTarget") and not trigger.powerRollModifier.powerRollModifier:try_get("hasTriggerBefore") then
                                         --this changes the target of the trigger.
 								        local targetToken = dmhub.GetTokenById(trigger.targets[1])
                                         local casterToken = dmhub.GetTokenById(trigger.casterid)
@@ -880,6 +980,23 @@ mod.shared.CreateTriggerPanel = function()
                                                                     triggerToken.properties:DispatchAvailableTrigger(trigger)
                                                                 end,
                                                             }
+                                                        end
+                                                    end
+
+                                                    --If the trigger-before flow marked this trigger as needing a
+                                                    --new-target choice (the serialized triggerBeforeRetarget flag,
+                                                    --set by the nested ability's own logic -- e.g. Devilish Charm
+                                                    --tier 1), open the retarget picker now. Read the live trigger
+                                                    --from the token: the panel's availableTriggers snapshot may
+                                                    --predate the nested ability's dispatch.
+                                                    if triggerToken.valid then
+                                                        local live = triggerToken.properties:GetAvailableTriggers() or {}
+                                                        local freshTrigger = live[key]
+                                                        if freshTrigger ~= nil and freshTrigger:try_get("triggerBeforeRetarget", false)
+                                                                and freshTrigger.powerRollModifier
+                                                                and freshTrigger.powerRollModifier.powerRollModifier:try_get("changeTarget")
+                                                                and not freshTrigger.retargetid then
+                                                            RunTriggerRetargetChoice(parentElement, triggerToken, freshTrigger)
                                                         end
                                                     end
                                                 end
@@ -1065,7 +1182,15 @@ mod.shared.CreateTriggerPanel = function()
 
                             local children = {triggerPanel}
 
-							local enhancementOptions = trigger:EnhancementOptions(g_token)
+							--hideEnhancementOptions (on the powertabletrigger modifier) is an
+							--opt-in for triggers whose outcome is decided by a nested
+							--trigger-before ability (e.g. Devilish Charm's Presence test):
+							--the additional cost modifiers still exist as outcome data, but
+							--they are not offered as manually pressable options.
+							local enhancementOptions = {}
+							if not (trigger.powerRollModifier and trigger.powerRollModifier:try_get("hideEnhancementOptions", false)) then
+								enhancementOptions = trigger:EnhancementOptions(g_token)
+							end
 							for index,option in ipairs(enhancementOptions) do
 								children[#children+1] = gui.Panel{
 									classes = {"triggerPanel"},
@@ -1154,7 +1279,7 @@ mod.shared.CreateTriggerPanel = function()
 
                                         audio.DispatchSoundEvent("Notify.TriggerUse", {})
 
-                                        if (not trigger.triggered) and #trigger.targets > 0 and trigger.powerRollModifier and trigger.powerRollModifier.powerRollModifier:try_get("changeTarget") then
+                                        if (not trigger.triggered) and #trigger.targets > 0 and trigger.powerRollModifier and trigger.powerRollModifier.powerRollModifier:try_get("changeTarget") and not trigger.powerRollModifier.powerRollModifier:try_get("hasTriggerBefore") then
                                             --this changes the target of the trigger.
                                             local targetToken = dmhub.GetTokenById(trigger.targets[1])
                                             local casterToken = dmhub.GetTokenById(trigger.casterid)

--- a/Timeline/EmbeddedRollDialog.lua
+++ b/Timeline/EmbeddedRollDialog.lua
@@ -2167,7 +2167,11 @@ function GameHud.CreateEmbeddedRollDialog()
                 if token ~= nil then
                     local tokenTriggers = token.properties:GetAvailableTriggers() or {}
                     local tokenTrigger = tokenTriggers[trigger.id]
-                    if tokenTrigger ~= nil and tokenTrigger.triggered ~= trigger.triggered then
+                    --retargetid is part of the change detection: a trigger whose
+                    --new target is chosen AFTER activation (e.g. a trigger-before
+                    --flow like Devilish Charm tier 1) updates retargetid without
+                    --flipping triggered, and that change must still sync.
+                    if tokenTrigger ~= nil and (tokenTrigger.triggered ~= trigger.triggered or tokenTrigger.retargetid ~= trigger.retargetid) then
                         trigger.triggered = tokenTrigger.triggered
                         trigger.retargetid = tokenTrigger.retargetid
                         trigger.dismissed = tokenTrigger.dismissed
@@ -3177,7 +3181,15 @@ function GameHud.CreateEmbeddedRollDialog()
                         if triggeredModifier then
                             local token = dmhub.GetTokenById(mod.modifier._tmp_triggerCharid)
                             if token ~= nil then
-                                text = string.format("%s (%s)", text, token.name)
+                                --token.name can be nil (e.g. locally-spawned tokens);
+                                --fall back to description rather than showing "(nil)".
+                                local tokenName = token.name
+                                if tokenName == nil or tokenName == "" then
+                                    tokenName = token.description
+                                end
+                                if tokenName ~= nil and tokenName ~= "" then
+                                    text = string.format("%s (%s)", text, tokenName)
+                                end
                             end
                         else
                             --resource usage gets an availability description.
@@ -3523,7 +3535,15 @@ function GameHud.CreateEmbeddedRollDialog()
                         if triggeredModifier then
                             local token = dmhub.GetTokenById(mod.modifier._tmp_triggerCharid)
                             if token ~= nil then
-                                text = string.format("%s (%s)", text, token.name)
+                                --token.name can be nil (e.g. locally-spawned tokens);
+                                --fall back to description rather than showing "(nil)".
+                                local tokenName = token.name
+                                if tokenName == nil or tokenName == "" then
+                                    tokenName = token.description
+                                end
+                                if tokenName ~= nil and tokenName ~= "" then
+                                    text = string.format("%s (%s)", text, tokenName)
+                                end
                             end
                         else
                             local availability = mod.modifier:DescribeResourceAvailability(creature,


### PR DESCRIPTION
## Summary
Four small core changes that let a power roll trigger resolve a nested ability (a triggerBefore test) *while the triggering roll's dialog is still open*, and act on its outcome -- selecting an augmentation, or choosing a new target for the triggering strike. All changes are opt-in flags or targeted bug fixes; no existing content sets the new flags. First consumer is the Devil Jurist's Devilish Charm (data repo, held until this merges).

## Changes
- **DSRequestRollsDialog.lua** -- the roll-request prompt listener has always deferred every request while any roll dialog is on screen, so a roll that needs to happen *during* another roll could never surface. A request whose checks carry `options.parallelWithRollDialog = true` now shows immediately; everything else defers exactly as before.
- **DrawSteelTriggerPanel.lua** -- a trigger with both a `changeTarget` config and a `triggerBefore` ability used to open the target picker on press and never run the nested ability. Now the nested ability runs first, and if it marks the trigger with a serialized `triggerBeforeRetarget` flag, the existing `complete` callback opens the standard retarget picker (new file-local `RunTriggerRetargetChoice`, mirroring the press-flow picker but re-fetching the live trigger by id on choose). Also adds an opt-in `hideEnhancementOptions` field on the powertabletrigger modifier that stops additional-cost modifiers rendering as their own pressable cards, for triggers whose outcome is decided by the nested ability.
- **EmbeddedRollDialog.lua** -- `charactersUpdated` only re-synced a trigger when `triggered` changed, so a `retargetid` arriving after activation was silently dropped (latent bug; the old picker flow always set both at once). `retargetid` is now part of the change detection. Also a cosmetic fix: trigger-source suffixes on modifier chips fall back to the token description when `token.name` is nil (was rendering "(nil)").
- The legacy twins (`DSRollDialog.lua`, `DSActionBar.lua`) contain the same sync gate / press-handler code and were deliberately left untouched; if they are ever revived they will want the same retargetid fix.

## Testing
Live-tested end to end on the Devil Jurist's Devilish Charm (strike-triggered Presence test with three tier outcomes): all three tiers verified -- retarget redirects the pending strike to the chosen token, halve/bane augmentations apply to the open roll, malice cost charged exactly once per use, canceled nested test degrades to a plain activation. Regression-tested ordinary strike rolls (open/roll/re-roll/accept/cancel), an existing hasTriggerBefore trigger with no new config, and the Time Raider Tyrannis's Precog Reflexes (populated additional-cost modifiers WITHOUT the new hide flag -- both option cards still render and press correctly).

## Notes for reviewer
The pause between the triggering roll and its outcome is deliberately human-mediated: the attacker's dialog never auto-accepts, so nothing blocks the roll lifecycle -- the nested test just needs its prompt to be allowed on screen (the DSRequestRollsDialog change) and its outcome to sync back (the EmbeddedRollDialog change). Everything rides the existing ActiveTrigger dispatch/sync machinery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)