### PR TITLE
Fix Encounters panel visible to players (report JA9XNYG3)

### DIFF
--- a/Draw Steel V/EncounterPanel.lua
+++ b/Draw Steel V/EncounterPanel.lua
@@ -62,6 +62,9 @@ if encounterBuilderSetting:Get() then
     --bug report meant.
     DockablePanel.Register {
         name = "Encounters",
+        --Authored encounters are Director-only content: the same reason the
+        --encounters search provider below returns nothing to players.
+        dmonly = true,
         icon = "icons/standard/Icon_App_EncounterCreator.png",
         minHeight = 200,
         vscroll = true,


### PR DESCRIPTION
**Symptom:** On the Experimental UI, a player can open an "Encounters" button on the left rail and read the encounters the Director has authored.

**Root cause:** The `DockablePanel.Register` call for the Encounters panel in `Draw Steel V/EncounterPanel.lua` never set `dmonly = true`, unlike every other Director-only panel (Bestiary, Floors & Layers, Map Settings, Objects, Terrain, Time of Day, Backups, Game Controls). The builtin "Player" rail view ships an `["encounters"]` entry at left-rail slot 2, so the panel was placed on the player's rail by default and `DockablePanel.GetMenuItems` also offered it in the Panels / add menus. The encounters global-search provider in the same file already guards with `if not dmhub.isDM then return {} end`, so the panel was the only remaining way in.

**Fix:** Add `dmonly = true` to that one registration table (three lines including a short comment). `DockablePanel.Register` stores the args verbatim; the flag is consumed downstream by `DockablePanel.GetMenuItems` (removes it from the menus) and by `PanelDocument.Get` / `ViewsEntryUnavailable` in `DocumentSystem/DocumentSystem.lua`, which already return nil / "Director only" for unavailable registrations. Rail entries resolve through `PanelDocument.Get`, so a stored player rail entry becomes inert (kept in storage, rendered as nothing) rather than erroring. Behaviour for Directors is unchanged.

`g_viewBuiltins` is deliberately left alone: removing `["encounters"]` from the builtin Player template would require renumbering slots and bumping the template `version`, which prompts users about a layout update -- a separate design decision.

Report id: JA9XNYG3. Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
