### PR TITLE
Fix condition purge aborting before ongoing-effect purge (report XZZZEPQK)

### DIFF
--- a/DMHub Game Rules/AbilityPurgeEffects.lua
+++ b/DMHub Game Rules/AbilityPurgeEffects.lua
@@ -670,42 +670,40 @@ function ActivatedAbilityPurgeEffectsBehavior:CastOnTarget(casterToken, targetTo
             end
         end
 
-        if #conditions == 0 then
-            return result
-        end
+        if #conditions > 0 then
+            local conditionsToPurge = {}
 
-        local conditionsToPurge = {}
+            if self.purgeType == "all" then
+                conditionsToPurge = conditions
+            else
+                table.insert(conditions, 1, "none")
+                conditionsToPurge = self:ShowConditionsSelection(casterToken, targetToken, ability, conditions, options)
+            end
 
-        if self.purgeType == "all" then
-            conditionsToPurge = conditions
-        else
-            table.insert(conditions, 1, "none")
-            conditionsToPurge = self:ShowConditionsSelection(casterToken, targetToken, ability, conditions, options)
-        end
+            print("Purge:: Purging =", conditionsToPurge)
 
-        print("Purge:: Purging =", conditionsToPurge)
+            if #conditionsToPurge > 0 then
+                options.symbols.cast.purgedConditions = #conditionsToPurge
 
-        if #conditionsToPurge > 0 then
-            options.symbols.cast.purgedConditions = #conditionsToPurge
+                targetToken:ModifyProperties{
+                    description = "Purge Conditions",
+                    execute = function()
+                        local purgeArgs = {purge = true}
+                        if limitToCasterid ~= nil then
+                            purgeArgs.casterInfo = {tokenid = limitToCasterid}
+                        end
+                        for _,condid in ipairs(conditionsToPurge) do
+                            targetCreature:InflictCondition(condid, purgeArgs)
+                            result[#result+1] = condid
+                        end
 
-            targetToken:ModifyProperties{
-                description = "Purge Conditions",
-                execute = function()
-                    local purgeArgs = {purge = true}
-                    if limitToCasterid ~= nil then
-                        purgeArgs.casterInfo = {tokenid = limitToCasterid}
-                    end
-                    for _,condid in ipairs(conditionsToPurge) do
-                        targetCreature:InflictCondition(condid, purgeArgs)
-                        result[#result+1] = condid
-                    end
-
-                    local damage = tonumber(self:EvalDamageToSelf(targetCreature))
-                    if damage ~= nil and damage > 0 then
-                        targetCreature:TakeDamage(damage, "Purged condition")
-                    end
-                end,
-            }
+                        local damage = tonumber(self:EvalDamageToSelf(targetCreature))
+                        if damage ~= nil and damage > 0 then
+                            targetCreature:TakeDamage(damage, "Purged condition")
+                        end
+                    end,
+                }
+            end
         end
     end
 


### PR DESCRIPTION
**Symptom:** Subtle Relocation teleported a restrained ally, but the Restrained condition was not removed.

**Root cause:** In `ActivatedAbilityPurgeEffectsBehavior:CastOnTarget` (`DMHub Game Rules/AbilityPurgeEffects.lua`), the `mode == "conditions"` branch is entered whenever the target creature has an `inflictedConditions` key -- which is commonly present but empty. If no entry in that table matched, the function did `return result`, aborting the whole purge before the ongoing-effect purge below it ever ran.

Conditions applied by monsters arrive as ongoing effects (e.g. Restrained is ongoing effect `edf8e3e7-a511-48af-a78a-9e38fb7fe385`, whose definition carries `condition: 2989a051-204f-442e-967d-edafc2dd5e43`), not as `inflictedConditions` entries. The Restrained condition's own `trigger: teleport` modifier fires a PurgeEffects behavior with `conditions: [2989a051-...]`, default `purgeType: all` / `mode: conditions` -- so the purge matched nothing in `inflictedConditions`, returned early, and never removed the ongoing effect. Grabbed is unaffected because it IS stored in `inflictedConditions`.

**Fix:** Remove the `if #conditions == 0 then return result end` early return and instead wrap the existing `inflictedConditions` purge body in `if #conditions > 0 then ... end`. Execution now falls through to the ongoing-effect purge, which uses `filteredEffects` (built from `targetCreature:ActiveOngoingEffects()` filtered by `AppliesToEffect`, already matching only effects whose definition condition is in `self.conditions`). No-op cases are unchanged: when both lists are empty the function still returns at the pre-existing `if #filteredEffects == 0 then return result end`. The moved code is byte-identical apart from indentation; no data/YAML changes.

Verified with `dependencies/lua/bin/luac.exe -p` (clean) and an ASCII-only check of the diff.

Report id: XZZZEPQK

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
