### PR TITLE
Fix pasted ability aliasing the copied ability (report TKCN66EH)

### DIFF
--- a/Draw Steel V/DrawSteelChararcterSheet.lua
+++ b/Draw Steel V/DrawSteelChararcterSheet.lua
@@ -4883,6 +4883,25 @@ local function DSCharSheet()
                         text = "Paste Ability",
                         press = function(element)
                             local clipboardItem = DeepCopy(dmhub.GetInternalClipboard())
+                            if clipboardItem == nil then
+                                return
+                            end
+
+                            --A pasted ability is a NEW ability, not the one that was
+                            --copied. Without a fresh guid the creature ends up with two
+                            --innate abilities sharing one guid, and guid-keyed lookups
+                            --(creature:IsActivatedAbilityInnate) resolve both sheet rows
+                            --to the same object, so one copy can never be edited (and
+                            --RemoveInnateActivatedAbility deletes both).
+                            clipboardItem.guid = dmhub.GenerateGuid()
+                            local behaviors = clipboardItem:try_get("behaviors")
+                            if behaviors ~= nil then
+                                for _, b in ipairs(behaviors) do
+                                    if b:try_get("guid") ~= nil then
+                                        b.guid = dmhub.GenerateGuid()
+                                    end
+                                end
+                            end
 
                             CharacterSheet.instance.data.info.token.properties:AddInnateActivatedAbility(
                                 clipboardItem)


### PR DESCRIPTION
**Symptom:** Duplicating an ability on the character sheet leaves both rows' gear icons opening the same (new) ability, so the original can no longer be edited.

**Root cause:** The "Paste Ability" button on the Draw Steel V character sheet deep-copies the clipboard ability *including its guid*, so the creature ends up with two innate abilities sharing one guid. `creature:IsActivatedAbilityInnate` matches on guid and returns the first hit, so both sheet rows resolve to the same object. The same collision makes `creature:RemoveInnateActivatedAbility` delete both copies at once. Every other duplicate path in the codex already regenerates the guid (the villain-action picker in this same file, the malice-ability paste in `Draw Steel UI/DSMaliceCompendium.lua`, `_applyAbilityFields` in `Draw Steel Ability Editor/AbilityEditorTemplates.lua`); the character-sheet paste was missed.

**Fix:** In `Draw Steel V/DrawSteelChararcterSheet.lua`, the Paste Ability `press` handler now assigns `clipboardItem.guid = dmhub.GenerateGuid()` and regenerates behavior guids (same guarded loop as `_applyAbilityFields`) before calling `AddInnateActivatedAbility`. The object is already a private `DeepCopy`, so nothing else references it. A `nil` guard was added for the clipboard-empty path that `refreshToken` already hides.

Report id: TKCN66EH

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
