### PR TITLE
Add Damage Dice trigger symbol to Take Damage / Damage an Enemy

### DIFF
--- a/Draw Steel Ability Behaviors/AbilityDamage.lua
+++ b/Draw Steel Ability Behaviors/AbilityDamage.lua
@@ -157,6 +157,7 @@ function ActivatedAbilityDamageBehavior:Cast(ability, casterToken, targets, opti
 
         local rollStr = dmhub.EvalGoblinScript(targetGroup.roll, casterToken.properties:LookupSymbol(symbols), string.format("Damage roll for %s", ability.name))
         local isRolledDamage = not dmhub.IsRollDeterministic(rollStr)
+        local damageDice = GameSystem.GetDamageDiceInRoll(rollStr)
 		local rollid = nil
         print("ROLL:: SHOW", rollStr)
 
@@ -346,7 +347,7 @@ function ActivatedAbilityDamageBehavior:Cast(ability, casterToken, targets, opti
 						description = "Damaged",
 						execute = function()
 							for _,entry in ipairs(damageEntries) do
-								local res = targetCreature:InflictDamageInstance(entry.amount, entry.catName, ability.keywords, entry.desc, {attacker = casterToken.properties, ability = ability, hasability = true, pusher = options.symbols.pusher, cannotBeReduced = self:try_get("cannotBeReduced"), doesNotTrigger = self:try_get("doesNotTrigger"), hasrolleddamage = isRolledDamage, cast = options.symbols.cast, patrondamage = entry.patrondamage})
+								local res = targetCreature:InflictDamageInstance(entry.amount, entry.catName, ability.keywords, entry.desc, {attacker = casterToken.properties, ability = ability, hasability = true, pusher = options.symbols.pusher, cannotBeReduced = self:try_get("cannotBeReduced"), doesNotTrigger = self:try_get("doesNotTrigger"), hasrolleddamage = isRolledDamage, damagedice = damageDice, cast = options.symbols.cast, patrondamage = entry.patrondamage})
 								options.symbols.cast:CountDamage(target.token, res.damageDealt, entry.amount, isRolledDamage, entry.patrondamage)
                                 print("DAMAGE:: COUNT", res.damageDealt)
 							end

--- a/Draw Steel Core Rules/MCDMAbilityBehavior.lua
+++ b/Draw Steel Core Rules/MCDMAbilityBehavior.lua
@@ -196,6 +196,7 @@ local function ExecuteDamage(behavior, ability, casterToken, targetToken, option
     local damageType = match.type or "untyped"
     local damage = tonumber(match.damage)
     local isRolledDamage = damage == nil
+    local damageDice = GameSystem.GetDamageDiceInRoll(match.damage)
 
     --Patron damage handling (Acolyte class).
     --The literal token "patron" in tier/rule text is a placeholder for the
@@ -340,7 +341,7 @@ local function ExecuteDamage(behavior, ability, casterToken, targetToken, option
                 description = "Inflict Damage",
                 undoable = false,
                 execute = function()
-                    result = targetToken.properties:InflictDamageInstance(damage, damageType, ability.keywords, string.format("%s's %s", selfName, ability.name), { criticalhit = false, attacker = attacker, surges = options.surges, ability = ability, hasability = true, cast = options.symbols.cast, hasrolleddamage = isRolledDamage, patrondamage = patrondamage, cannotBeReduced = ignoreImmunity})
+                    result = targetToken.properties:InflictDamageInstance(damage, damageType, ability.keywords, string.format("%s's %s", selfName, ability.name), { criticalhit = false, attacker = attacker, surges = options.surges, ability = ability, hasability = true, cast = options.symbols.cast, hasrolleddamage = isRolledDamage, damagedice = damageDice, patrondamage = patrondamage, cannotBeReduced = ignoreImmunity})
                     options.symbols.cast:CountDamage(targetToken, result.damageDealt, damage, isRolledDamage, patrondamage)
 
                     --Damage halved away by (half) power-roll modifiers counts as

--- a/Draw Steel Core Rules/MCDMCreature.lua
+++ b/Draw Steel Core Rules/MCDMCreature.lua
@@ -5525,6 +5525,7 @@ function creature.TakeDamage(self, amount, note, info)
         eventArg.rawdamage = info.rawdamage
         eventArg.damageimmunity = info.damageImmunity and info.damageImmunity.dr ~= nil
         eventArg.damagetype = eventArg.damagetype or "none"
+        eventArg.damagedice = eventArg.damagedice or StringSet.new{}
         eventArg.hasattacker = eventArg.attacker ~= nil
         eventArg.surges = info.surges or 0
         eventArg.edges = 0
@@ -5566,6 +5567,7 @@ function creature.TakeDamage(self, amount, note, info)
                 ability = eventArg.ability,
                 usedability = eventArg.ability,
                 hasrolleddamage = eventArg.hasrolleddamage,
+                damagedice = eventArg.damagedice,
                 --The ActivatedAbilityCast associated with this damage, if any.
                 --hascast lets trigger formulas guard before reading Cast.Tier etc.
                 cast = eventArg.cast,
@@ -5686,6 +5688,7 @@ function creature.TakeDamage(self, amount, note, info)
     eventArg.rawdamage = info.rawdamage
     eventArg.damageimmunity = info.damageImmunity and info.damageImmunity.dr ~= nil
     eventArg.damagetype = eventArg.damagetype or "untyped"
+    eventArg.damagedice = eventArg.damagedice or StringSet.new{}
     eventArg.hasattacker = eventArg.attacker ~= nil
     eventArg.surges = info.surges or 0
     eventArg.edges = 0
@@ -5839,6 +5842,7 @@ function creature.TakeDamage(self, amount, note, info)
             ability = eventArg.ability,
             usedability = eventArg.ability,
             hasrolleddamage = eventArg.hasrolleddamage,
+            damagedice = eventArg.damagedice,
             --The ActivatedAbilityCast associated with this damage, if any.
             --hascast lets trigger formulas guard before reading Cast.Tier etc.
             cast = eventArg.cast,

--- a/Draw Steel Core Rules/MCDMRules.lua
+++ b/Draw Steel Core Rules/MCDMRules.lua
@@ -73,6 +73,31 @@ GameSystem.ApplyBoons = function(roll, boons)
     return dmhub.RollToString(rollInfo)
 end
 
+--- Returns a StringSet of the die sizes (e.g. "d3", "d6") actually rolled to
+--- produce a damage roll, so triggers can key off a specific die rather than
+--- just "any dice were rolled". rollStr should already be fully resolved (no
+--- outstanding GoblinScript symbols), matching the roll text handed to the
+--- roll dialog. Empty for flat/fixed damage.
+function GameSystem.GetDamageDiceInRoll(rollStr)
+    local result = StringSet.new{}
+    if rollStr == nil or rollStr == "" then
+        return result
+    end
+
+    local ok, rollInfo = pcall(dmhub.ParseRoll, rollStr)
+    if ok and rollInfo ~= nil and rollInfo.categories ~= nil then
+        for _,category in pairs(rollInfo.categories) do
+            for _,group in ipairs(category.groups or {}) do
+                if group.numFaces ~= nil then
+                    result:Add(string.format("d%d", group.numFaces))
+                end
+            end
+        end
+    end
+
+    return result
+end
+
 GameSystem.CalculateDeathSavingThrowRoll = function(creature)
     return "1d20"
 end
@@ -1064,6 +1089,11 @@ TriggeredAbility.RegisterTrigger{
             type = "creature",
             desc = "The creature being moved through.",
         },
+        first = {
+            name = "First",
+            type = "boolean",
+            desc = "True if this is the first creature moved through during this move action.",
+        },
     }
 }
 
@@ -1466,12 +1496,21 @@ TriggeredAbility.RegisterTrigger{
             type = "boolean",
             desc = "True if the damage came from a dice roll rather than flat damage.",
         },
+        damagedice = {
+            name = "Damage Dice",
+            type = "set",
+            desc = "The die sizes rolled to produce this damage, e.g. 'd3' or 'd6'. Empty if the damage wasn't randomly rolled.",
+        },
     },
 
     examples = {
         {
             script = "damage > 8 and (damage type is slashing or damage type is piercing)",
             text = "The triggered ability only activates if more than 8 damage was done and the damage was slashing or piercing damage."
+        },
+        {
+            script = 'Damage Dice has "d3" or Damage Dice has "d6"',
+            text = "The triggered ability only activates if the damage came from rolling a 1d3 or a 1d6."
         }
     },
 }
