### PR TITLE
Fix augmented-ability OnBeginCast dropping cast options (report DAZ5HX6C)

### DIFF
--- a/Draw Steel Core Rules/DSAugmentAbilities.lua
+++ b/Draw Steel Core Rules/DSAugmentAbilities.lua
@@ -42,10 +42,10 @@ function ActivatedAbilityAugmentedAbilityBehavior:SynthesizeAbilities(ability, c
 
             if OnBeginCast ~= nil then
                 local oldBeginCast = synth:try_get("OnBeginCast")
-                synth.OnBeginCast = function()
-                    OnBeginCast()
+                synth.OnBeginCast = function(synthAbility, castOptions)
+                    OnBeginCast(synthAbility, castOptions)
                     if oldBeginCast ~= nil then
-                        oldBeginCast()
+                        oldBeginCast(synthAbility, castOptions)
                     end
                 end
             end


### PR DESCRIPTION
**Symptom:** A Fury/Stormwight player stopped being offered the start-of-turn Ferocity roll (and, in fact, no triggered ability fired again on that client for the rest of the session).

**Root cause:** In `Draw Steel Core Rules/DSAugmentAbilities.lua`, `ActivatedAbilityAugmentedAbilityBehavior:SynthesizeAbilities` re-wraps the synthesized ability's `OnBeginCast` with a zero-parameter closure that forwards no arguments. The engine invokes the hook as `self.OnBeginCast(self, options)` (`DMHub Game Rules/ActivatedAbility.lua:2727`), and the parent handler this wrapper forwards to is the ability-invoke wrapper in `DMHub Game Rules/AbilityInvokeAbility.lua`, `function(_ability, castOptions) ... casting = true; installFinishHandler(castOptions) end`.

Because the options argument was dropped, `installFinishHandler` hit its `if castOptions == nil then return end` guard and the invoke's `finishHandler` was never appended to `options.OnFinishCastHandlers`. The fallback `ability.OnFinishCast` field is stripped by mid-cast serialization (documented in `AbilityInvokeAbility.lua`; confirmed in this report's log by `Unknown type deep copied: Function` errors from the `abilityTimelineShare` write during the power-roll dialog), so nothing ever cleared the invoke's `casting` flag.

One earlier Charge therefore left its "Attack when Charging" invoke coroutine spinning forever (`INVOKEDIAG:: waiting for Attack when Charging casting=true`, 830+ five-second heartbeats over 68 minutes), permanently pinning `ActivatedAbility.coroutineStorage` non-empty. That wedges `ActivatedAbility.RunWhenCastsComplete` and therefore every deferred triggered-ability cast (`DMHub Game Rules/TriggeredAbility.lua`). Ferocity was just the visible symptom.

**The fix:** Declare the wrapper as `function(synthAbility, castOptions)` and forward both arguments to `OnBeginCast` and `oldBeginCast`. This matches what the `mustPayResourceCost` branch further down the same function already does, and what the `OnFinishCast` wrapper directly below already does.

Passing extra arguments to a Lua function that declares none is a no-op, so any existing handler that ignores its parameters is unaffected. The only behavioural change is that `installFinishHandler` now receives the real cast options - the documented intent of the `OnFinishCastHandlers`-on-options mechanism. Double invocation is harmless: the invoke's `finishHandler` is idempotent via its `finishedCasting` guard.

Report: DAZ5HX6C

_Originated from automated feedback triage._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
