### PR TITLE
Fix Troubadour routines and their auras persisting after combat (report KXB2QP6B)

### DIFF
--- a/Draw Steel Core Rules/MCDMCreature.lua
+++ b/Draw Steel Core Rules/MCDMCreature.lua
@@ -7061,6 +7061,15 @@ function creature:EndCombat()
         }
     end
 
+    if self:try_get("routinesSelected") ~= nil then
+        token:ModifyProperties {
+            description = "End Routines",
+            execute = function()
+                self.routinesSelected = nil
+            end,
+        }
+    end
+
     token:ModifyProperties {
         description = "Reset Heroic Resource",
         execute = function()


### PR DESCRIPTION
**Symptom:** "Trubadour auras from their performance do not go away after combat ends." -- a Troubadour's selected Routine, and the aura it projects, survive the end of the encounter.

**Root cause:** A routine's aura is a `behavior: aura` CharacterModifier that follows the `behavior: routine` modifier on the same CharacterFeature. `CharacterFeature:FillModifiers` (`DMHub Game Rules/CharacterFeature.lua:75`) stops accumulating a feature's modifiers at a `routine` modifier whose ability guid is not present in `creature.routinesSelected`, so the aura is active exactly while `routinesSelected[guid]` is set. `creature:EndCombat()` ends persistent abilities, removes EoE ongoing effects/conditions, expires the auras in `self.auras`, clears temp HP and resets the heroic resource -- but it never touched `routinesSelected`, and a modifier-derived routine aura is not in `self.auras`. So both the selection and the aura outlived the encounter, contrary to the class rule "Your routine ends if you are unable to maintain it, or at the end of the encounter."

**Fix:** Add a guarded `token:ModifyProperties` block to `creature:EndCombat()` that clears `routinesSelected`, alongside the existing "Remove Temporary Hit Points" and "Reset Heroic Resource" blocks. `nil` is already the supported "no routine" state -- the character sheet's "None" chip sets it the same way -- and every reader goes through `try_get("routinesSelected", {})` or an explicit nil check. The `try_get` guard makes this a no-op for every creature with no routines (all monsters and non-Troubadour heroes), so it cannot produce spurious patches. Players re-select at the next combat's begin-round Routines prompt, which is the rules-correct flow.

Report id: KXB2QP6B

Note: investigation also turned up a separate, unrelated singular `routineSelected` typo in the data repo. That is deliberately left out of scope here.

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
