### PR TITLE
Fix Lua error editing power modifiers with no modtype (report 9W2E4U5J)

### DIFF
--- a/Draw Steel Core Rules/MCDModifyPowerRolls.lua
+++ b/Draw Steel Core Rules/MCDModifyPowerRolls.lua
@@ -1712,6 +1712,11 @@ CharacterModifier.TypeInfo.power = {
             end
 
 
+            --Legacy/imported power modifiers may never have been through
+            --TypeInfo.power.init, so modtype can be absent; default it the
+            --same way init does rather than hard-erroring on the read.
+            local modtypeValue = modifier:try_get("modtype", "none")
+
             children[#children+1] = gui.Panel{
                 classes = {"formPanel"},
                 gui.Label{
@@ -1723,7 +1728,7 @@ CharacterModifier.TypeInfo.power = {
                     styles = ThemeEngine.GetStyles(),
                     options = ActivatedAbilityPowerRollBehavior.s_modificationTypes,
                     valign = "center",
-                    idChosen = modifier.modtype,
+                    idChosen = modtypeValue,
                     change = function(element)
                         modifier.modtype = element.idChosen
                         Refresh()
@@ -1732,10 +1737,10 @@ CharacterModifier.TypeInfo.power = {
             }
 
             children[#children+1] = gui.Panel{
-                classes = {"formPanel", cond(modifier.modtype ~= "replaceroll" and modifier.modtype ~= "appendroll", 'collapsed-anim')},
+                classes = {"formPanel", cond(modtypeValue ~= "replaceroll" and modtypeValue ~= "appendroll", 'collapsed-anim')},
                 gui.Label{
                     classes = {"formLabel"},
-                    text = cond(modifier.modtype == "replaceroll", "Replace roll with:", "Append to roll:"),
+                    text = cond(modtypeValue == "replaceroll", "Replace roll with:", "Append to roll:"),
                 },
                 gui.Input{
                     classes = {"formInput"},


### PR DESCRIPTION
**Symptom:** Opening the Wode Elf Lookout's "There!" trait and editing its aura throws `Attempt to read unknown field modtype in type CharacterModifier`, and the Edit Aura dialog stops rendering half-built.

**Root cause:** The `power` modifier editor (`CharacterModifier.TypeInfo.power.createEditor`) reads `modifier.modtype` directly in three places when building the "Roll Mod:" form. `modtype` is only ever written by `TypeInfo.power.init` (which sets it to `"none"`) and there is no class-level default on `CharacterModifier` the way there is for e.g. `displayCondition`. Legacy/imported power modifiers that never went through `init` simply have no `modtype` key, and DMHub's typed-record index metamethod raises on unknown fields instead of returning `nil`, so the editor dies mid-build. The offending record here is the nested aura modifier `62503f72-a7cd-4a5f-a07d-92840d02c6ab` in `data/monsters/wode-elf-lookout.yaml`, which has `behavior: power` but no `modtype`.

**Fix:** Read the value once via `modifier:try_get("modtype", "none")` at the top of that section of `Refresh` and use it for the three reads (dropdown `idChosen`, the collapsed-anim class test, and the label text). The write in the dropdown's `change` handler is unchanged, as are all runtime `self.modtype` reads elsewhere in the file. For well-formed modifiers the behaviour is byte-identical, since `"none"` is exactly what `init` writes; for records missing the field the editor now renders the `none` default and the first user edit persists a real value.

Fixing it in the codex (rather than only patching the five affected content records) also repairs copies of these modifiers that already live in users' games.

Report: 9W2E4U5J. Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
