### PR TITLE
Fix downtime project completing early from double-counted roll progress (report UF8AXZWV)

### DIFF
--- a/Downtime Projects/DTProject.lua
+++ b/Downtime Projects/DTProject.lua
@@ -343,14 +343,15 @@ end
 --- Sets project status before adding or removing a progress item
 --- @param item DTRoll|DTAdjustment|DTProgressItem The progress item to be considered
 --- @param direction number The direction of progress: 1 if adding, -1 if removing
-function DTProject:_setStateFromProgressChange(item, direction)
+--- @param priorProgress number|nil Progress value to use as the baseline instead of the current cached/recomputed progress (used when the item has already been inserted into its list)
+function DTProject:_setStateFromProgressChange(item, direction, priorProgress)
     if type(direction) ~= "number" or math.abs(direction) ~= 1 then return end
 
     local function isRoll() return item.typeName == "DTRoll" end
     local function isAdjustment() return item.typeName == "DTAdjustment" end
 
     local STATUS = DTConstants.STATUS
-    local oldValue = self:GetProgress()
+    local oldValue = priorProgress or self:GetProgress()
     local newValue = oldValue + (direction * item:GetAmount())
     local currentStatus = self:GetStatus()
     local projectGoal = self:GetProjectGoal()
@@ -410,9 +411,14 @@ function DTProject:AddRoll(roll)
             self.projectRolls = {}
         end
 
+        -- Capture progress BEFORE inserting the roll: _setStateFromProgressChange
+        -- must compare against the pre-roll total, otherwise GetProgress() (which
+        -- re-sums projectRolls when the cache is dirty) already includes this roll
+        -- and the status check double-counts it.
+        local priorProgress = self:GetProgress()
         roll:SetCommitInfo()
         self.projectRolls[#self.projectRolls + 1] = roll
-        self:_setStateFromProgressChange(roll, 1)
+        self:_setStateFromProgressChange(roll, 1, priorProgress)
         self:_invalidateProgressCache()
 
     end


### PR DESCRIPTION
**Symptom:** A downtime project showed the "Project Complete" banner and flipped to Status: Complete (granting the crafted item) while progress was still 48/50.

**Root cause:** `DTProject:AddRoll` appended the new roll to `self.projectRolls` *before* calling `self:_setStateFromProgressChange(roll, 1)`. That method takes its baseline from `local oldValue = self:GetProgress()`, and `GetProgress()` re-sums `projectRolls` whenever the cache is dirty -- which it is for the 2nd..Nth roll of a batch, since `AddRoll` ends with `_invalidateProgressCache()` and breakthrough chains come in via `AddRolls` -> loop of `AddRoll`. So the baseline already included the roll being added, and `newValue = oldValue + item:GetAmount()` counted it twice, letting the `newValue >= projectGoal` completion branch (and the milestone branch) fire early. `AddAdjustment` / `RemoveRoll` / `RemoveAdjustment` all compute their state change against the correct list state; `AddRoll` was the only outlier.

**Fix:** `AddRoll` now captures `GetProgress()` *before* the insert and passes it to `_setStateFromProgressChange` as a new optional third parameter, `priorProgress`, used as the baseline in place of the recomputed value. The insert still happens before the status evaluation, so the completing roll's roller is included in `GetUniqueRollers()` when `GiveItemToCharacter` -> `ProjectMeetsRequisite` runs. No existing call site passes the new argument, so all other paths are unchanged. Under the reported case (goal 50; rolls of 14, 23, 11) the totals are now evaluated as 14 / 37 / 48 and the project correctly stays Active.

Report: UF8AXZWV. Parse-checked with `luac -p`.

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
