### PR TITLE
Fix two flanking grantors cancelling each other out (report Q37DW443)

### DIFF
--- a/Draw Steel Core Rules/MCDMCreature.lua
+++ b/Draw Steel Core Rules/MCDMCreature.lua
@@ -2276,11 +2276,33 @@ function creature:GetFlankingTokens(tokensOverride)
     end
 
     local grantedFlanking = {}
-    for i, enemy in ipairs(adjacentEnemies) do
-        local grantFlanking = enemy.properties:GrantFlankingToAllies()
-        if grantFlanking then
-            grantedFlanking = DeepCopy(adjacentEnemies)
-            grantedFlanking[i].properties._tmp_grantsFlanking = token.charid
+    local granterIds = {}
+    for _, enemy in ipairs(adjacentEnemies) do
+        if enemy.properties:GrantFlankingToAllies() then
+            granterIds[#granterIds + 1] = enemy.charid
+        end
+    end
+
+    if #granterIds > 0 then
+        grantedFlanking = DeepCopy(adjacentEnemies)
+        for _, enemy in ipairs(grantedFlanking) do
+            --a creature that grants flanking to its allies can't grant it to itself,
+            --so it is marked as a grantor (and excluded by FlankedBy) only when it is
+            --the *only* grantor here. If a second creature also grants flanking, that
+            --creature is an ally granting flanking to this one, so it must not be marked.
+            local grantedByOther = false
+            for _, granterId in ipairs(granterIds) do
+                if granterId ~= enemy.charid then
+                    grantedByOther = true
+                    break
+                end
+            end
+
+            if grantedByOther then
+                enemy.properties._tmp_grantsFlanking = nil
+            else
+                enemy.properties._tmp_grantsFlanking = token.charid
+            end
         end
     end
 


### PR DESCRIPTION
**Symptom:** With two Paragon-order Censors ("Lead by Example") adjacent to the same enemy, neither Censor gets the flanking edge from the other, while every other adjacent ally does.

**Root cause:** In `creature:GetFlankingTokens` the `_tmp_grantsFlanking` mark identifies a token that is present in the flanking list *only* because it grants flanking to its allies; `creature:FlankedBy` skips any token whose `_tmp_grantsFlanking` equals the target's charid, so a marked creature gets no Flanking edge. The old loop reassigned its local `grantedFlanking` array on every grantor it found, and `DeepCopy` does not actually clone tokens (`DeepCopyInternal` in `DMHub Utils/Utils.lua` forwards userdata to `dmhub.DeepCopy`, which returns the same `LuaCharacterToken` reference), so the mark is written to the live creature properties. With two grantors adjacent to the same enemy, both ended up marked and each cancelled the other. The rule is "your allies gain the benefits of flanking against that creature", so each Paragon is the other's ally and both should benefit. The reporter correctly guessed that two Censors was the edge case.

**The fix:** Collect the charids of all adjacent grantors first, then mark a creature as a grantor only when it is the *only* grantor present. If a second creature also grants flanking, that creature is an ally granting flanking to this one, so this one must not be marked (and any stale mark on the live object is cleared).

With exactly one grantor the behaviour is identical to today. No other flanking logic (positional flanking, `FlankFromAnyDirection`, the trailing merge loop) is changed. Syntax-checked with `luac -p` (exit 0).

Report: Q37DW443

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
