### PR TITLE
Fix floor up/down keybind blipping for a Director in token vision (report P8GZ4FDP)

### DIFF
--- a/DMHub Core Panels/Floors.lua
+++ b/DMHub Core Panels/Floors.lua
@@ -190,10 +190,12 @@ end
 
 --Move the active floor up (offset +1) or down (offset -1) among the top-level floors,
 --clamping at the top and bottom. Applies the auto-hide behaviour when the setting is on.
---Used by the floor up/down keybinds. Moving the active floor is a director tool; for players
---the same keybind instead adjusts the "look up" view (see LookRelative above).
+--Used by the floor up/down keybinds. Moving the active floor is a director tool; for players,
+--and for a director who is currently seeing through a token's vision, the same keybind instead
+--adjusts the "look up" view (see LookRelative above). The engine forces the active floor back to
+--the vision token's floor while token vision is on, so changing it there would only blip.
 function FloorNavigation.ChangeFloorRelative(offset)
-	if not dmhub.isDM then
+	if (not dmhub.isDM) or dmhub.tokenVision ~= nil then
 		FloorNavigation.LookRelative(offset)
 		return
 	end


### PR DESCRIPTION
**Symptom:** As Director, with a token selected (so you are seeing through that token's vision), pressing the Look Up / Look Down keybind makes the view jump one floor and immediately snap back instead of looking up through the floors above.

**Root cause:** `FloorNavigation.ChangeFloorRelative()` in `DMHub Core Panels/Floors.lua` branched on `dmhub.isDM` alone. `dmhub.isDM` (`GameController.isDM`) only goes false under Become Player, so a Director who merely selects a token and is seeing through its vision still takes the director branch and calls `game.ChangeMap(currentMap, targetFloor)`. The engine's per-frame update forces `currentFloorId` back to the vision token's floor whenever `isDMVision` is false (for a DM that is `tokenVision.Count == 0`), so the floor change is reverted on the next frame - the one-frame blip - and the intended Look Up behaviour is never reached.

**Fix:** Change the guard to `if (not dmhub.isDM) or dmhub.tokenVision ~= nil then`, so a Director in token vision falls through to `FloorNavigation.LookRelative(offset)`. `dmhub.tokenVision ~= nil` is the established "this DM is viewing through a token" predicate and is already used for exactly this feature by the character panel's Look Up eye icon (`Draw Steel Core Rules/MCDMCharacterPanel.lua:2216`) and the Look Up slider (`:8846`). The comment above the function was updated to match.

No working behaviour is lost: the edit only redirects the keybind in the one state where the director branch provably could not take effect anyway. With no token vision the Director still changes the active floor exactly as before, and players are unaffected. `LookRelative` already returns early for `dmhub.currentToken == nil`, `canlookup == "never"` and `maxLookup <= 0`, so the new path cannot error - it is simply a no-op where the map's Look Up rules allow nothing.

Report id: P8GZ4FDP. Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
