### PR TITLE
Add Trigger Mode and Hostile options to aura triggers

### DIFF
--- a/Draw Steel Ability Editor/NewTriggeredAbilityEditor.lua
+++ b/Draw Steel Ability Editor/NewTriggeredAbilityEditor.lua
@@ -6922,6 +6922,66 @@ function TriggeredAbility:GenerateEmbeddedEditor()
             },
         }
 
+        --Trigger Mode. Aura triggers used to always fire automatically, since
+        --TriggeredAbility.mandatory defaults to true and the embedded editor
+        --never surfaced it. This is the same setting the standalone trigger
+        --editor writes, so IsMandatory / MayBePrompted keep working unchanged.
+        local promptTextPanel
+        local hostileCheck
+
+        --Prompt Text and Hostile only do anything on the prompt path; hide
+        --them when the chosen mode fires without asking.
+        local RefreshPromptVisibility = function()
+            local mayPrompt = self:MayBePrompted()
+            promptTextPanel:SetClass("collapsed", not mayPrompt)
+            hostileCheck:SetClass("collapsed", not mayPrompt)
+        end
+
+        children[#children+1] = gui.Panel{
+            classes = {"abilityInfo", "formPanel"},
+            gui.Label{ classes = "formLabel", text = "Triggering:" },
+            gui.Dropdown{
+                classes = "formDropdown",
+                idChosen = self.mandatory,
+                options = TriggeredAbility.mandatoryTriggerSettings,
+                change = function(element)
+                    self.mandatory = element.idChosen
+                    RefreshPromptVisibility()
+                end,
+            },
+        }
+
+        promptTextPanel = gui.Panel{
+            classes = {"abilityInfo", "formPanel"},
+            gui.Label{ classes = "formLabel", text = "Prompt Text:" },
+            gui.Input{
+                classes = "formInput",
+                characterLimit = 300,
+                placeholderText = "Prompt shown to the player...",
+                text = self:try_get("triggerPrompt", ""),
+                change = function(element)
+                    self.triggerPrompt = element.text
+                end,
+            },
+        }
+        children[#children+1] = promptTextPanel
+
+        --A hostile trigger is a harmful prompt forced on the creature (e.g.
+        --an aura that burns anything standing in it) rather than a beneficial
+        --reaction offer: red prompt icon, never ages out at end of turn, and
+        --must be manually activated or dismissed.
+        hostileCheck = gui.Check{
+            halign = "left",
+            text = "Hostile trigger (harmful prompt; never expires, must be manually dismissed)",
+            value = self:try_get("hostile", false),
+            change = function(element)
+                self.hostile = element.value
+            end,
+        }
+        children[#children+1] = hostileCheck
+
+        RefreshPromptVisibility()
+
         local helpSymbols = {
             caster = {
                 name = "Caster",


### PR DESCRIPTION
## Summary
- Aura triggers were always created with `TriggeredAbility.mandatory = true` (the class default) because the aura-embedded trigger editor (`TriggeredAbility:GenerateEmbeddedEditor`) never exposed the Trigger Mode / Hostile fields that the standalone trigger editor already has.
- Adds the same "Triggering" dropdown (`TriggeredAbility.mandatoryTriggerSettings`: Occurs Automatically, Automatic and Local, Prompt Remote/Auto Local, Prompt, Automatic Heroic Resource Setting), a Prompt Text field, and a Hostile trigger checkbox to the aura trigger editor.
- Prompt Text and Hostile only apply on modes that can prompt, so they collapse when a non-prompting mode is selected (matching the standalone editor's behavior).

No changes to underlying trigger logic — `IsMandatory`/`MayBePrompted`/hostile-prompt handling in `TriggeredAbility.lua` already supported this; only the aura-specific editor was missing the controls.

## Test plan
- [x] `luac -p` syntax check on the changed file
- [x] Reloaded into a running DMHub instance via the dev-mod bridge; built the embedded editor in both automatic and prompt modes and confirmed no errors and correct field visibility
- [ ] Manual click-through in the aura editor UI (author to verify visually)

🤖 Generated with [Claude Code](https://claude.com/claude-code)