### PR TITLE
Hidden targeting: replace hard non-Area block with a visible advisory

### DIFF
--- a/Draw Steel Core Rules/MCDMRules.lua
+++ b/Draw Steel Core Rules/MCDMRules.lua
@@ -1248,20 +1248,26 @@ local friendlyFire = setting{
 
 local g_hiddenConditionId = "31daf7f6-f77c-4f73-8eab-43e2d0f123c0"
 
-function GameSystem.AllowTargeting(casterToken, targetToken, ability)
-	if friendlyFire:Get() == false and ability:HasKeyword("Strike") and ability:HasKeyword("Area") and casterToken:IsFriend(targetToken) then
-		return false
-	end
-
-	-- Hidden: "While you are hidden from another creature, the creature can't
-	-- target you with abilities that don't have the Area keyword." A creature
-	-- with the Hidden condition is treated as hidden from all its enemies:
-	-- enemies lose non-Area targeting (including free strikes), while allies
-	-- can still target them normally. Area abilities are unaffected, so a
-	-- hidden creature standing in a swept area is still hit.
+-- Advisory (non-blocking) targeting note, shown as a tooltip on the target
+-- ring during ability targeting. Hidden: "While you are hidden from another
+-- creature, the creature can't target you with abilities that don't have the
+-- Area keyword." We deliberately do NOT hard-block this on the backend:
+-- abilities that exist to interact with hidden creatures (Search for Hidden,
+-- Revelator) must be able to target them, so the rule surfaces as a warning
+-- and the table adjudicates the exceptions. Allies are unaffected (a creature
+-- is only hidden from its enemies) and Area abilities are unaffected.
+function GameSystem.TargetingAdvisoryReason(casterToken, targetToken, ability)
 	if (not targetToken.isObject) and (not ability:HasKeyword("Area"))
 		and (not casterToken:IsFriend(targetToken))
 		and targetToken.properties:HasCondition(g_hiddenConditionId) ~= false then
+		return "This creature is hidden: it can't normally be targeted by abilities without the Area keyword."
+	end
+
+	return nil
+end
+
+function GameSystem.AllowTargeting(casterToken, targetToken, ability)
+	if friendlyFire:Get() == false and ability:HasKeyword("Strike") and ability:HasKeyword("Area") and casterToken:IsFriend(targetToken) then
 		return false
 	end
 

--- a/Draw Steel UI/DSActionBar.lua
+++ b/Draw Steel UI/DSActionBar.lua
@@ -1569,8 +1569,17 @@ function GameHud.CreateActionBar(self, dialog, tokenInfo)
                                         targetToken.sheet.data.targetInfo = nil
                                         targetToken.sheet:FireEvent("untarget")
                                     end
+
+                                    --game-system advisory (e.g. "this creature is hidden"):
+                                    --a non-blocking rules note surfaced as a tooltip on the
+                                    --target ring, the way reasoned filters surface reasons.
+                                    local advisoryReason = nil
+                                    if GameSystem.TargetingAdvisoryReason ~= nil then
+                                        advisoryReason = GameSystem.TargetingAdvisoryReason(token, targetToken, spell)
+                                    end
+
 									targetToken.sheet.data.targetInfo = targetInfo
-									targetToken.sheet:FireEvent('target', { classes = cond(valid, {}, {'invalid'}) })
+									targetToken.sheet:FireEvent('target', { classes = cond(valid, {}, {'invalid'}), reason = advisoryReason })
 
                                     potentialTargetTokens[#potentialTargetTokens+1] = targetToken
 								end


### PR DESCRIPTION
## What this does

Follow-up to the review feedback on #191: the Hidden condition's targeting rule ("while you are hidden from another creature, the creature can't target you with abilities that don't have the Area keyword") was enforced as a **hard block** in `GameSystem.AllowTargeting`. That prevented abilities that exist to interact with hidden creatures — **Search for Hidden**, **Revelator** — from targeting them at all, and it blocked silently, which read as a bug.

This replaces the hard block with a **visible, non-blocking advisory**:

- Hidden creatures are targetable again by all abilities (Search/Revelator work).
- Targeting a hidden creature with a non-Area ability now shows a reason tooltip on the target ring — *"This creature is hidden: it can't normally be targeted by abilities without the Area keyword."* — the same way reasoned filters surface reasons. The exception cases are left to table adjudication.
- Allies and Area abilities are unaffected (a creature is only hidden from its enemies, and Area targeting was never blocked).

## How

- `MCDMRules.lua`: the hidden branch is removed from `AllowTargeting`; a new `GameSystem.TargetingAdvisoryReason(casterToken, targetToken, ability)` returns the rules note for enemy, non-Area, non-object targeting of a creature with the Hidden condition (and `nil` otherwise — the hook is generic for future advisories).
- `DSActionBar.lua`: the ability-targeting flow passes the advisory into the token `target` event; TokenUI's handler already renders `options.reason` as a hover tooltip on the target ring.

## Testing

Verified live: with no Hidden condition, `AllowTargeting` allows and the advisory is nil; after applying Hidden to a monster, `AllowTargeting` **allows** (previously blocked) and the advisory returns the reason text for a non-Area ability from an enemy hero.
