### PR TITLE
Fix power modifier hint crash on YAML-authored activationCondition (report 6TVK648E)

### DIFF
--- a/Draw Steel Core Rules/MCDModifyPowerRolls.lua
+++ b/Draw Steel Core Rules/MCDModifyPowerRolls.lua
@@ -352,6 +352,11 @@ CharacterModifier.TypeInfo.power = {
     hintPowerRoll = function(self, creature, rollType, options)
         options = options or {}
 
+        --Imported/YAML-authored modifiers may lack activationCondition
+        --entirely (only the editor's init path sets it); treat missing
+        --as false, matching the init default.
+        local activationCondition = self:try_get("activationCondition", false)
+
         if type(self:try_get("activationAfterRoll", false)) == "string" then
             return {
                 result = false,
@@ -367,7 +372,7 @@ CharacterModifier.TypeInfo.power = {
         end
 
 
-        if (self.activationCondition == false) or (not RollTypeMatches(self, rollType, options)) then
+        if (activationCondition == false) or (not RollTypeMatches(self, rollType, options)) then
             return {
                 result = false,
                 justification = {}
@@ -411,7 +416,7 @@ CharacterModifier.TypeInfo.power = {
             }
         end
 
-        if self.activationCondition == true then
+        if activationCondition == true then
             return {
                 result = true,
                 justification = {}
@@ -443,7 +448,7 @@ CharacterModifier.TypeInfo.power = {
         print("POWER ROLL:: OPTIONS:", options)
 
         return {
-            result = GoblinScriptTrue(ExecuteGoblinScript(self.activationCondition, lookupFunction, 0, "Power Roll Activation Condition")),
+            result = GoblinScriptTrue(ExecuteGoblinScript(activationCondition, lookupFunction, 0, "Power Roll Activation Condition")),
             justification = {},
         }
     end,


### PR DESCRIPTION
**Symptom:** A Wode Elf minion squad's main-action strike silently does nothing when the last target is clicked - no power roll, no dice, no error shown to the player.

**Root cause:** `CharacterModifier.TypeInfo.power.hintPowerRoll` raw-reads the optional `activationCondition` field. That field is only ever written by the editor's `TypeInfo.power.init`, so a power modifier authored directly in YAML (here, the Wode Elf Lookout "There!" aura, `behavior: power` with no `activationCondition`) lacks it entirely and the read raises `Attempt to read unknown field activationCondition in type CharacterModifier`.

The raise propagates up through the targeting-arrow label path and aborts `CalculateSpellTargeting()` before it reaches the auto-cast, so the ability is never cast:

```
MCDModifyPowerRolls:370 (in local 'hint')
  <- MCDModifyPowerRolls:2898 HintModifyPowerRolls
  <- MCDMAbilityRollBehavior:989 DescribeModifiersOnTarget
  <- DrawSteelActionBar:2985 AddModifierLabelsToMarker
  <- DrawSteelActionBar:3029 ReplaceTargetLineOfSightRays
  <- DrawSteelActionBar:7612 CalculateSpellTargeting
```

**What this changes:** In `hintPowerRoll` only, reads the field once via `self:try_get("activationCondition", false)` into a local and uses that local for the three reads (previously lines 370, 414, 446). `false` is exactly the default `TypeInfo.power.init` writes, and the same default every other consumer of this field already uses - see line 1170 of this file, `MCDMActivatedAbility.lua:816`, and `MCDMAbilityBehavior.lua:2112`.

Behaviour is bit-identical for every modifier that has the field. For a modifier missing it, the first check now takes the early `result = false` return and the modifier is reported inactive instead of raising - which is its effective state today anyway, since the raise means it never applies.

No other logic, ordering, or the `baseModifier` recursion was touched; `hintPowerRollAfter`, `shouldShowInPowerRollDialog`, and `modifyPowerRoll` are unchanged. Syntax-checked with the bundled `luac -p`.

**Not included (deliberately):** the underlying `wode-elf-lookout.yaml` authoring gap and defensive hardening of the `DrawSteelActionBar` targeting path both need separate design decisions and are left for follow-up.

Report id: 6TVK648E. Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
