### PR TITLE
Fix save roll coroutine hanging forever when its dialog is destroyed (report NQMSECG3)

### DIFF
--- a/Draw Steel Core Rules/MCDMAbilitySaveBehavior.lua
+++ b/Draw Steel Core Rules/MCDMAbilitySaveBehavior.lua
@@ -225,16 +225,10 @@ function ActivatedAbilitySaveBehavior:RollSaveInTimeline(ability, casterToken, t
         if rollCanceled then
             return false
         end
-        --Backstop: the embedded roll dialog can be destroyed out from under an
-        --active save when a sibling end-of-turn trigger cast finishes and tears
-        --down the ability sidebar (log signature: "RollDialog:: DESTROY
-        --castCoroutine=<n> wasShown=true" with no matching RICH:: Pop). Neither
-        --cancelRoll nor completeRoll fires on that path, so without this check
-        --the cast coroutine yields forever, stays "suspended" in
-        --ActivatedAbility.coroutineStorage, and permanently blocks
-        --ActivatedAbility.RunWhenCastsComplete -- silently killing every later
-        --deferred triggered-ability cast on this client (report NQMSECG3:
-        --Troubadour "Start of Turn Drama" never fired again all session).
+        --If the roll dialog is destroyed while we wait here (another cast can
+        --tear it down), neither callback ever fires and this loop would spin
+        --forever, quietly breaking every later triggered ability. Treat it as
+        --a canceled roll instead. (report NQMSECG3)
         if dialog == nil or (not dialog.valid) or dialog.data == nil then
             return false
         end

--- a/Draw Steel Core Rules/MCDMAbilitySaveBehavior.lua
+++ b/Draw Steel Core Rules/MCDMAbilitySaveBehavior.lua
@@ -225,6 +225,19 @@ function ActivatedAbilitySaveBehavior:RollSaveInTimeline(ability, casterToken, t
         if rollCanceled then
             return false
         end
+        --Backstop: the embedded roll dialog can be destroyed out from under an
+        --active save when a sibling end-of-turn trigger cast finishes and tears
+        --down the ability sidebar (log signature: "RollDialog:: DESTROY
+        --castCoroutine=<n> wasShown=true" with no matching RICH:: Pop). Neither
+        --cancelRoll nor completeRoll fires on that path, so without this check
+        --the cast coroutine yields forever, stays "suspended" in
+        --ActivatedAbility.coroutineStorage, and permanently blocks
+        --ActivatedAbility.RunWhenCastsComplete -- silently killing every later
+        --deferred triggered-ability cast on this client (report NQMSECG3:
+        --Troubadour "Start of Turn Drama" never fired again all session).
+        if dialog == nil or (not dialog.valid) or dialog.data == nil then
+            return false
+        end
         coroutine.yield(0.1)
     end
 


### PR DESCRIPTION
**Symptom:** A Troubadour stopped gaining Drama at the start of their turns for an entire session (report: "Not rolling drama when i start my turn.").

**Root cause:** The first turn rolled normally; then an unresolved end-of-turn "Saving Throw vs Weakened" had its embedded roll dialog destroyed by a sibling end-of-turn trigger cast's teardown of the ability sidebar (log signature: `RollDialog:: DESTROY castCoroutine=19 wasShown=true` with no matching `RICH:: Pop`). Neither `completeRoll` nor `cancelRoll` runs on that path, so the unbounded wait loop at the end of `ActivatedAbilitySaveBehavior:RollSaveInTimeline` yielded forever, leaving the cast coroutine suspended in `ActivatedAbility.coroutineStorage`. That permanently blocks `ActivatedAbility.RunWhenCastsComplete`, so every subsequent deferred triggered-ability cast on that client -- including Start of Turn Drama -- is queued and never executed.

**Fix:** Add a dialog-liveness guard inside that wait loop in `Draw Steel Core Rules/MCDMAbilitySaveBehavior.lua`. It is the exact same three-part condition (`dialog == nil or (not dialog.valid) or dialog.data == nil`) the function already applies right after acquiring the dialog, and it already returns `false` there -- this just re-checks it while waiting instead of only once at acquisition. Returning `false` means "the save was not rolled", which the sole caller `ActivatedAbilitySaveBehavior:Cast` already handles (`if not rolled then return end`). The cast then unwinds normally, the coroutine dies, and the deferred-trigger queue drains.

The change is purely additive: on every path where the dialog stays alive, behaviour is byte-for-byte identical.

**Known related exposure (deliberately not touched here):** the structurally identical wait loops in `DMHub Game Rules/AbilityReplenish.lua:271` and `Draw Steel Ability Behaviors/AbilityDamage.lua:361` have the same shape, but neither was the proven path in this report; they are tracked separately.

**Report id:** NQMSECG3

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
