### PR TITLE
Fix hero followers gaining monster band Malice abilities (report B9PHVKF6)

### DIFF
--- a/Draw Steel Core Rules/MCDMMonster.lua
+++ b/Draw Steel Core Rules/MCDMMonster.lua
@@ -61,7 +61,7 @@ function monster:FillMonsterActivatedAbilities(options, result)
 
     self:FillFreeStrikes(options, result)
 
-    if self:try_get("retainer", false) then
+    if self:try_get("retainer", false) or self:IsFollower() then
         return
     end
 


### PR DESCRIPTION
**Symptom:** A hero's retainer follower shows a Malice-cost monster ability on its action bar (Illwyth gained the Human band's 3-Malice "Alchemical Device" maneuver and used it in play).

**Root cause:** Adding a retainer via the journal follower widget produces a `follower` record (`follower = RegisterGameType("follower", "monster")`, `DSFollower.lua:18`) that has `followerType: "retainer"` but no `retainer` flag, and `CreateFollowerMonster` assigns it the chosen ancestry's monster band as its `groupid`. The malice guard in `monster:FillMonsterActivatedAbilities` (`Draw Steel Core Rules/MCDMMonster.lua`) only checked the `retainer` flag, so it missed these followers and the band's `maliceAbilities` were appended to a hero-side creature. Malice is a Director resource for the Director's monsters and should never appear on a hero's follower.

**The fix:** Widen the existing early-return guard from `self:try_get("retainer", false)` to `self:try_get("retainer", false) or self:IsFollower()`. `monster:IsFollower()` (`MCDMCreature.lua:537`) is true for retainer, artisan and sage followers, so artisans and sages -- which had the same exposure -- are covered too; `creature:IsFollower()` returns false, so no non-monster type is affected. The `self:FillFreeStrikes(options, result)` call above the guard is untouched, so followers keep their free strike. This makes the generic-follower path consistent with bestiary retainers, which carry `retainer: true` and were already excluded by commit 3f2c936d "Retainers do not gain malice abilities".

**Not addressed:** The other half of the report -- the retainer being created as a blank statblock rather than from the bestiary entry -- needs design work in `DSFollower.lua` / `RichFollower.lua` and remains open.

Report: B9PHVKF6
Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
