### PR TITLE
Fix icon-rail character card always showing 0 surges (report HW7HNPD6)

### DIFF
--- a/DocumentSystem/DocumentSystem.lua
+++ b/DocumentSystem/DocumentSystem.lua
@@ -7675,8 +7675,10 @@ local function CreateCharacterCardVisual(charid)
             if resourceLabel ~= nil and resourceLabel.valid then
                 resourceLabel.text = tostring(hr)
             end
+            local surges = 0
+            pcall(function() surges = c:GetAvailableSurges() or 0 end)
             if surgeLabel ~= nil and surgeLabel.valid then
-                surgeLabel.text = tostring(c:try_get("surges", 0))
+                surgeLabel.text = tostring(surges)
             end
         end
     end


### PR DESCRIPTION
**Symptom:** A character pinned to the icon rail always shows `0` surges on its rail card, no matter how many surges the hero actually has (the heroic resource next to it is correct).

**Root cause:** `CreateCharacterCardVisual`'s `UpdateCard` closure in `DocumentSystem/DocumentSystem.lua` read surges as `c:try_get("surges", 0)`. A creature has no `surges` property -- surges are stored as an *unbounded resource* under `CharacterResource.surgeResourceId` (`Draw Steel Core Rules/DSResources.lua:6`). The `try_get` therefore always fell through to its `0` default. The canonical accessor is `creature:GetAvailableSurges()` (`Draw Steel Core Rules/MCDMCreature.lua:406`), which also handles the summoner-shared-surges redirect, and is what every other surge display uses (e.g. `Draw Steel Core Rules/MCDMCharacterPanel.lua:2614`).

**The fix:** One label, display-only. The surge line now reads through `GetAvailableSurges()`, wrapped in a `pcall` mirroring the `IsHero()` / `GetHeroicOrMaliceResources()` calls immediately above it -- so if the Draw Steel ruleset (which defines `GetAvailableSurges`) is not loaded, `surges` stays `0`, i.e. exactly today's behaviour. No state is written. `CreateCharacterCardVisual` backs both the drag-preview ghost and the docked rail card, so this single edit covers both.

Deliberately untouched: the adjacent `victories` `try_get` idiom is correct (`victories` really is a creature field), as is the same-looking idiom in `Draw Steel Core Rules/CompanionAuraSync.lua:102`, which is a different subsystem outside this report's scope.

Syntax-checked with `luac -p`; diff is ASCII-only.

Report id: **HW7HNPD6**. Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)