### PR TITLE
Add First symbol to Move Through Creature trigger

### DIFF
--- a/DMHub Game Rules/Creature.lua
+++ b/DMHub Game Rules/Creature.lua
@@ -6268,6 +6268,14 @@ function creature:OnMove(path)
     
     local movedThroughTokens = rawget(self, "_tmp_movedThroughTokens")
 
+    -- Tracks whether we've fired "movethrough" yet during THIS move (this single
+    -- OnMove call), as opposed to movedThroughTokens above which dedupes per
+    -- creature across the whole round. Local to this call, never persisted, so
+    -- it resets on every new move -- lets a trigger's conditionFormula check
+    -- "First" to fire only for the first creature moved through per move,
+    -- without needing a turn-scoped usage charge that would block later moves.
+    local firedMoveThroughThisMove = false
+
     -- Reaping Scythe (Beastheart deinonychus L10): totally inert unless the mover carries the
     -- "Reaping Scythe Damage" custom attribute (> 0 only while rampaging under an L10 beastheart,
     -- set entirely in data via a filterCondition'd attribute modifier whose value is the mover's
@@ -6312,8 +6320,9 @@ function creature:OnMove(path)
                     
                     if overlapping and not movedThroughTokens[otherToken.charid] then
                         --we moved through this token for the first time this turn.
-                        ourToken.properties:DispatchEvent("movethrough", { target = otherToken.properties })
+                        ourToken.properties:DispatchEvent("movethrough", { target = otherToken.properties, first = not firedMoveThroughThisMove })
                         movedThroughTokens[otherToken.charid] = true
+                        firedMoveThroughThisMove = true
                     end
                 end
 

--- a/Draw Steel Core Rules/MCDMRules.lua
+++ b/Draw Steel Core Rules/MCDMRules.lua
@@ -1064,6 +1064,11 @@ TriggeredAbility.RegisterTrigger{
             type = "creature",
             desc = "The creature being moved through.",
         },
+        first = {
+            name = "First",
+            type = "boolean",
+            desc = "True if this is the first creature moved through during this move action.",
+        },
     }
 }
 

--- a/TRIGGER_EVENT_PROSE.md
+++ b/TRIGGER_EVENT_PROSE.md
@@ -233,6 +233,7 @@ Priority-sorted for display. These are the most-used triggers per the design doc
 - **Engine description:** Fires when the subject moves through another creature's square.
 - **Template:** `when {subject} move{s} through another creature`
 - **Example (subject=self):** *"When you move through another creature."*
+- **Example (subject=self, cond=`First`):** *"When you move through another creature, if it is the first creature moved through this move."*
 - **Status:** `OK`
 
 ### `pressureplate` ("Stepped on a Pressure Plate")


### PR DESCRIPTION
## Summary
- The `movethrough` trigger fires once per distinct creature moved through, but there was no way to gate a triggered ability to just the *first* creature per move without spending a turn-scoped usage charge -- which then blocks the ability on any later, separate move in the same turn.
- Adds a `First` boolean symbol to the `movethrough` trigger: true only for the first `movethrough` dispatch within a single move action, reset on every new move. A triggered ability can gate on `conditionFormula: First` instead of consuming a charge, so it works every move, not just once per turn.
- Needed for **Yddraed the Leech-lord** (Dark Heart of the Wood): its movement ability punishes the first creature it moves through on *each* move it makes, not just once per turn -- the existing once-per-turn charge mechanism can't express that.

## Changes
- `DMHub Game Rules/Creature.lua`: `creature:OnMove` now tracks a local (non-persisted) flag for whether `movethrough` has already fired during the current move, and passes `first = <bool>` on the dispatched event.
- `Draw Steel Core Rules/MCDMRules.lua`: registers the new `First` (boolean) symbol on the `movethrough` trigger.
- `TRIGGER_EVENT_PROSE.md`: documents an example condition using `First`.

## Test plan
- [ ] In DMHub, create a triggered ability with trigger "Move Through Creature" and condition `First`; move a token through two enemies in one move and confirm only the first triggers.
- [ ] Move through the same two enemies again in a separate move action later in the same turn and confirm it fires again on the first one (not blocked by turn economy).