### PR TITLE
Fix GoblinScript Cast.Boons uses deprecated 5e wording; add Cast.Edges (report RE6PNYMM)

### DIFF
--- a/Draw Steel Core Rules/MCDMActivatedAbilityCast.lua
+++ b/Draw Steel Core Rules/MCDMActivatedAbilityCast.lua
@@ -13,9 +13,22 @@ GameSystem.RegisterGoblinScriptField{
     target = ActivatedAbilityCast,
     name = "Boons",
     type = "number",
-    desc = "The number of boons applied while using this ability.",
-    seealso = {},
+    desc = "Deprecated name for Edges. The number of edges applied while using this ability.",
+    deprecated = true,
+    seealso = {"Edges"},
     examples = {},
+    calculate = function(c)
+        return c.boonsApplied
+    end,
+}
+
+GameSystem.RegisterGoblinScriptField{
+    target = ActivatedAbilityCast,
+    name = "Edges",
+    type = "number",
+    desc = "The number of edges applied while using this ability.",
+    seealso = {"Banes"},
+    examples = {"Cast.Edges > Cast.Banes", "Cast.Edges >= 1"},
     calculate = function(c)
         return c.boonsApplied
     end,


### PR DESCRIPTION
**Symptom:** In GoblinScript, a cast's edges are only reachable as `Cast.Boons` -- deprecated 5e-era wording -- with no `Cast.Edges` available.

**Root cause:** The GoblinScript field exposing a cast's edges is registered as `Boons` in `Draw Steel Core Rules/MCDMActivatedAbilityCast.lua`. Draw Steel's term is Edges, and `Edges` is already the correct name in the takedamage/dealdamage trigger symbol sets. There is no `Cast.Edges` symbol at all today, so authors are forced to use the deprecated word -- the docs even paper over it (`CORE.md:363` reads "`Cast.Boons` | Number | Edges applied (Draw Steel)").

**What the fix changes:** Registers `Edges` as a pure additive alias on `ActivatedAbilityCast` with the same `calculate` (`c.boonsApplied`), and marks the existing `Boons` field `deprecated = true` with an updated description and `seealso = {"Edges"}`.

`Boons` is deliberately left registered and functionally untouched: shipped monster data uses it (`data/monsters/fleshflayed-shambler.yaml:123` has `filterTarget: Cast.Boons > Cast.Banes`) and an unknown amount of user-authored content does too. `RegisterGoblinScriptSymbol` keys entries by the lowercased name, so this writes a brand-new `edges` key and leaves `boons` byte-identical; `ActivatedAbilityCast` has no `derivedTypes`, so nothing fans out to other types. The `deprecated` flag is only stored in `helpSymbols` and is not read by any current consumer, so both fields show in the field docs -- the intended transitional state.

Verified `luac -p` clean and ASCII-only.

Report: RE6PNYMM
Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)