### PR TITLE
Fix Action Log roll total not revealing until message completes (report NY2X4E2H)

### DIFF
--- a/ChatPanel/ActionLogPanel.lua
+++ b/ChatPanel/ActionLogPanel.lua
@@ -676,6 +676,12 @@ local CreateRollMessagePanel = function(message, adoptiveParentPanel)
                 chatMessagePanel:SetClassTree("adopted", true)
             end,
 
+            --The custom power roll panel is a sibling of rollContentPanel, so its
+            --FireEventOnParents("forceShowResult") only reaches this common ancestor.
+            forceShowResult = function(element)
+                rollContentPanel:FireEventTree("showresult")
+            end,
+
             adoptedRollContent,
             customPanelWrapper,
         }
@@ -723,6 +729,12 @@ local CreateRollMessagePanel = function(message, adoptiveParentPanel)
                 else
                     rollNameLabel.text = message.playerName or ""
                 end
+            end,
+
+            --The custom power roll panel is a sibling of rollContentPanel, so its
+            --FireEventOnParents("forceShowResult") only reaches this common ancestor.
+            forceShowResult = function(element)
+                rollContentPanel:FireEventTree("showresult")
             end,
 
             gui.Panel{


### PR DESCRIPTION
**Symptom:** In the Action Log a characteristic-test power roll shows the dice faces and highlights the correct tier, but the large roll total stays invisible until the chat message is marked complete.

**Root cause:** `CreateRollCategoryPanel` builds `resultLabel` with class `roll-category-total`, whose style sets `color = 'clear'`; it only becomes visible once the label gains the `show` class, which its `showresult` handler sets. The sole producer of `showresult` is the `forceShowResult` handler on `rollContentPanel`, and the sole caller is `element:FireEventOnParents("forceShowResult")` in the `diceend` handler of `RollPropertiesPowerTable:CustomPanel` (`Draw Steel Core Rules/MCDMAbilityRollBehavior.lua`). `FireEventOnParents` walks strict ancestors only. Since commit cf435813 the custom power-roll panel lives in `customPanelWrapper`, which is a *sibling* subtree of `rollContentPanel` in both the adopted and standalone layout branches -- so the event never reaches the handler and the `show` style state became dead code.

**Fix:** Add a delegating `forceShowResult` handler to both `chat-message-panel` constructions (the nearest common ancestor of `customPanelWrapper` and `rollContentPanel` in each branch), which re-fires `showresult` down the `rollContentPanel` subtree. No panels are moved, so layout is unchanged. The handler is purely additive: `showresult`'s only listener does `element:SetClass("show", true)` (idempotent), and the label's text is already assigned on every `refreshInfo`, so no value is computed or changed. The reveal still only happens after the dice land, because the trigger remains the power-roll panel's `diceend`.

Report: NY2X4E2H

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
