### PR TITLE
Forced-movement aura triggers, map records for created objects, aura caster/identity on spawn

### DIFF
--- a/DMHub Core Panels/CharacterPanel.lua
+++ b/DMHub Core Panels/CharacterPanel.lua
@@ -2491,10 +2491,11 @@ CharacterPanel.CreateMapModificationsFolder = function()
             }
         end
 
-        --wall-building records (e.g. Motivate Earth) reference the wall voxels
-        --they placed; reverting one removes whatever remains of the wall.
-        --voxelCount/voxelsRemaining are nil on engine builds without wall records.
-        local IsWallRecord = function()
+        --Object-placing records (walls from Motivate Earth, the brambles from a
+        --Bramble Barricade) reference the objects they placed rather than captured
+        --map edits; reverting one removes whatever of the placement still stands.
+        --voxelCount/voxelsRemaining are nil on engine builds without object records.
+        local IsPlacementRecord = function()
             return (modInfo.voxelCount or 0) > 0 and (modInfo.count or 0) == 0
         end
 
@@ -2508,7 +2509,7 @@ CharacterPanel.CreateMapModificationsFolder = function()
 
         local EntryText = function()
             local text = BaseText()
-            if IsWallRecord() and (modInfo.voxelsRemaining or 0) == 0 then
+            if IsPlacementRecord() and (modInfo.voxelsRemaining or 0) == 0 then
                 text = text .. " (destroyed)"
             end
             return text
@@ -2550,13 +2551,13 @@ CharacterPanel.CreateMapModificationsFolder = function()
                     local revertEntryText = "Revert Modification"
                     local confirmTitle = "Revert Map Modification?"
                     local confirmMessage = string.format("This will restore the map to how it was before %s. Overlapping edits made since then may also be affected.", BaseText())
-                    if IsWallRecord() then
-                        revertEntryText = "Remove Wall"
-                        confirmTitle = "Remove Wall?"
+                    if IsPlacementRecord() then
+                        revertEntryText = "Remove Placement"
+                        confirmTitle = "Remove Placement?"
                         if (modInfo.voxelsRemaining or 0) > 0 then
-                            confirmMessage = string.format("This will remove what remains of the wall created by %s.", BaseText())
+                            confirmMessage = string.format("This will remove what remains of what %s placed on the map.", BaseText())
                         else
-                            confirmMessage = string.format("The wall created by %s has already been destroyed. This will remove its record.", BaseText())
+                            confirmMessage = string.format("What %s placed on the map has already been destroyed. This will remove its record.", BaseText())
                         end
                     end
 