@@ -1541,6 +1580,11 @@ TriggeredAbility.RegisterTrigger{
             name = "hasrolleddamage",
             type = "boolean",
             desc = "True if the damage came from a dice roll rather than flat damage.",
+        },
+        {
+            name = "Damage Dice",
+            type = "set",
+            desc = "The die sizes rolled to produce this damage, e.g. 'd3' or 'd6'. Empty if the damage wasn't randomly rolled.",
         },
         {
             name = "HasCast",


### PR DESCRIPTION
## Summary
- Adds a **Damage Dice** `set` symbol (e.g. `"d3"`, `"d6"`) to the `losehitpoints` ("Take Damage") and `dealdamage` ("Damage an Enemy") triggered-ability triggers, populated wherever damage is inflicted via the `Damage` ability behavior (`AbilityDamage.lua`) or power-roll tier text (`MCDMAbilityBehavior.lua`).
- Lets a triggered ability's condition formula check which die sizes actually produced a hit, e.g. `Damage Dice has "d3" or Damage Dice has "d6"` 
- Adds `GameSystem.GetDamageDiceInRoll(rollStr)` in `MCDMRules.lua`, which uses `dmhub.ParseRoll` to pull the die faces out of a resolved roll formula into a `StringSet`.

## Why
This is needed for **Yddraed the Leech-lord**, a monster in the **Dark Heart of the Wood** adventure. Yddraed's Dragonsealed condition inflicts an extra die of damage specifically when the triggering damage was rolled as a d3 or d6 (per its rules text: "...causing them to take an extra 1d3 damage whenever they take damage rolled as a d6 or a d3"). There was previously no way for a triggered ability's condition formula to key off the specific die size used in a damage roll.

## Test plan
- [x] Verified `GameSystem.GetDamageDiceInRoll` against various roll strings (fixed damage, single die, multi-term formulas) via the DMHub MCP bridge against a live instance.
- [x] Confirmed both `Take Damage` and `Damage an Enemy` triggers list the new `Damage Dice` symbol.
- [x] Verified end-to-end against a live game: the `DragonsealedThorn` ongoing effect's `Damage Dice has "d3" or Damage Dice has "d6"` condition correctly evaluates and fires Dragonsealed's extra 1d3 damage when the triggering hit was rolled as a d6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)