### PR TITLE
fix(auras): move an aura's mechanical area with its relocated object

### DIFF
--- a/DMHub Game Rules/Aura.lua
+++ b/DMHub Game Rules/Aura.lua
@@ -1307,6 +1307,14 @@ function AuraInstance:FillActivatedAbilities(creature, resultAbilities)
     if self.aura.canrelocate and self:GetArea() ~= nil then
         local area = self:GetArea()
 
+        --A relocated aura's stored area is an explicit-locations shape (see
+        --ActivatedAbilityMoveAuraBehavior.SetCasterAuraArea), whose shape
+        --type ("Locations") is not a placeable target type. Fall back to the
+        --targeting shape recorded at relocation time.
+        local targetType = area.shape
+        if string.lower(tostring(targetType)) == "locations" then
+            targetType = self:try_get("moveTargetType", "cube")
+        end
 
         resultAbilities[#resultAbilities + 1] = ActivatedAbility.Create {
             name = string.format("Move %s", self.name),
@@ -1314,7 +1322,7 @@ function AuraInstance:FillActivatedAbilities(creature, resultAbilities)
             iconid = self.iconid,
             casterLocOverride = self.area.origin,
             display = self.display,
-            targetType = area.shape,
+            targetType = targetType,
             range = self.aura.relocateRange,
             radius = area.radius,
             actionResourceId = self.aura.relocateResource,
@@ -1890,6 +1898,90 @@ function creature:GetAura(auraid)
     end
 end
 
+--Relocating an aura's map object only moves the VISUAL. The mechanical area
+--lives in TWO serialized copies of the AuraInstance, and both must be updated:
+-- 1. The copy inside the object's Aura component: this is the one the engine
+--    actually registers in the aura index, so it decides which tiles the
+--    aura's concealment/damage/triggers apply to.
+-- 2. The copy in the CASTER's auras list: drives the aura panel outline and
+--    caster-side bookkeeping.
+--The area is also converted to an explicit-locations shape before assignment.
+--A serialized targeted shape is a RECIPE {originCreature, targetPoint, range,
+--checklos} that the engine re-evaluates on every aura index rebuild and on
+--load, re-clamping the target point by the ORIGINAL cast's range and line of
+--sight. For an aura cast at short range (e.g. Shadow Skulk's range-1 "leave
+--darkness in your space") that recompute pins the mechanical area near the
+--cast location no matter where the object is moved. A locations shape stores
+--the exact tiles and recomputes to itself.
+--NOTE: assign a whole shape; mutating the existing shape's .locations does not
+--persist, because AuraInstance:GetArea materialises a fresh userdata per read.
+function ActivatedAbilityMoveAuraBehavior.SetCasterAuraArea(obj, newArea)
+    if newArea == nil then
+        return
+    end
+
+    local component = obj:GetComponent("Aura")
+    if component == nil or component.properties == nil then
+        return
+    end
+
+    --Remember the targeting shape the aura was placed with ("Cube" etc.)
+    --before converting: FillActivatedAbilities builds the aura's built-in
+    --Move ability from the stored area's shape/radius, and a converted area
+    --reports shape "Locations", which is not a placeable target type.
+    local moveTargetType = nil
+    local locs = newArea.locations
+    if locs ~= nil and #locs > 0 then
+        local converted = dmhub.CalculateShape{
+            shape = "locations",
+            locations = locs,
+            locOverride = newArea.origin or locs[1],
+            radius = tonumber(newArea.radius) or 0,
+            range = 0,
+            checklos = false,
+        }
+        if converted ~= nil then
+            moveTargetType = newArea.shape
+            newArea = converted
+        end
+    end
+
+    local objInstance = component.properties:try_get("aura")
+    if objInstance ~= nil then
+        component:BeginChanges()
+        objInstance.area = newArea
+        if moveTargetType ~= nil then
+            objInstance.moveTargetType = moveTargetType
+        end
+        component:CompleteChanges("Relocate aura area")
+    end
+
+    local auraid = component.properties:try_get("auraid")
+    local casterid = component.properties:try_get("casterid")
+    if auraid == nil or casterid == nil then
+        return
+    end
+
+    local casterTok = dmhub.GetTokenById(casterid)
+    if casterTok == nil or not casterTok.valid then
+        return
+    end
+
+    casterTok:ModifyProperties {
+        description = "Relocate aura area",
+        undoable = false,
+        execute = function()
+            local inst = casterTok.properties:GetAura(auraid)
+            if inst ~= nil then
+                inst.area = newArea
+                if moveTargetType ~= nil then
+                    inst.moveTargetType = moveTargetType
+                end
+            end
+        end,
+    }
+end
+
 function ActivatedAbilityMoveAuraBehavior:Cast(ability, casterToken, targets, options)
     if options.targetArea == nil or self:try_get("object") == nil then
         return
@@ -1904,19 +1996,23 @@ function ActivatedAbilityMoveAuraBehavior:Cast(ability, casterToken, targets, op
 
     local destx = options.targetArea.xpos
     local desty = options.targetArea.ypos
+    local dx = destx - obj.x
+    local dy = desty - obj.y
 
     local objAura = obj:GetComponent("Aura")
     if objAura ~= nil then
         objAura:SetAndUploadProperties {
             moveTimestamp = dmhub.serverTime,
-            movex = destx - obj.x,
-            movey = desty - obj.y,
+            movex = dx,
+            movey = dy,
         }
     end
 
     obj:SetAndUploadPos(destx, desty)
 
     dmhub.EndTransaction()
+
+    ActivatedAbilityMoveAuraBehavior.SetCasterAuraArea(obj, options.targetArea)
 
     ability:ConsumeResources(casterToken, {
         costOverride = options.costOverride,

--- a/Draw Steel Ability Behaviors/AbilityRelocateAura.lua
+++ b/Draw Steel Ability Behaviors/AbilityRelocateAura.lua
@@ -83,6 +83,8 @@ function ActivatedAbilityRelocateAuraBehavior:Cast(ability, casterToken, targets
     -- Destination coordinates come from the ability's targeted area.
     local destx = options.targetArea.xpos
     local desty = options.targetArea.ypos
+    local dx = destx - obj.x
+    local dy = desty - obj.y
 
     -- Record the movement delta on the Aura component so the engine plays the slide animation
     -- from the old position to the new one.
@@ -90,8 +92,8 @@ function ActivatedAbilityRelocateAuraBehavior:Cast(ability, casterToken, targets
     if objAura ~= nil then
         objAura:SetAndUploadProperties{
             moveTimestamp = dmhub.serverTime,
-            movex = destx - obj.x,
-            movey = desty - obj.y,
+            movex = dx,
+            movey = dy,
         }
     end
 
@@ -99,6 +101,14 @@ function ActivatedAbilityRelocateAuraBehavior:Cast(ability, casterToken, targets
     obj:SetAndUploadPos(destx, desty)
 
     dmhub.EndTransaction()
+
+    -- Moving the object only moves the VISUAL: the mechanical area lives in
+    -- serialized AuraInstance copies on the object's Aura component (the one
+    -- the engine registers) and in the caster's auras list. The shared helper
+    -- in DMHub Game Rules/Aura.lua updates both, converting the area to an
+    -- explicit-locations shape so the engine's recipe recompute cannot clamp
+    -- it back toward the original cast position.
+    ActivatedAbilityMoveAuraBehavior.SetCasterAuraArea(obj, options.targetArea)
 end
 
 --- Builds the editor UI for this behavior: a single text input for the aura's name.

--- a/Draw Steel Core Rules/MCDMAbilitySaveBehavior.lua
+++ b/Draw Steel Core Rules/MCDMAbilitySaveBehavior.lua
@@ -76,6 +76,23 @@ function ActivatedAbilitySaveBehavior:GetSaveRollFormula(targetCreature, item)
             end
         end
     end
+
+    -- Per-condition save modifier: a custom attribute named "Save Bonus vs <name>"
+    -- (e.g. "Save Bonus vs Frightened") adjusts saves against that one condition or
+    -- ongoing effect only. The attribute may not exist for most conditions, and
+    -- CalculateNamedCustomAttribute raises on unknown names, so probe under pcall.
+    local vsBonus = nil
+    pcall(function()
+        vsBonus = targetCreature:CalculateNamedCustomAttribute("Save Bonus vs " .. item.name)
+    end)
+    if type(vsBonus) == "number" and vsBonus ~= 0 then
+        if vsBonus > 0 then
+            rollStr = string.format("%s + %d", rollStr, vsBonus)
+        else
+            rollStr = string.format("%s - %d", rollStr, -vsBonus)
+        end
+    end
+
     return rollStr
 end
 


### PR DESCRIPTION
## Summary
Relocating an aura's map object (built-in Move, Relocate Aura behavior, or scripted moves like the Gloom Dragon's Encroaching Darkness) only moved the visual. The mechanical area the engine registers comes from the AuraInstance copy stored on the object's Aura component, whose serialized recipe shape is re-evaluated on every aura index rebuild and re-clamped by the ORIGINAL cast's range and line of sight - so a short-range leave-behind aura (e.g. Shadow Skulk's range-1 darkness cube) snapped back to its cast position no matter where the object moved. Also includes a small independent commit adding per-condition save modifiers.

## Changes
- `SetCasterAuraArea` (Aura.lua): on relocation, convert the freshly targeted area to an explicit-locations shape (exact tiles, immune to recipe recompute drift) and assign it to BOTH serialized AuraInstance copies - the object component's (the one the aura index registers) and the caster's auras-list copy. Records the pre-conversion targeting shape as `moveTargetType`.
- `AuraInstance:FillActivatedAbilities`: when the stored area reports shape "Locations" (i.e. the aura has been relocated), fall back to `moveTargetType` (default "cube") for the built-in Move ability's targetType, so repeat moves keep a working placement targeter. Never-relocated auras hit the exact pre-change path.
- `ActivatedAbilityRelocateAuraBehavior:Cast` calls the same shared helper after moving the object.
- Separate commit: `GetSaveRollFormula` folds in a "Save Bonus vs <condition name>" custom attribute when the target has one, adjusting saves against that single condition only (used by the Gloom Dragon's domain: -2 to saves against frightened).

## Testing
Live-verified in a dev game via the bridge: after moving a Shadow Skulk darkness cube, the caster copy, object copy, and the engine's registered area (probed with game.GetAurasAtLoc sweeps) all agree at the new tiles, including across aura index rebuilds; previously the registered area stayed pinned near the cast position (Breath of Brume only appeared to work because its cast range is 10). Regression-checked FillActivatedAbilities with legacy recipe-shape instances (identical Move ability output), converted instances with the new field, and converted instances without it. Radius round-trips through the conversion, keeping the aura editor's radius display working.

## Notes for reviewer
- The conversion runs only on user-initiated relocations; no per-frame cost. The aura index already consumes locations shapes (map-markup zones), so registration cost is unchanged.
- Known minor edge: editing the radius in a MOVED aura's object-Properties dialog no longer resizes its area (a locations list does not derive from radius). Unmoved auras unaffected.
- The area sync is deliberately non-undoable; undoing a move restores the visual but not the mechanical tiles (pre-existing behavior was strictly worse - the mechanics never moved at all).

🤖 Generated with [Claude Code](https://claude.com/claude-code)