@@ -2578,8 +2579,16 @@ CharacterPanel.CreateMapModificationsFolder = function()
                                         message = confirmMessage,
                                         options = {
                                             {
-                                                text = cond(IsWallRecord(), "Remove", "Revert"),
+                                                text = cond(IsPlacementRecord(), "Remove", "Revert"),
                                                 execute = function()
+                                                    --The engine's own revert only collapses wall-voxel
+                                                    --columns, so plain created objects (brambles and
+                                                    --the like) have to be torn down from Lua first;
+                                                    --they are stamped with this record's key at spawn.
+                                                    local createObject = rawget(_G, "ActivatedAbilityCreateObjectBehavior")
+                                                    if createObject ~= nil and createObject.DestroyRecordedObjects ~= nil then
+                                                        createObject.DestroyRecordedObjects(modInfo.key)
+                                                    end
                                                     game.DeleteMapModification(modInfo.id)
                                                     resultPanel:FireEventTree("refresh")
                                                 end,
@@ -2633,7 +2642,13 @@ CharacterPanel.CreateMapModificationsFolder = function()
                                         {
                                             text = "Revert All",
                                             execute = function()
+                                                --see the per-record revert above: created objects
+                                                --are torn down from Lua, the engine handles the rest.
+                                                local createObject = rawget(_G, "ActivatedAbilityCreateObjectBehavior")
                                                 for _,m in ipairs(game.GetMapModifications()) do
+                                                    if createObject ~= nil and createObject.DestroyRecordedObjects ~= nil then
+                                                        createObject.DestroyRecordedObjects(m.key)
+                                                    end
                                                     game.DeleteMapModification(m.id)
                                                 end
                                                 resultPanel:FireEventTree("refresh")

--- a/DMHub Game Rules/Aura.lua
+++ b/DMHub Game Rules/Aura.lua
@@ -6,7 +6,9 @@ local mod = dmhub.GetModLoading()
 --- @field canrelocate boolean If true, the caster can spend an action to move the aura.
 --- @field relocateResource string Action resource id used to relocate the aura.
 --- @field relocateRange number Maximum range in world units for relocating the aura.
---- @field triggers table[] List of trigger definitions {trigger: string, ability: TriggeredAbility, destroyaura: boolean}.
+--- @field triggers table[] List of trigger definitions {trigger: string, ability: TriggeredAbility, destroyaura: boolean, movementFilter: string}.
+--- movementFilter ("all" or "forced", default "all") restricts an onenter trigger to entries made
+--- by forced movement; see Aura.TriggerMovementFilters and the stash helpers further down.
 --- @field name string Display name.
 --- @field source string Source description string.
 --- @field description string Rules text.
@@ -69,6 +71,22 @@ Aura.ApplyOptions = {
     {
         id = "othertype",
         text = "Other Type Creatures",
+    },
+}
+
+--Which kind of movement into the aura may fire an "onenter" trigger. Deliberately
+--offers fewer options than movementDamageFilter: move damage is filtered by the
+--engine, which sees the movement type, whereas creature:EnterAura is called
+--identically for a shove and for a walk-in, so "forced" is the only distinction
+--Lua can honour (see the stash helpers below).
+Aura.TriggerMovementFilters = {
+    {
+        id = "all",
+        text = "Any Movement",
+    },
+    {
+        id = "forced",
+        text = "Forced Movement Only",
     },
 }
 
@@ -531,6 +549,20 @@ function Aura:GenerateEditor(options)
                         value = (trigger.destroyaura or false),
                         change = function(element)
                             trigger.destroyaura = element.value
+                            resultPanel:FireEventTree("refreshAura")
+                        end,
+                    },
+
+                    --Only entering the aura can be attributed to a kind of movement;
+                    --the end-of-turn trigger has no movement to filter.
+                    gui.Dropdown {
+                        styles = ThemeEngine.GetStyles(),
+                        classes = { "formDropdown", cond(trigger.trigger ~= "onenter", "collapsed") },
+                        halign = "left",
+                        options = Aura.TriggerMovementFilters,
+                        idChosen = trigger.movementFilter or "all",
+                        change = function(element)
+                            trigger.movementFilter = element.idChosen
                             resultPanel:FireEventTree("refreshAura")
                         end,
                     },
@@ -1141,6 +1173,134 @@ function AuraInstance:FireTriggeredAbility(ability, castingCreature, targetToken
         debugLog = {}
     }
     ability:Trigger(temporaryModifier, castingCreature, symbols, targetToken, nil, options)
+end
+
+--"Forced Movement Only" aura triggers are resolved from the engine's own move
+--notification (creature:OnMove), NOT from creature:EnterAura. Three findings from tracing
+--real movement forced this:
+--
+-- 1. EnterAura runs BEFORE a relocate behavior's Cast. The engine walks the prospective
+--    path while planning the move (that is what EnterAuraHaltsMovement answers), so
+--    anything hooked around the Cast is out of step with it.
+--
+-- 2. EnterAura is gated to once per aura per turn, and -- worse -- the PLANNING pass is
+--    what consumes the gate, so the real movement's entries are reported with the gate
+--    already closed. "Force moved into the area" has no such limit: a creature shoved in,
+--    cleared, and shoved in again on the same turn takes the effect both times.
+--
+-- 3. Hooking the forced-movement ABILITY path only covers scripted pushes. A Director
+--    ALT-dragging a token is forced movement that casts no ability at all, and was
+--    silently missed. OnMove is the one place every kind of movement arrives.
+--
+--OnMove hands over the real LuaPath, so the squares entered are the engine's own steps
+--rather than a reconstructed straight line -- rebounds and collision-shortened pushes
+--come out right for free.
+
+--- Index every object-hosted aura carrying a "forced" trigger, keyed by "floor,x,y".
+--- Object auras are positioned by their object (their stored area shape is authored data
+--- and does not track the spawn location), which is also how the engine places them.
+--- @return table<string, AuraInstance[]>
+local function CollectForcedTriggerAurasByLoc()
+    local result = {}
+
+    for _, floor in ipairs(game.currentMap.floors) do
+        for _, obj in pairs(floor.objects) do
+            if obj.valid then
+                local component = obj:GetComponent("Aura")
+                local auraInstance = nil
+                if component ~= nil and component.properties ~= nil then
+                    auraInstance = component.properties:try_get("aura")
+                end
+
+                if auraInstance ~= nil then
+                    local key = string.format("%d,%d,%d",
+                        obj.floorIndex, math.floor(obj.x + 0.5), math.floor(obj.y + 0.5))
+                    local list = result[key]
+                    if list == nil then
+                        list = {}
+                        result[key] = list
+                    end
+                    list[#list + 1] = auraInstance
+                end
+            end
+        end
+    end
+
+    return result
+end
+
+--- Call fn(instance, triggerInfo) for each "forced" onenter trigger on this aura,
+--- including those carried by its sub-auras (a split aura normally keeps its triggers on
+--- the child payload). Child triggers fire through the child view so the trigger sees the
+--- child's own payload.
+local function ForEachForcedTrigger(auraInstance, fn)
+    for _, triggerInfo in ipairs(auraInstance.aura:try_get("triggers", {})) do
+        if triggerInfo.trigger == "onenter" and triggerInfo.movementFilter == "forced" then
+            fn(auraInstance, triggerInfo)
+        end
+    end
+
+    for _, child in ipairs(auraInstance:GetChildInstances() or {}) do
+        for _, triggerInfo in ipairs(child.aura:try_get("triggers", {})) do
+            if triggerInfo.trigger == "onenter" and triggerInfo.movementFilter == "forced" then
+                fn(child, triggerInfo)
+            end
+        end
+    end
+end
+
+--- Fire the "Forced Movement Only" triggers of every aura whose squares a creature entered
+--- during a forced move. Fires every time, with no per-turn dedupe -- see the note above.
+--- Called from creature:OnMove for any path flagged `forced`, whatever produced it.
+--- @param c nil|creature The creature that was force moved.
+--- @param token nil|CharacterToken That creature's token.
+--- @param path nil|LuaPath The path the engine actually moved it along.
+--- @return nil
+function Aura.FireForcedMovementTriggersForPath(c, token, path)
+    if c == nil or token == nil or (not token.valid) or path == nil then
+        return
+    end
+
+    --steps[1] is where the move STARTED; a square is only "entered" from steps[2] on.
+    --A shove that went nowhere therefore has nothing to fire.
+    local steps = path.steps
+    if steps == nil or #steps < 2 then
+        return
+    end
+
+    local aurasByLoc = CollectForcedTriggerAurasByLoc()
+
+    --Mirrors the caster-token fallback in creature:EnterAura: a non-uploadable token
+    --cannot own the triggered cast, so fall back to the creature's own token.
+    local auraCasterToken = token
+    if auraCasterToken.valid == false or (not auraCasterToken.uploadable) then
+        auraCasterToken = dmhub.LookupToken(c)
+    end
+
+    --One firing per aura instance per move: a path can re-enter a square it already
+    --crossed (a rebound), and a creature larger than one square reports overlaps.
+    local fired = {}
+
+    for i = 2, #steps do
+        local loc = steps[i]
+        local key = string.format("%d,%d,%d", loc.floor, loc.x, loc.y)
+        for _, auraInstance in ipairs(aurasByLoc[key] or {}) do
+            ForEachForcedTrigger(auraInstance, function(instance, triggerInfo)
+                if fired[instance.guid] then
+                    return
+                end
+                if instance.aura:CreaturePassesFilter(c, instance) == false then
+                    return
+                end
+
+                fired[instance.guid] = true
+                instance:FireTriggeredAbility(triggerInfo.ability, c, auraCasterToken)
+                if triggerInfo.destroyaura then
+                    instance:DestroyAura(c)
+                end
+            end)
+        end
+    end
 end
 
 --creates a temporary triggered ability copy and populates it with our spellcasting feature making it ready to use.

--- a/DMHub Game Rules/Creature.lua
+++ b/DMHub Game Rules/Creature.lua
@@ -6283,6 +6283,15 @@ function creature:OnMove(path)
         }
     })
 
