### PR TITLE
Fix Power Table Effect behavior showing as "Power Roll Effect" once added (report 9F2V7C3G)

### DIFF
--- a/Draw Steel Core Rules/MCDMAbilityBehavior.lua
+++ b/Draw Steel Core Rules/MCDMAbilityBehavior.lua
@@ -17,7 +17,7 @@ end
 --- Executes a GoblinScript "rule" as part of the ability's power table effect resolution.
 ActivatedAbilityDrawSteelCommandBehavior = RegisterGameType("ActivatedAbilityDrawSteelCommandBehavior", "ActivatedAbilityBehavior")
 
-ActivatedAbilityDrawSteelCommandBehavior.summary = 'Power Roll Effect'
+ActivatedAbilityDrawSteelCommandBehavior.summary = 'Power Table Effect'
 ActivatedAbilityDrawSteelCommandBehavior.rule = ''
 
 ActivatedAbility.RegisterType


### PR DESCRIPTION
**Symptom:** In the Add Behavior picker the entry reads "Power Table Effect", but once you add it the behavior card header reads "Power Roll Effect" - the name changes at the moment of selection.

**Root cause:** `ActivatedAbilityDrawSteelCommandBehavior` (id `draw_steel_command`) has two user-facing names in `Draw Steel Core Rules/MCDMAbilityBehavior.lua`. The picker renders the registered type's `text` ('Power Table Effect', line 26), while behavior cards render the class's `summary` field, which was set to 'Power Roll Effect' (line 20).

"Power Table Effect" is the correct name: the behavior executes power-table rule strings (`shift 3`, `2 fire damage`) through the rules engine and does not itself make a power roll. `data/docs/reference/MONSTERS.md` documents it as "registered as \"Power Table Effect\"", the picker's own description is "Apply an effect from the power table.", and a separate type, `ActivatedAbilityPowerRollBehavior`, is the actual power roll - so "Power Roll Effect" was also confusable with that neighbouring entry.

**What the fix changes:** One line - `summary` becomes `'Power Table Effect'`. That single edit corrects every display site fed by `summary`: the new ability/trigger editor behavior-card header (the reported case), the legacy compendium editor header, the Apply-To GoblinScript help text (previously "this Power Roll Effect behavior"), and `ActivatedAbility:BehaviorSummary()`.

**Safety:** `summary` is display-only here. The literal "Power Roll Effect" occurred exactly once in the repo (this line); it is absent from the engine and from the data content repo, so it is never persisted in saved behavior instances. Nothing branches on this value - the only equality tests against `.summary` anywhere are for "Attack", "Damage" and "Heal". No mechanical behavior changes. `luac -p` passes; the file stays ASCII-only.

Report: `9F2V7C3G`

This PR originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
