### PR TITLE
Fix onboarding tips drawing over the character sheet (report KCF5YRFH)

### DIFF
--- a/DMHub Game Hud/GameHud.lua
+++ b/DMHub Game Hud/GameHud.lua
@@ -2353,6 +2353,11 @@ local g_tipBlockingClasses = {
 
 --Returns true if any tip-blocking dialog is currently in the panel tree.
 function GameHud:_TipIsBlockedByDialog()
+	--The character sheet is hosted by the engine in its own SheetPanel root
+	--(CharacterSheetHarness), not under the HUD's parentPanel, so the class
+	--walk below cannot see it. Ask the engine directly.
+	if dmhub.inCharacterSheet then return true end
+
 	local root = self:try_get("parentPanel")
 	if root == nil or not root.valid then return false end
 	for _, cls in ipairs(g_tipBlockingClasses) do


### PR DESCRIPTION
**Symptom:** After picking a pregen, onboarding tip banners drew across the top of the character builder the player had just opened ("I got tutorial banners over top of my character explanation. Not the right moment.").

**Root cause:** The tip driver's only suppression check, `GameHud:_TipIsBlockedByDialog()`, walks the HUD's `parentPanel` looking for a `journalViewer` class. The character sheet / builder is hosted by the engine in its own SheetPanel root (CharacterSheetHarness), not under the HUD's `parentPanel`, so that walk can never see it and tips kept firing. (The specific tips were camera-move, camera-zoom and token-drag-move, identified from the byte sizes of the `tipsLearned` preference writes in the report log.)

**Fix:** Add a single early-out at the top of `_TipIsBlockedByDialog()` that consults the existing read-only engine flag `dmhub.inCharacterSheet`. This gives the character sheet the same suppress-without-consuming treatment the journal viewer already gets: on the active-tip path the banner is hidden without marking the tip learned (so it returns later), and on the scan path display is simply skipped for that tick. No engine change is required, and the check runs at most once per 1 Hz think tick.

Neither of the two tips that place tutorial highlights (`use-light` -> `#char-panel-light-btn`, `beastheart-call` -> `#beastheart-call-btn`) targets anything inside the character sheet, so nothing is lost by suppressing while the sheet is up.

Report id: KCF5YRFH

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
