### PR TITLE
fix(floors): floor up/down keybind ignores director token-vision preview

### DIFF
--- a/DMHub Core Panels/Floors.lua
+++ b/DMHub Core Panels/Floors.lua
@@ -191,9 +191,15 @@ end
 --Move the active floor up (offset +1) or down (offset -1) among the top-level floors,
 --clamping at the top and bottom. Applies the auto-hide behaviour when the setting is on.
 --Used by the floor up/down keybinds. Moving the active floor is a director tool; for players
---the same keybind instead adjusts the "look up" view (see LookRelative above).
+--the same keybind instead adjusts the "look up" view (see LookRelative above). A director
+--currently previewing a token's vision (dmhub.tokenVision, the "Show Token Vision" keybind)
+--is treated the same as a player here: the engine keeps the rendered floor locked to the
+--previewed token's actual floor while vision preview is active, so moving the active floor
+--out from under it just gets silently reverted -- it looks like the keybind is glitching.
+--CharacterPanel.CreateLookupPanel applies the same isDM-and-tokenVision check for the
+--equivalent "look up" slider on the character panel.
 function FloorNavigation.ChangeFloorRelative(offset)
-	if not dmhub.isDM then
+	if (not dmhub.isDM) or dmhub.tokenVision ~= nil then
 		FloorNavigation.LookRelative(offset)
 		return
 	end


### PR DESCRIPTION
## Summary
- Directors previewing a token's vision (right-click a token -> Show Token Vision) would find the floor up/down keybind appear to glitch: pressing it moved the map's active floor for a moment, then the engine silently reverted it back to the previewed token's real floor, since it keeps the rendered floor locked to that token while vision preview is active.
- `FloorNavigation.ChangeFloorRelative` only branched on `dmhub.isDM`, so it never noticed the director was mid-preview and kept trying to move the global active floor instead of adjusting the "look up" view (the same behavior a player already gets, and the same behavior `CharacterPanel.CreateLookupPanel` already uses for the equivalent slider on the character panel).
- Fix: also take the "look up" branch when `dmhub.tokenVision ~= nil`.

## Test plan
- [x] Reproduced live via the DMHub MCP bridge: instrumented `ChangeFloorRelative`, enabled `dmhub.tokenVision` on a token, confirmed the active floor moved then silently reverted on the next read (matching the reported glitch).
- [x] Applied the fix, hot-reloaded, and re-ran the same repro: with token vision active, the keybind now walks the transient `lookup` setting (0 -> 1 -> 2 -> 1 -> 0) without touching the active floor.
- [x] Confirmed the normal director path (no token vision) still moves the active floor as before.
- [x] `reload_lua` after the change produced no new console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)