+    --Aura triggers marked "Forced Movement Only" ("force moved into or within the area").
+    --Hooked here rather than on the forced-movement ability path because this is the one
+    --place EVERY kind of movement arrives: a Director ALT-dragging a token is forced
+    --movement that casts no ability at all. path.forced is the engine's own verdict
+    --(an ALT-drag reports forced=true, movementType="pushed").
+    if path.forced then
+        Aura.FireForcedMovementTriggersForPath(self, ourToken, path)
+    end
+
     --floorAltitude
 
     -- Forced movement no longer short-circuits the per-step processing -- we
@@ -10311,7 +10320,11 @@ function creature:EnterAura(info)
 	end
 
 	for i,triggerInfo in ipairs(info.auraInstance.aura.triggers) do
-		if triggerInfo.trigger == "onenter" then
+		--"Forced Movement Only" triggers are NOT resolved here. This runs identically for a
+		--shove and a walk-in, it runs during path PLANNING rather than during the move, and
+		--it is gated to once per aura per turn -- all three are wrong for "force moved into
+		--the area". Aura.FireForcedMovementTriggersForPath owns them instead.
+		if triggerInfo.trigger == "onenter" and triggerInfo.movementFilter ~= "forced" then
             local auraCasterToken = info.token
             if auraCasterToken == nil or auraCasterToken.valid == false or (not auraCasterToken.uploadable) then
                 auraCasterToken = dmhub.LookupToken(self)

