### PR TITLE
Fix conditions listed three times in the Conditions symbol (report NKHPJQW8)

### DIFF
--- a/DMHub Game Rules/Creature.lua
+++ b/DMHub Game Rules/Creature.lua
@@ -8595,7 +8595,7 @@ creature.lookupSymbols = {
 	conditions = function(c)
 
 		local result = {}
-		local conditions = {}
+		local ongoingEffectConditions = {}
 		local ongoingEffects = c:ActiveOngoingEffects()
 		if #ongoingEffects > 0 then
 			local ongoingEffectsTable = GetTableCached("characterOngoingEffects")
@@ -8603,7 +8603,7 @@ creature.lookupSymbols = {
 				local ongoingEffectInfo = ongoingEffectsTable[cond.ongoingEffectid]
 				--if this ongoing effect has an underlying condition then record us having that condition since conditions can also have modifiers.
 				if ongoingEffectInfo.condition ~= 'none' then
-					conditions[ongoingEffectInfo.condition] = true
+					ongoingEffectConditions[ongoingEffectInfo.condition] = true
 				end
 			end
 		end
@@ -8632,18 +8632,35 @@ creature.lookupSymbols = {
         end
 
 		--we have a table of conditions based on ongoing effects, add any of their modifiers.
-		for k,_ in pairs(conditions) do
+		for k,_ in pairs(ongoingEffectConditions) do
 			local conditionInfo = conditionsTable[k]
-			result[#result+1] = conditionInfo.name
+			if conditionInfo ~= nil then
+				result[#result+1] = conditionInfo.name
+			end
 		end
 
 		local inflictedConditions = c:get_or_add("inflictedConditions", {})
 		for condid,_ in pairs(inflictedConditions) do
-			result[#result+1] = conditionsTable[condid].name
+			local conditionInfo = conditionsTable[condid]
+			if conditionInfo ~= nil then
+				result[#result+1] = conditionInfo.name
+			end
+		end
+
+		--the same condition can be reached by several of the paths above, so de-duplicate
+		--while preserving the order we first saw each name in.
+		local seen = {}
+		local uniqueResult = {}
+		for _,name in ipairs(result) do
+			local key = string.lower(name)
+			if seen[key] == nil then
+				seen[key] = true
+				uniqueResult[#uniqueResult+1] = name
+			end
 		end
 
 		return StringSet.new{
-			strings = result,
+			strings = uniqueResult,
 		}
 
 	end,


### PR DESCRIPTION
**Symptom:** A manually-added condition shows up three times in a character's Conditions list in the Character Inspector.

**Root cause:** In the `conditions` GoblinScript symbol in `DMHub Game Rules/Creature.lua`, ongoing-effect-derived condition ids are collected into a local table named `conditions`. That local is then shadowed twice -- first by `local conditions = rawget(c, "_tmp_directConditions")` and then by the reassignment `conditions = rawget(c, "_tmp_calculatedConditions")`. The final loop -- whose comment says it is adding the ongoing-effect-derived conditions -- therefore re-iterates `_tmp_calculatedConditions` a second time, and the `inflictedConditions` loop then adds each condition a third time. `StringSet.new` does not de-duplicate (only `StringSet:Add` does; see `DMHub Game Rules/CustomAttribute.lua`). Since `creature:FillTemporalActiveModifiers` records both inflicted and ongoing-effect conditions into `_tmp_calculatedConditions`, a single active condition lands in the result three times.

**What this changes** (all inside that one function):
- Renames the ongoing-effect local to `ongoingEffectConditions` so it is no longer shadowed, and points the final loop at it -- this is the actual duplicate fix, and it also removes a latent `pairs(nil)` crash for creatures whose `_tmp_calculatedConditions` has never been computed.
- Nil-guards the `conditionsTable` lookups in the ongoing-effect and `inflictedConditions` loops (matching the guard the other two loops already use), so a stale or removed condition id can no longer raise an index-nil error.
- De-duplicates the names before constructing the `StringSet`, preserving first-seen order and keying on `string.lower(name)` to match `StringSet:Has`'s case-insensitive comparison.

A `StringSet` is semantically a set, so removing duplicates cannot change any `has` / `has not` / `is` result; it only corrects the Character Inspector display (which joins `strings` with newlines) and any sequence iteration or count over `Conditions`, both of which are wrong today.

Out of scope: the report also asks why Ongoing Effects do not appear in the Conditions set. That behaves as designed and is deliberately untouched here. The `ongoingeffects` symbol and the `conditioncount` symbol in `Draw Steel Core Rules/MCDMCreature.lua` (which still has the original, unshadowed shape) are unchanged.

Report id: NKHPJQW8

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
