### PR TITLE
Fix Title benefits missing from character panel FEATURES (report 6QMBR2YM)

### DIFF
--- a/Draw Steel Character Builder/FeatureCache.lua
+++ b/Draw Steel Character Builder/FeatureCache.lua
@@ -1932,8 +1932,9 @@ end
 --- This runs per CAPABILITY -- so a perk chosen via a career slot is dropped
 --- even though its parent slot sits in the Career bucket.
 --- @param feature any
+--- @param bucketId string|nil optional; the index bucket the leaf's entry belongs to
 --- @return boolean
-function FeatureCategoriser.IsPassiveFeature(feature)
+function FeatureCategoriser.IsPassiveFeature(feature, bucketId)
     if feature == nil then return true end
     --A skill / language / perk CHOICE container belongs to its own section
     --(a skill-group pick is captured under Skills). The recursion can surface
@@ -1946,7 +1947,13 @@ function FeatureCategoriser.IsPassiveFeature(feature)
             return false
         end
     end
-    if not categoriserIsDerived(feature, "Title")
+    --The Title / Complication exemption is decided by the BUCKET the leaf came
+    --from: a title's benefit resolves to a plain CharacterFeature carrying
+    --`source = "Feat"`, which never reports the Title type, so the derived-type
+    --tests below can only ever match an unresolved origin object. They stay as a
+    --fallback for callers that pass no bucket.
+    if bucketId ~= "title" and bucketId ~= "complication"
+        and not categoriserIsDerived(feature, "Title")
         and not categoriserIsDerived(feature, "CharacterComplication") then
         --A perk: either CharacterFeat-derived, or a resolved feature whose
         --source is the feats table ("Feat"). The latter catches a career- or
@@ -2039,7 +2046,7 @@ function FeatureCategoriser.BuildTacIndex(creature)
     --at the wrapper, and only emit the surviving passive LEAVES (with their own
     --name + description) -- never the "list of features" wrapper.
     local lc = (creature ~= nil and creature:GetLevelChoices()) or {}
-    local function collectLeaves(feature, out, depth)
+    local function collectLeaves(feature, out, depth, bucketId)
         if feature == nil or depth > 6 then return end
         local tn = nil
         pcall(function() tn = feature.typeName end)
@@ -2050,7 +2057,7 @@ function FeatureCategoriser.BuildTacIndex(creature)
             local kids = nil
             pcall(function() kids = feature:try_get("features", {}) end)
             if type(kids) == "table" then
-                for _,sub in ipairs(kids) do collectLeaves(sub, out, depth + 1) end
+                for _,sub in ipairs(kids) do collectLeaves(sub, out, depth + 1, bucketId) end
             end
         elseif tn == "CharacterFeatureChoice" then
             local guid = nil
@@ -2066,12 +2073,12 @@ function FeatureCategoriser.BuildTacIndex(creature)
                 if g ~= nil then byGuid[g] = o end
             end
             for _,id in ipairs(made) do
-                if byGuid[id] ~= nil then collectLeaves(byGuid[id], out, depth + 1) end
+                if byGuid[id] ~= nil then collectLeaves(byGuid[id], out, depth + 1, bucketId) end
             end
         else
             --A leaf feature: keep it if it is a passive capability. Domain
             --scaffolding is dropped at emit (it applies to plain entries too).
-            if FeatureCategoriser.IsPassiveFeature(feature) then
+            if FeatureCategoriser.IsPassiveFeature(feature, bucketId) then
                 out[#out+1] = feature
             end
         end
@@ -2106,9 +2113,9 @@ function FeatureCategoriser.BuildTacIndex(creature)
         if FeatureCategoriser.IsTacPanelEntry(creature, entry) then
             local leaves = {}
             if entry.chosen ~= nil and #entry.chosen > 0 then
-                for _,opt in ipairs(entry.chosen) do collectLeaves(opt, leaves, 0) end
+                for _,opt in ipairs(entry.chosen) do collectLeaves(opt, leaves, 0, entry.bucket) end
             else
-                collectLeaves(entry.feature, leaves, 0)
+                collectLeaves(entry.feature, leaves, 0, entry.bucket)
             end
             for _,leaf in ipairs(leaves) do
                 emit(_safeFeatureName(leaf), leaf, entry)


### PR DESCRIPTION
**Symptom:** Titles never appear in the right-hand Character panel's FEATURES section, even when the hero has titles with all benefit choices made (report 6QMBR2YM: "Titles not shown on list of features in the character sidebar").

**Root cause:** `FeatureCategoriser.ClassifyEntry` buckets title entries correctly as `title`, and `title` is not in `TAC_EXCLUDED_BUCKETS`, so titles do reach the tac index. But `BuildTacIndex` -> `collectLeaves` applies `FeatureCategoriser.IsPassiveFeature` to the RESOLVED LEAF feature. A title benefit resolves to a plain `CharacterFeature` carrying `source: Feat` (61 of 63 files in `data/objectTables/titles`). `IsPassiveFeature`'s Title/Complication exemption is expressed as `categoriserIsDerived(feature, "Title")` on that leaf, which can never be true for a resolved feature -- so the exemption was dead code and the `source == "Feat"` perk rule dropped every title benefit. The Perks section only surfaces `CharacterFeatChoice` picks, so the benefits appeared nowhere. Complication features escape the same rule only incidentally, because they carry `source: Complications`.

**The fix:** Make the exemption bucket-aware. `IsPassiveFeature` takes an optional `bucketId` and bails out of the perk-detection block when the bucket is `title` or `complication`; `collectLeaves` threads the entry's bucket down through its recursive calls to the leaf test. The two `categoriserIsDerived` tests remain as a fallback for any caller that passes no bucket (there are none today -- `IsPassiveFeature` has exactly one caller in the codex -- so behaviour is unchanged for everything else). All the other per-leaf filters are untouched, so a title benefit that grants a skill/language, a resource, only characteristics, or an `activated`/`triggerdisplay`/`routine` ability (e.g. Battlefield Commander's activated benefit) is still routed to its own section or the action bar rather than duplicated here. The full (non-tac) index used by the character sheet is not affected.

**Effect:** Additive -- a "Title - <name>" group with its passive benefits now renders in the sidebar FEATURES list, matching the Complication group that already works. For the reporter's Fury 6 (Angler / Local Hero / Battlefield Commander / Siege Breaker), Siege Breaker's chosen "Hold the Line" and Local Hero's "Easy Marks" now appear. Angler has `features: []` in the data, so it still has nothing to show; that data gap is out of scope here.

Verified: `luac -p` on the edited file exits 0, and the file remains pure ASCII.

Report: 6QMBR2YM. Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