--- a/Draw Steel Ability Behaviors/AbilityCreateObject.lua
+++ b/Draw Steel Ability Behaviors/AbilityCreateObject.lua
@@ -18,6 +18,147 @@ ActivatedAbility.RegisterType
 	end
 }
 
+--Objects placed by this behavior are stamped with the id of the map modification
+--record they belong to, so the record can find and destroy them when it is reverted.
+--The engine's own revert only knows how to collapse wall-voxel columns (verified: a
+--plain spawned object survives DeleteMapModification), so the teardown is done from
+--Lua -- see DestroyRecordedObjects, called by the Map Modifications folder in
+--DMHub Core Panels/CharacterPanel.lua. Mirrors how AbilityBuildWall stamps
+--wallcreator/wallcastid onto Targetable properties; must be set before Upload to persist.
+local function StampRecordKey(obj, key)
+    if obj == nil or key == nil then
+        return
+    end
+
+    local targetable = obj:GetComponent("Targetable")
+    if targetable ~= nil and targetable.properties ~= nil then
+        targetable.properties.mapmodkey = key
+    end
+end
+
+--True if this aura definition carries any onenter/end-of-turn trigger, counting
+--sub-aura triggers (a split aura normally keeps its triggers on the child payload).
+local function AuraDefHasTriggers(auraDef)
+    if auraDef == nil then
+        return false
+    end
+
+    if #auraDef:try_get("triggers", {}) > 0 then
+        return true
+    end
+
+    for _, childDef in ipairs(auraDef:try_get("subauras", {})) do
+        if #childDef:try_get("triggers", {}) > 0 then
+            return true
+        end
+    end
+
+    return false
+end
+
+--Object assets bake a FIXED AuraInstance guid, so every object spawned from one asset
+--shares it. creature.aurasEntered dedupes aura triggers by that guid for the rest of the
+--turn (see creature:EnterAuraHaltsMovement), which collapses a whole wall of spawned
+--squares into a SINGLE trigger slot: enter any one square and no other square can fire
+--again that turn. Worse, the slot is burned by entries that produce nothing -- starting a
+--turn inside the area, or walking in before being pushed in -- so the trigger looks
+--intermittent. Give each spawned object its own instance guid so squares dedupe
+--independently. Child instances derive their guid from the parent's, so the sub-aura
+--carrying the triggers becomes distinct too.
+--
+--Restricted to auras that actually have triggers. A trigger-less aura has nothing to
+--dedupe, and its guid still feeds EnterAuraHaltsMovement -- making those unique would
+--start halting movement at EVERY square of existing content (the Delian Tomb brambles)
+--rather than once per turn, which is a gameplay change nobody asked for.
+local function FreshenSpawnedAuraGuid(auraInstance)
+    if auraInstance == nil or (not AuraDefHasTriggers(auraInstance.aura)) then
+        return
+    end
+
+    auraInstance.guid = dmhub.GenerateGuid()
+end
+
+--Stamp the caster onto a spawned object's aura so the aura knows who made it.
+--Without this an object-hosted aura has no casterid, which leaves every
+--caster-relative audience ("All Other Creatures", "Enemies", ...) resolving
+--against nobody. That matters beyond modifiers: the engine evaluates the aura's
+--audience PER CREATURE when computing cover, so a caster-less aura marked
+--blocks_line_of_effect blocks line of effect for its own creator too (the Thorn
+--Dragon's Bramble Barricade is meant to block for everyone except the dragon).
+--Must be set before Upload so it persists.
+local function StampAuraCaster(obj, casterToken)
+    if obj == nil or casterToken == nil or (not casterToken.valid) then
+        return
+    end
+
+    local auraComponent = obj:GetComponent("Aura")
+    if auraComponent == nil or auraComponent.properties == nil then
+        return
+    end
+
+    local auraInstance = auraComponent.properties:try_get("aura")
+    if auraInstance ~= nil then
+        auraInstance.casterid = casterToken.id
+    end
+end
+
+--Give a spawned object's aura its own identity (see FreshenSpawnedAuraGuid). Split out
+--from StampAuraCaster because this applies even to objects created with no caster.
+local function StampAuraIdentity(obj)
+    if obj == nil then
+        return
+    end
+
+    local auraComponent = obj:GetComponent("Aura")
+    if auraComponent == nil or auraComponent.properties == nil then
+        return
+    end
+
+    FreshenSpawnedAuraGuid(auraComponent.properties:try_get("aura"))
+end
+
+--record a spawned object into the active map modification recording, so the
+--placement shows up in the character panel's Map Modifications folder and can be
+--removed from there. Nil-guarded for engine builds that predate the API.
+local function RecordObjectInModification(obj)
+    if obj == nil or rawget(_G, "game") == nil or game.AddMapModificationVoxel == nil then
+        return
+    end
+
+    game.AddMapModificationVoxel(obj)
+end
+
+--- Destroy every object placed by the map modification record with the given key.
+--- Called from the Map Modifications folder before the record itself is deleted.
+--- @param key nil|string The record's key (the placing cast's castid).
+--- @return nil
+function ActivatedAbilityCreateObjectBehavior.DestroyRecordedObjects(key)
+    if key == nil or key == "" or rawget(_G, "game") == nil or game.currentMap == nil then
+        return
+    end
+
+    --Scanning the floors directly rather than Encounter.GetTargetableObjectsWithKeyword:
+    --created objects carry whatever keywords their asset happens to define, so there is no
+    --single keyword to look them up by.
+    local victims = {}
+    for _, floor in ipairs(game.currentMap.floors) do
+        for _, obj in pairs(floor.objects) do
+            if obj.valid then
+                local targetable = obj:GetComponent("Targetable")
+                if targetable ~= nil and targetable.properties ~= nil and targetable.properties:try_get("mapmodkey") == key then
+                    victims[#victims + 1] = obj
+                end
+            end
+        end
+    end
+
+    for _, obj in ipairs(victims) do
+        obj:DestroyWithBehavior {
+            ttl = 3,
+        }
+    end
+end
+
 function ActivatedAbilityCreateObjectBehavior:Cast(ability, casterToken, targets, options)
     local targetArea = options.targetArea
     local locations = nil
@@ -43,6 +184,16 @@ function ActivatedAbilityCreateObjectBehavior:Cast(ability, casterToken, targets
 
     --make sure we do the top locations first so their zorder is behind.
     table.sort(locations, function(a, b) return a.y > b.y end)
+
+    --Group every object this cast places into one revertible map modification record,
+    --keyed by castid (the same key BeginMapModificationRecording derives), so the
+    --Director can clear the placement from the character panel later.
+    local recordKey = nil
+    if options.symbols ~= nil then
+        recordKey = options.symbols.castid
+    end
+    ActivatedAbility.BeginMapModificationRecording(ability, casterToken, options, locations[1])
+
     for _,loc in ipairs(locations) do
         local targetFloor = game.currentMap:GetFloorFromLoc(loc)
         print("CAST:: TARGET FLOOR:", targetFloor)
@@ -63,6 +214,10 @@ function ActivatedAbilityCreateObjectBehavior:Cast(ability, casterToken, targets
             if obj ~= nil then
                 obj.x = loc.x + xdelta
                 obj.y = loc.y + ydelta
+                StampRecordKey(obj, recordKey)
+                StampAuraIdentity(obj)
+                StampAuraCaster(obj, casterToken)
+                RecordObjectInModification(obj)
                 for _,child in ipairs(spawnOptions.outChildren) do
                     if self.randomize then
                         for _,component in pairs(child.components) do
@@ -85,6 +240,8 @@ function ActivatedAbilityCreateObjectBehavior:Cast(ability, casterToken, targets
     --sets options.pay, so ConsumeResources is skipped and a consumable item is not
     --removed from inventory on use. Mirrors AbilityChangeTerrain / AbilityBuildWall.
     ability:CommitToPaying(casterToken, options)
+
+    ActivatedAbility.EndMapModificationRecording()
 end
 
 function ActivatedAbilityCreateObjectBehavior:EditorItems(parentPanel)


### PR DESCRIPTION
Three related aura/created-object capabilities, driven by implementing the Thorn
Dragon's Bramble Barricade malice option ("any creature force moved into or within
the area ... is bleeding until the end of their next turn").

## Forced-movement aura triggers

Aura trigger definitions take a new `movementFilter` (`"all"` / `"forced"`), with a
dropdown in the aura trigger editor. A `"forced"` trigger fires only when the
creature was force moved into the aura.

These are resolved from **`creature:OnMove`, gated on `path.forced`**. Two other
candidate hooks were tried against a live instance and rejected:

* **`creature:EnterAura` cannot serve them.** It runs *before* a relocate
  behavior's `Cast` — the engine walks the prospective path while planning the
  move, which is what `EnterAuraHaltsMovement` answers — and it is gated to once
  per aura per turn, with the *planning* pass consuming the gate, so the real
  movement's entries arrive with it already closed. "Force moved into the area"
  carries no such limit: a creature shoved in, cleared, and shoved in again on the
  same turn takes the effect both times.
* **Hooking the forced-movement _ability_ path only covers scripted pushes.** A
  Director ALT-dragging a token is forced movement that casts no ability at all
  (it reports `forced=true`, `movementType="pushed"`), and was silently missed.

`OnMove` is the one place every kind of movement arrives, and it hands over the
real `LuaPath`, so the squares entered are the engine's own steps rather than a
reconstructed straight line — rebounds and collision-shortened pushes come out
right for free. Note `steps[1]` is where the move started, so a square counts as
entered only from `steps[2]` on; a shove that goes nowhere fires nothing.

`EnterAura` skips `movementFilter == "forced"` triggers; every other trigger is
handled there exactly as before, so existing auras are untouched.

## Map modification records for created objects

`ActivatedAbilityCreateObjectBehavior` groups a cast's placements into one
revertible record, so created objects appear in the character panel's Map
Modifications folder alongside walls and terrain edits.

`game.AddMapModificationVoxel` accepts a plain spawned object and the record shows
up correctly, but `DeleteMapModification` does **not** destroy it — the engine's
revert only collapses wall-voxel columns. Placements are therefore stamped with the
record key and torn down from Lua before the engine call. The shared revert UI is
reworded off "wall", which is no longer the only thing recorded.

## Aura caster and identity on spawned objects

Spawned object auras carry `casterid`. Without it every caster-relative audience
(`allother`, `enemies`, ...) resolves against nobody — which notably makes a
`blocks_line_of_effect` aura block line of effect for its own creator, since the
engine evaluates the audience per creature when computing cover.

Each spawned object's aura also gets its own instance guid. Object assets bake a
fixed one, so a whole wall of spawned squares shared a single `aurasEntered` slot:
entering any one square silenced the entire wall for the turn. Restricted to auras
carrying triggers, because that guid also feeds `EnterAuraHaltsMovement` — making
trigger-less auras unique would start halting movement at every square of existing
content (the Delian Tomb brambles) instead of once per turn.

## Testing

Driven against a live instance, confirmed for **both scripted pushes and
ALT-drags**:

* Crossing the area bleeds and deals the per-square damage.
* Cleared and pushed again on the same turn bleeds again.
* A blocked shove, a forced path that misses the area, and a creature starting on
  a square without entering another all correctly do nothing.
* Map modification round trip: placements grouped into one record, revert destroys
  them and removes the record, unrelated records untouched.
* Cover: with `casterid` set and `applyto: allother`, the creator shoots through its
  own wall while it still blocks for everyone else.

## Not included

The Bramble Barricade content itself (a new object asset and the monster group
edit) lives in the `data` submodule and is **not** part of this PR. These Lua
changes are generic and stand alone, but nothing here exercises them until that
content lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
