### PR TITLE
Fix overlapping alternate-characteristic options in the roll dialog (report AMYFGPKB)

### DIFF
--- a/Draw Steel UI/DSRollDialog.lua
+++ b/Draw Steel UI/DSRollDialog.lua
@@ -1523,6 +1523,7 @@ function GameHud.CreateRollDialog(self)
     }
 
     alternateRollsBar = gui.Panel {
+        styles = Styles.AdvantageBar,
         classes = { "hideWhenMinimized", "advantage-bar" },
         prepare = function(element, options)
             if options.alternateOptions == nil or #options.alternateOptions <= 1 then


### PR DESCRIPTION
**Symptom:** In the roll dialog, the alternate-characteristic options (e.g. "Reason" vs "Intuition") are drawn on top of each other in the top-left corner as an unreadable smear, so the alternate cannot be picked.

**Root cause:** `Draw Steel UI/DSRollDialog.lua` builds `alternateRollsBar` with `classes = { "hideWhenMinimized", "advantage-bar" }` and child labels with `classes = { 'advantage-element', ... }`, but the file never attaches `Styles.AdvantageBar` (defined in `DMHub Titlescreen/Styles.lua`, which is what gives `advantage-bar` its horizontal flow and `advantage-element` its width/height/alignment). With no matching styles the panel keeps the engine default `Flow.None`, so every option is laid out at the same origin and only the last-drawn one is clickable.

**Fix:** Add `styles = Styles.AdvantageBar` to that one panel - the same pattern every other consumer of these classes already uses (`Draw Steel UI/DSActionBar.lua:3556`, `DMHub Game Hud/RollOnTableDialog.lua:428`, `Timeline/EmbeddedRollDialog.lua:4838`). The styles are scoped to this panel's subtree and add no new selectors, so nothing else in the dialog changes. One line; no other edits.

Verified with `luac -p` (parses clean) and checked for non-ASCII bytes (none).

Report id: AMYFGPKB

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
