### PR TITLE
Fix stale prone state after condition removal

### DIFF
--- a/DMHub Game Rules/Creature.lua
+++ b/DMHub Game Rules/Creature.lua
@@ -4798,6 +4798,11 @@ function creature:RefreshToken(token)
     end
 
     self._tmp_grabbedby = nil
+    --Rebuild prone from the current inflicted-condition state on every token refresh.
+    --The modifier cache can already be stamped for this game update before
+    --this base refresh runs, which skips Invalidate() above; without this
+    --explicit reset, removing Prone can leave _tmp_prone stuck true.
+    self._tmp_prone = nil
 
     --check if grabbed.
     local inflictedConditions = self:try_get("inflictedConditions")


### PR DESCRIPTION
## What changed

- Clear the transient `_tmp_prone` cache whenever `creature:RefreshToken()` rebuilds inflicted-condition state.

## Why

Removing Prone can occur after the modifier cache has already been stamped for the current game update. In that ordering, the existing invalidation path is skipped and `_tmp_prone` can remain stuck `true`, preventing the creature from flying after Prone is removed.

The reset applies regardless of whether Prone is cleared from the character panel or through Purge Ongoing Effect, because both paths ultimately refresh the token from its current inflicted conditions.

## Impact

Creatures recover their correct prone state and movement capabilities immediately after Prone is removed. The cache remains transient and is reconstructed from the authoritative inflicted-condition list during the same refresh.

## Validation

- Verified the staged manifest contains only `DMHub Game Rules/Creature.lua`.
- `git diff --check` passed with the repository's CRLF convention.
- Confirmed the Lua file remains ASCII-only.
- Live-connected testing covered direct panel removal and Purge Ongoing Effect removal; flying was restored after Prone cleared.
- Deployment dry-run was unavailable in the sandbox because it resolved a different dev-mod folder, but the changed path had already been reloaded and tested through the connected app.
