### PR TITLE
Trigger prompts: show every mode with its own name, cost and availability

### DIFF
--- a/DMHub Game Rules/Creature.lua
+++ b/DMHub Game Rules/Creature.lua
@@ -9931,6 +9931,8 @@ end
 --- @field text string
 --- @field retargetid false|string
 --- @field rules string
+--- @field activateText string The name of mode 1 of a multi-mode trigger.
+--- @field activateRules string The rules text of mode 1 of a multi-mode trigger.
 --- @field modes {text: string, rules: string}[]
 --- @field casterid false|string The id of the caster of the ability that caused the trigger.
 --- @field originalAbilityRange number the range of the original ability that caused the trigger.
@@ -9962,7 +9964,11 @@ ActiveTrigger.dismissed = false
 ActiveTrigger.ping = false
 ActiveTrigger.retargetid = false
 ActiveTrigger.text = "Trigger"
+--A multi-mode trigger (a TriggeredAbility with multipleModes) keeps mode 1 out
+--of the modes list: activateText/activateRules are its name and rules, and
+--modes holds the remaining modes whose conditions passed. See UsesModeHeading.
 ActiveTrigger.activateText = "Activate"
+ActiveTrigger.activateRules = ""
 ActiveTrigger.rules = ""
 ActiveTrigger.modes = {}
 ActiveTrigger.casterid = false
@@ -10144,6 +10150,19 @@ function ActiveTrigger:GetRulesText()
 	end
 
 	return self.rules
+end
+
+--A multi-mode trigger prompt draws one card per mode: mode 1 is the trigger's
+--own card and the rest are the enhancement-option cards below it. When there
+--are additional modes the trigger's name and prompt go into heading boxes above
+--the whole group and every card carries its own mode's name and rules, so mode
+--1 is not anonymised by the trigger's name/prompt -- see DrawSteelTriggerPanel.
+--
+--This is only for mode-driven triggers. A powerRollModifier trigger's
+--"enhancement options" are extra resource spends rather than modes, so its
+--single card keeps the trigger's own name and rules.
+function ActiveTrigger:UsesModeHeading()
+	return (not self.powerRollModifier) and #self.modes > 0
 end
 
 function ActiveTrigger:IsFreeTriggeredAbility()

--- a/DMHub Game Rules/Creature.lua
+++ b/DMHub Game Rules/Creature.lua
@@ -9933,7 +9933,7 @@ end
 --- @field rules string
 --- @field activateText string The name of mode 1 of a multi-mode trigger.
 --- @field activateRules string The rules text of mode 1 of a multi-mode trigger.
---- @field modes {text: string, rules: string}[]
+--- @field modes {text: string, rules: string, unavailable: boolean|nil}[] unavailable marks a mode whose condition is not currently met; it is still offered, greyed out, and may be overridden.
 --- @field casterid false|string The id of the caster of the ability that caused the trigger.
 --- @field originalAbilityRange number the range of the original ability that caused the trigger.
 --- @field abilityGuid false|string The guid of the TriggeredAbility that created this prompt.

--- a/DMHub Game Rules/Creature.lua
+++ b/DMHub Game Rules/Creature.lua
@@ -9933,7 +9933,7 @@ end
 --- @field rules string
 --- @field activateText string The name of mode 1 of a multi-mode trigger.
 --- @field activateRules string The rules text of mode 1 of a multi-mode trigger.
---- @field modes {text: string, rules: string, unavailable: boolean|nil}[] unavailable marks a mode whose condition is not currently met; it is still offered, greyed out, and may be overridden.
+--- @field modes {text: string, rules: string, modeIndex: number|nil, unavailable: boolean|nil, conditionReason: string|nil}[] modeIndex is the entry's position in the ability's modeList (see ModeIndexForTriggered). unavailable/conditionReason mark a mode whose condition is not met but which is offered anyway, greyed out, with that reason shown.
 --- @field casterid false|string The id of the caster of the ability that caused the trigger.
 --- @field originalAbilityRange number the range of the original ability that caused the trigger.
 --- @field abilityGuid false|string The guid of the TriggeredAbility that created this prompt.
@@ -10161,6 +10161,26 @@ end
 --This is only for mode-driven triggers. A powerRollModifier trigger's
 --"enhancement options" are extra resource spends rather than modes, so its
 --single card keeps the trigger's own name and rules.
+--The modeList index that a `triggered` value selects, which is what drives
+--symbols.mode and so which behaviors run. A mode whose condition fails and
+--carries no Condition Reason is never offered, leaving a hole in modes, so an
+--option's position here is not its position in modeList -- each entry records
+--the index it came from. Prompts serialized before modeIndex existed, and the
+--non-numeric `triggered == true` case (mode 1, the trigger's own card), fall
+--back to the positional reading.
+function ActiveTrigger:ModeIndexForTriggered(triggered)
+	if type(triggered) ~= "number" then
+		return 1
+	end
+
+	local entry = self.modes[triggered]
+	if entry ~= nil and entry.modeIndex ~= nil then
+		return entry.modeIndex
+	end
+
+	return triggered + 1
+end
+
 function ActiveTrigger:UsesModeHeading()
 	return (not self.powerRollModifier) and #self.modes > 0
 end

--- a/DMHub Game Rules/TriggeredAbility.lua
+++ b/DMHub Game Rules/TriggeredAbility.lua
@@ -1371,27 +1371,33 @@ function TriggeredAbility:Trigger(characterModifier, creature, symbols, auraCont
                         end
                     end
 
-                    --A mode whose condition fails is still offered: the panel
-                    --greys it out and says so, and the player may override it.
-                    --
-                    --Dropping it was also wrong. symbols.mode is derived from
-                    --the option's position in this list (see `symbols.mode =
-                    --trigger.triggered + 1` below), so every mode after a
-                    --dropped one addressed the wrong modeList entry -- pick
-                    --Shift with no Recovery available and the trigger ran Spend
-                    --Recovery's behaviors. Keeping the list dense with modeList
-                    --makes that mapping hold.
-                    local entry = {
-                        text = modeEntry.text,
-                        rules = StringInterpolateGoblinScript(modeEntry.rules, casterSymbols),
-                    }
+                    --A failed condition hides the mode, as it always has, unless
+                    --the author gave it a Condition Reason: then it is offered
+                    --anyway, greyed out and annotated with that reason, and the
+                    --player may override it.
+                    local reason = trim(modeEntry.conditionReason or "")
 
-                    if not passes then
-                        entry.unavailable = true
+                    if passes or reason ~= "" then
+                        --modeIndex is what selects the behaviors to run.
+                        --Hidden modes leave holes in this list, so an option's
+                        --position in it is not its position in modeList -- the
+                        --index has to be carried rather than inferred, or every
+                        --mode after a hidden one runs the wrong modeList
+                        --entry's behaviors.
+                        local entry = {
+                            text = modeEntry.text,
+                            rules = StringInterpolateGoblinScript(modeEntry.rules, casterSymbols),
+                            modeIndex = i,
+                        }
+
+                        if not passes then
+                            entry.unavailable = true
+                            entry.conditionReason = StringInterpolateGoblinScript(reason, casterSymbols)
+                        end
+
+                        modes = modes or {}
+                        modes[#modes+1] = entry
                     end
-
-                    modes = modes or {}
-                    modes[#modes+1] = entry
                 end
             end
 
@@ -1616,9 +1622,9 @@ function TriggeredAbility:Trigger(characterModifier, creature, symbols, auraCont
                     return
                 end
 
-                if accepted and type(trigger.triggered) == "number" then
+                if accepted then
                     --the first mode is just the 'activate' which will show up as true.
-                    symbols.mode = trigger.triggered + 1
+                    symbols.mode = trigger:ModeIndexForTriggered(trigger.triggered)
                 else
                     symbols.mode = 1
                 end
@@ -2027,12 +2033,8 @@ function TriggeredAbility.ActivateOrphanedTrigger(casterToken, triggerid)
 			return
 		end
 
-		if type(record.triggered) == "number" then
-			--the first mode is just the 'activate' which shows up as true.
-			symbols.mode = record.triggered + 1
-		else
-			symbols.mode = 1
-		end
+		--the first mode is just the 'activate' which shows up as true.
+		symbols.mode = record:ModeIndexForTriggered(record.triggered)
 
 		--Mirror TriggeredAbilityRemoteExecution:Invoke: install per-modifier
 		--context symbols, then apply the creature's Modify Abilities pass.

--- a/DMHub Game Rules/TriggeredAbility.lua
+++ b/DMHub Game Rules/TriggeredAbility.lua
@@ -1349,10 +1349,17 @@ function TriggeredAbility:Trigger(characterModifier, creature, symbols, auraCont
             local casterSymbols = casterToken.properties:LookupSymbol{}
 
             local activateText = nil
+            local activateRules = nil
             local modes = nil
             if self.multipleModes then
                 local modeList = self:try_get("modeList", {})
-                activateText = modeList[1].text
+                --Mode 1 is carried separately from the modes list: it is the
+                --trigger's own card in the trigger panel, and the panel shows
+                --its name and rules there when other modes are present.
+                if modeList[1] ~= nil then
+                    activateText = modeList[1].text
+                    activateRules = StringInterpolateGoblinScript(modeList[1].rules or "", casterSymbols)
+                end
                 for i=2,#modeList do
                     local modeEntry = modeList[i]
                     local passes = true
@@ -1393,6 +1400,7 @@ function TriggeredAbility:Trigger(characterModifier, creature, symbols, auraCont
 			local trigger = ActiveTrigger.new{
 				id = guid,
                 activateText = activateText,
+                activateRules = activateRules,
 				text = text,
 				rules = StringInterpolateGoblinScript(self:try_get("triggerPrompt"), casterSymbols),
                 targets = targetids,

--- a/DMHub Game Rules/TriggeredAbility.lua
+++ b/DMHub Game Rules/TriggeredAbility.lua
@@ -1371,13 +1371,27 @@ function TriggeredAbility:Trigger(characterModifier, creature, symbols, auraCont
                         end
                     end
 
-                    if passes then
-                        modes = modes or {}
-                        modes[#modes+1] = {
-                            text = modeEntry.text,
-                            rules = StringInterpolateGoblinScript(modeEntry.rules, casterSymbols),
-                        }
+                    --A mode whose condition fails is still offered: the panel
+                    --greys it out and says so, and the player may override it.
+                    --
+                    --Dropping it was also wrong. symbols.mode is derived from
+                    --the option's position in this list (see `symbols.mode =
+                    --trigger.triggered + 1` below), so every mode after a
+                    --dropped one addressed the wrong modeList entry -- pick
+                    --Shift with no Recovery available and the trigger ran Spend
+                    --Recovery's behaviors. Keeping the list dense with modeList
+                    --makes that mapping hold.
+                    local entry = {
+                        text = modeEntry.text,
+                        rules = StringInterpolateGoblinScript(modeEntry.rules, casterSymbols),
+                    }
+
+                    if not passes then
+                        entry.unavailable = true
                     end
+
+                    modes = modes or {}
+                    modes[#modes+1] = entry
                 end
             end
 

--- a/Draw Steel Ability Editor/AbilityEditor.lua
+++ b/Draw Steel Ability Editor/AbilityEditor.lua
@@ -2355,6 +2355,31 @@ _buildModesBlock = function(ability, fireChange)
                     }
                 )
 
+                -- Mode Condition Reason. Blank (the default) keeps the original
+                -- behaviour: a mode whose condition fails is not offered at all.
+                -- Fill it in and the mode is offered anyway, greyed out and
+                -- annotated with this text, so the player can see what they are
+                -- missing and the table can still allow it.
+                modeChildren[#modeChildren + 1] = gui.Panel{
+                    classes = {"nae-field-row"},
+                    children = {
+                        gui.Label{
+                            classes = {"nae-field-label"},
+                            text = "Condition Reason",
+                        },
+                        gui.Input{
+                            classes = {"nae-field-input"},
+                            characterLimit = 200,
+                            placeholderText = "Blank: hide the mode when unavailable",
+                            text = entry.conditionReason or "",
+                            change = function(el)
+                                entry.conditionReason = el.text
+                                fireChange()
+                            end,
+                        },
+                    },
+                }
+
                 -- "Has Ability" checkbox + Edit button (variations only)
                 modeChildren[#modeChildren + 1] = gui.Panel{
                     classes = {"nae-field-row",

--- a/DrawSteelActionBar/CLAUDE.md
+++ b/DrawSteelActionBar/CLAUDE.md
@@ -104,7 +104,9 @@ Creates the floating trigger panel that appears above the trigger drawer when th
 - Buttons: Activate, Enhancement Options, Dismiss
 - "Dismiss Triggers" bar to dismiss all at once
 
-A mode whose `condition` is not currently met is still offered (`modes[i].unavailable`, set in `TriggeredAbility:Trigger`): its card is dimmed via the `unavailableMode` class and notes "Conditions not met - select to override", but stays pressable so the table can allow it. Keeping unavailable modes in the list is also load-bearing, not just cosmetic: `symbols.mode` is derived from the option's position (`trigger.triggered + 1`), and `modesSelected` on each behavior indexes `modeList`, so dropping a failed mode used to shift every later one onto the wrong `modeList` entry.
+A mode whose `condition` is not met is hidden, unless the author filled in its **Condition Reason** (`modeList[i].conditionReason`, edited under Mode Condition in the ability editor's Modes section). With a reason set, the mode is offered anyway: the card is dimmed via the `unavailableMode` class and carries the reason in `triggerUnavailableNote`, but stays pressable so the table can allow it. Blank -- the default -- keeps the original hide behaviour.
+
+Because hidden modes leave holes in `modes`, an option's position there is **not** its position in `modeList`. Each entry records `modeIndex`, and `ActiveTrigger:ModeIndexForTriggered` resolves it; `symbols.mode` (which selects behaviors via their `modesSelected`) must go through that helper rather than the old `trigger.triggered + 1`, or every mode after a hidden one runs the wrong entry's behaviors. Prompts serialized before `modeIndex` existed fall back to the positional reading.
 
 Trigger activation either fires immediately or enters target-selection mode (via `chooseTarget` event on the ability controller) if the trigger supports retargeting.
 

--- a/DrawSteelActionBar/CLAUDE.md
+++ b/DrawSteelActionBar/CLAUDE.md
@@ -96,10 +96,11 @@ Creates the floating trigger panel that appears above the trigger drawer when th
 
 **Panel structure per trigger:**
 
+- Heading boxes above the group holding the trigger's name and its prompt -- only for a multi-mode trigger (`ActiveTrigger:UsesModeHeading()`). Such a trigger draws one card per mode, so its own name and prompt would otherwise displace the first mode's; with the headings present every card carries its own mode's name and rules. Mode 1 lives on the trigger as `activateText` / `activateRules` rather than in `modes`.
 - `!` icon (gold = normal, blue = free)
 - Title and markdown rules text
 - Target token images (with optional retarget arrow)
-- Cost diamond (if heroic-resource cost required)
+- Cost diamond (if heroic-resource cost required). A mode-driven trigger's option cards carry no cost of their own -- picking any mode costs the trigger's cost -- so they repeat the trigger's diamond. A `powerRollModifier` trigger's options are extra resource spends and price themselves.
 - Buttons: Activate, Enhancement Options, Dismiss
 - "Dismiss Triggers" bar to dismiss all at once
 

--- a/DrawSteelActionBar/CLAUDE.md
+++ b/DrawSteelActionBar/CLAUDE.md
@@ -104,6 +104,8 @@ Creates the floating trigger panel that appears above the trigger drawer when th
 - Buttons: Activate, Enhancement Options, Dismiss
 - "Dismiss Triggers" bar to dismiss all at once
 
+A mode whose `condition` is not currently met is still offered (`modes[i].unavailable`, set in `TriggeredAbility:Trigger`): its card is dimmed via the `unavailableMode` class and notes "Conditions not met - select to override", but stays pressable so the table can allow it. Keeping unavailable modes in the list is also load-bearing, not just cosmetic: `symbols.mode` is derived from the option's position (`trigger.triggered + 1`), and `modesSelected` on each behavior indexes `modeList`, so dropping a failed mode used to shift every later one onto the wrong `modeList` entry.
+
 Trigger activation either fires immediately or enters target-selection mode (via `chooseTarget` event on the ability controller) if the trigger supports retargeting.
 
 ## Integration

--- a/DrawSteelActionBar/DrawSteelTriggerPanel.lua
+++ b/DrawSteelActionBar/DrawSteelTriggerPanel.lua
@@ -12,6 +12,15 @@ local g_blurColorHighlight = "srgb:#000000ee"
 local g_borderColor = "srgb:#A48B74"
 local g_forbiddenColor = "srgb:#C73131"
 
+--Geometry shared by a trigger's card and the heading boxes stacked on top of
+--it, so the two line up exactly. triggerPanel declares its width without
+--borderBox, so its padding sits outside the declared width and its outer width
+--is the sum; the heading boxes use borderBox and declare that outer width
+--directly.
+local g_triggerCardWidth = 178
+local g_triggerCardHPad = 6
+local g_triggerCardOuterWidth = g_triggerCardWidth + g_triggerCardHPad*2
+
 -- Build the candidate retarget list for a triggered ability that changes its
 -- target. Every token passing the all-inclusive changeTargetFilter is returned
 -- in `targets`. A token that additionally fails one of the "reasoned" filters is
@@ -243,11 +252,11 @@ mod.shared.CreateTriggerPanel = function()
                 },
 				{
 					selectors = {"triggerPanel"},
-                    width = 178,
+                    width = g_triggerCardWidth,
                     minHeight = 44,
                     height = "auto",
                     vpad = 6,
-                    hpad = 6,
+                    hpad = g_triggerCardHPad,
                     vmargin = 0,
                     halign = "center",
                     valign = "bottom",
@@ -278,6 +287,65 @@ mod.shared.CreateTriggerPanel = function()
 					selectors = {"triggerPanel", "ping", "pong"},
 					brightness = 2,
 				},
+                --The heading boxes above a multi-mode trigger's cards: one for
+                --the trigger's own name and one for its prompt, both of which
+                --would otherwise displace the name and rules of the first
+                --mode's card. They read as the top of the stack of cards rather
+                --than as separate floating boxes, so they take the card's outer
+                --width and no bottom margin -- the boxes and the first card butt
+                --together exactly as the cards do against each other.
+                {
+                    selectors = {"triggerHeadingPanel"},
+                    width = g_triggerCardOuterWidth,
+                    height = "auto",
+                    halign = "center",
+                    valign = "bottom",
+                    vpad = 4,
+                    hpad = g_triggerCardHPad,
+                    vmargin = 0,
+                    borderBox = true,
+                    flow = "vertical",
+                    bgimage = true,
+                    bgcolor = "#1D1D1D",
+                    borderColor = "#606060",
+                    --per-edge widths only, no borderWidth: a blanket borderWidth
+                    --overrides them and re-draws all four edges.
+                    border = {x1 = 2, y1 = 2, x2 = 2, y2 = 2},
+                },
+                --The title and prompt are one header block, so a hairline
+                --divides them instead of the doubled 2px seam that separates one
+                --mode card from the next.
+                {
+                    selectors = {"triggerHeadingPanel", "triggerHeadingJoined"},
+                    border = {x1 = 2, y1 = 1, x2 = 2, y2 = 2},
+                },
+                {
+                    selectors = {"triggerHeadingPanel", "triggerPromptBox"},
+                    border = {x1 = 2, y1 = 2, x2 = 2, y2 = 0},
+                },
+                {
+                    selectors = {"triggerHeadingLabel"},
+                    width = "100%",
+                    height = "auto",
+                    halign = "center",
+                    valign = "center",
+                    textAlignment = "center",
+                    fontSize = 14,
+                    bold = true,
+                    color = Styles.textColor,
+                    textWrap = true,
+                },
+                {
+                    selectors = {"triggerPromptLabel"},
+                    width = "100%",
+                    height = "auto",
+                    halign = "center",
+                    valign = "center",
+                    textAlignment = "center",
+                    fontSize = 12,
+                    color = Styles.textColor,
+                    textWrap = true,
+                },
                 {
                     selectors = {"triggerTitle"},
                     fontSize = 14,
@@ -419,6 +487,23 @@ mod.shared.CreateTriggerPanel = function()
 						local panel = m_activeTriggerPanels[key]
 						
 						if panel == nil then
+							--A trigger with several modes draws one card per mode. The
+							--trigger's own name and prompt then move to heading boxes
+							--above the group, so that this first card can carry the
+							--first mode's name and rules rather than being anonymised
+							--by the trigger's.
+							local usesModeHeading = trigger:UsesModeHeading()
+							local cardTitle = trigger:GetText()
+							local cardRules = trigger:GetRulesText()
+							if usesModeHeading then
+								cardTitle = trigger.activateText
+								cardRules = trigger.activateRules
+							end
+
+							--The trigger's own resource cost, shown in the diamond on
+							--the edge of its card.
+							local resourceCost = trigger.heroicResourceCost ~= 0 and trigger.heroicResourceCost or trigger.epicResourceCost
+
 							local targetPanels = {}
 							for _,target in ipairs(trigger.targets) do
 								local token = dmhub.GetTokenById(target)
@@ -1111,9 +1196,7 @@ mod.shared.CreateTriggerPanel = function()
                                     end,
                                 },
 
-        (function()
-            local resourceCost = trigger.heroicResourceCost ~= 0 and trigger.heroicResourceCost or trigger.epicResourceCost
-            return gui.Panel{
+        gui.Panel{
             classes = {"costDiamond", cond(resourceCost == 0, "hidden")},
             floating = true,
             rotate = 135,
@@ -1142,8 +1225,7 @@ mod.shared.CreateTriggerPanel = function()
                     end,
                 },
             },
-        }
-        end)(),
+        },
 
         --icon panel.
         gui.Label{
@@ -1174,12 +1256,12 @@ mod.shared.CreateTriggerPanel = function()
 								gui.Label{
 									classes = {"triggerTitle"},
                                     interactable = false,
-									text = trigger:GetText(),
+									text = cardTitle,
 								},
 								gui.Label{
 									classes = {"triggerRules"},
                                     markdown = true,
-									text = StringInterpolateGoblinScript(trigger:GetRulesText(), g_token.properties:LookupSymbol{}),
+									text = StringInterpolateGoblinScript(cardRules, g_token.properties:LookupSymbol{}),
 								},
 								gui.Panel{
 									width = "100%",
@@ -1199,7 +1281,40 @@ mod.shared.CreateTriggerPanel = function()
                             }
 							}
 
-                            local children = {triggerPanel}
+                            local children = {}
+
+                            if usesModeHeading then
+                                local promptText = StringInterpolateGoblinScript(trigger:GetRulesText(), g_token.properties:LookupSymbol{})
+                                local hasPrompt = trim(promptText or "") ~= ""
+
+                                --The title only gives up its full bottom edge to a
+                                --prompt box below it; standing alone it meets the
+                                --first mode card and keeps the card seam.
+                                children[#children+1] = gui.Panel{
+                                    classes = {"triggerHeadingPanel", cond(hasPrompt, "triggerHeadingJoined")},
+                                    blurBackground = true,
+                                    interactable = false,
+                                    gui.Label{
+                                        classes = {"triggerHeadingLabel"},
+                                        text = trigger:GetText(),
+                                    },
+                                }
+
+                                if hasPrompt then
+                                    children[#children+1] = gui.Panel{
+                                        classes = {"triggerHeadingPanel", "triggerPromptBox"},
+                                        blurBackground = true,
+                                        interactable = false,
+                                        gui.Label{
+                                            classes = {"triggerPromptLabel"},
+                                            markdown = true,
+                                            text = promptText,
+                                        },
+                                    }
+                                end
+                            end
+
+                            children[#children+1] = triggerPanel
 
 							--hideEnhancementOptions (on the powertabletrigger modifier) is an
 							--opt-in for triggers whose outcome is decided by a nested
@@ -1258,19 +1373,27 @@ mod.shared.CreateTriggerPanel = function()
                                         },
                                     },
 
-        gui.Panel{
-            classes = {"costDiamond", cond(option.cost == 0, "hidden")},
+        --A mode-driven trigger's options carry no cost of their own: choosing any
+        --one of the modes costs the trigger's own resource cost, so every card
+        --shows the same diamond as the first one. A powerRollModifier trigger's
+        --options are extra resource spends, so they price themselves.
+        (function()
+            local optionCost = option.cost
+            local optionIsEpic = false
+            if optionCost == nil then
+                optionCost = resourceCost
+                optionIsEpic = trigger.epicResourceCost ~= 0
+            end
+            return gui.Panel{
+            classes = {"costDiamond", cond(optionCost == 0, "hidden")},
             floating = true,
             rotate = 135,
             gui.Panel{
-                classes = {"costInnerDiamond"},
+                classes = {"costInnerDiamond", cond(optionIsEpic, "epicCost")},
                 gui.Label{
                     classes = {"abilityCostLabel"},
                     rotate = -135,
-                    text = option.cost,
-                    create = function(element)
-                        print("TARGETS:: OPTION", option)
-                    end,
+                    text = optionCost,
 
                     ability = function(element, ability)
 --[[
@@ -1290,7 +1413,8 @@ mod.shared.CreateTriggerPanel = function()
                     end,
                 },
             },
-        },
+        }
+        end)(),
 
 
 

--- a/DrawSteelActionBar/DrawSteelTriggerPanel.lua
+++ b/DrawSteelActionBar/DrawSteelTriggerPanel.lua
@@ -374,6 +374,35 @@ mod.shared.CreateTriggerPanel = function()
 					fontSize = 12,
 					maxWidth = 140,
 				},
+                --A mode whose condition is not currently met is still offered:
+                --it is dimmed and carries a note saying so, but remains
+                --pressable so the player can override it.
+                {
+                    selectors = {"triggerPanel", "unavailableMode"},
+                    bgcolor = "#141414",
+                    borderColor = "#4A4A4A",
+                },
+                {
+                    selectors = {"triggerTitle", "unavailableMode"},
+                    color = "#8C8C8C",
+                },
+                {
+                    selectors = {"triggerRules", "unavailableMode"},
+                    color = "#8C8C8C",
+                },
+                {
+                    selectors = {"triggerUnavailableNote"},
+                    width = "auto",
+                    height = "auto",
+                    maxWidth = 140,
+                    hmargin = 0,
+                    tmargin = 0,
+                    bmargin = 4,
+                    fontSize = 11,
+                    italics = true,
+                    color = g_forbiddenColor,
+                    textWrap = true,
+                },
 				{
 					selectors = {"triggerButton"},
 					halign = "left",
@@ -388,6 +417,11 @@ mod.shared.CreateTriggerPanel = function()
 					color = Styles.textColor,
 					borderColor = Styles.textColor,
 					bgcolor = Styles.backgroundColor,
+				},
+				{
+					selectors = {"triggerButton", "unavailableMode"},
+					color = "#8C8C8C",
+					borderColor = "#4A4A4A",
 				},
 				{
 					selectors = {"triggerButton", "hover"},
@@ -747,9 +781,9 @@ mod.shared.CreateTriggerPanel = function()
 							end
 							for index,option in ipairs(enhancementOptions) do
 								buttons[#buttons+1] = gui.Label{
-									classes = {"triggerButton"},
+									classes = {"triggerButton", cond(option.unavailable == true, "unavailableMode")},
 									text = option.text,
-									hover = gui.Tooltip(option.rules),
+									hover = gui.Tooltip(cond(option.unavailable == true, "Conditions not met - select to override.\n\n" .. tostring(option.rules), option.rules)),
 									press = function(element)
 
                                         audio.DispatchSoundEvent("Notify.TriggerUse", {})
@@ -1326,8 +1360,13 @@ mod.shared.CreateTriggerPanel = function()
 								enhancementOptions = trigger:EnhancementOptions(g_token)
 							end
 							for index,option in ipairs(enhancementOptions) do
+								--A mode whose condition is not met is offered anyway,
+								--dimmed and annotated, and stays pressable: the table
+								--can always agree to allow it.
+								local unavailable = option.unavailable == true
+
 								children[#children+1] = gui.Panel{
-									classes = {"triggerPanel"},
+									classes = {"triggerPanel", cond(unavailable, "unavailableMode")},
 
                                     hover = function(element)
                                         triggerPanel:SetClass("pseudohover", true)
@@ -1363,13 +1402,18 @@ mod.shared.CreateTriggerPanel = function()
                                         height = "auto",
                                         width = "100%-36",
                                         gui.Label{
-                                            classes = {"triggerTitle"},
+                                            classes = {"triggerTitle", cond(unavailable, "unavailableMode")},
                                             text = option.text,
                                         },
                                         gui.Label{
-                                            classes = {"triggerRules"},
+                                            classes = {"triggerRules", cond(unavailable, "unavailableMode")},
                                             markdown = true,
                                             text = StringInterpolateGoblinScript(option.rules, g_token.properties:LookupSymbol{}),
+                                        },
+                                        gui.Label{
+                                            classes = {"triggerUnavailableNote", cond(not unavailable, "collapsed")},
+                                            interactable = false,
+                                            text = "Conditions not met - select to override",
                                         },
                                     },
 

--- a/DrawSteelActionBar/DrawSteelTriggerPanel.lua
+++ b/DrawSteelActionBar/DrawSteelTriggerPanel.lua
@@ -271,10 +271,12 @@ mod.shared.CreateTriggerPanel = function()
                     selectors = {"triggerPanel", "hover"},
                     borderColor = "white",
                 },
-                {
-                    selectors = {"triggerPanel", "pseudohover"},
-                    borderColor = "white",
-                },
+                --pseudohover deliberately has no highlight of its own. An option
+                --card sets it on the trigger's first card so that card's hover
+                --handler runs (ability preview + line-of-sight rays) and so its
+                --dehover knows an option is still hovered -- but the first card
+                --is a mode card like any other, so highlighting it while the
+                --pointer is on a sibling made two cards look hovered at once.
                 {
                     selectors = {"triggerPanel", "press"},
                     brightness = 2,

--- a/DrawSteelActionBar/DrawSteelTriggerPanel.lua
+++ b/DrawSteelActionBar/DrawSteelTriggerPanel.lua
@@ -783,7 +783,7 @@ mod.shared.CreateTriggerPanel = function()
 								buttons[#buttons+1] = gui.Label{
 									classes = {"triggerButton", cond(option.unavailable == true, "unavailableMode")},
 									text = option.text,
-									hover = gui.Tooltip(cond(option.unavailable == true, "Conditions not met - select to override.\n\n" .. tostring(option.rules), option.rules)),
+									hover = gui.Tooltip(cond(option.unavailable == true, tostring(option.conditionReason or "") .. "\n\n" .. tostring(option.rules), option.rules)),
 									press = function(element)
 
                                         audio.DispatchSoundEvent("Notify.TriggerUse", {})
@@ -1413,7 +1413,8 @@ mod.shared.CreateTriggerPanel = function()
                                         gui.Label{
                                             classes = {"triggerUnavailableNote", cond(not unavailable, "collapsed")},
                                             interactable = false,
-                                            text = "Conditions not met - select to override",
+                                            markdown = true,
+                                            text = tostring(option.conditionReason or ""),
                                         },
                                     },
 


### PR DESCRIPTION
## Summary

A multi-mode trigger prompt (a `TriggeredAbility` with `multipleModes`) draws one card per mode. The first mode's card was being used as the trigger's own card, and which mode you picked was resolved by list position -- which silently broke as soon as a mode was hidden.

This branch separates the trigger's identity from mode 1, fixes the selection mapping, and adds an opt-in way to show a mode that is currently unavailable instead of hiding it.

Reference case throughout: the Tactician's **Mark: Benefit**, whose `modeList` is Additional Damage / Spend Recovery / Shift / Taunt, with the last three gated behind conditions.

---

## Bugs found

### 1. Picking a mode could run a *different* mode's behaviors (gameplay, pre-existing)

The worst of these, and it predates everything else here.

`symbols.mode` -- which selects the behaviors to run, via each behavior's `modesSelected` -- was computed as `trigger.triggered + 1`, i.e. from the option's **position** in the `modes` list. That only holds if `modes` is dense with `modeList[2..n]`. It was not: a mode whose `condition` failed was dropped from the list, leaving a hole, so every mode below it addressed the wrong `modeList` entry.

Concretely, on Mark: Benefit, if the damage dealer had no Recoveries left, Spend Recovery (`modeList[2]`) was dropped, and choosing **Shift** resolved to `modeList[2]` -- so the trigger ran **Spend Recovery's** behaviors. No error, no warning; the wrong thing just happened.

Fixed by carrying the index rather than inferring it: each entry records `modeIndex`, and `ActiveTrigger:ModeIndexForTriggered` resolves it. Both call sites (the live path in `TriggeredAbility:Trigger` and the orphan-recovery path in `ActivateOrphanedTrigger`) now go through it.

### 2. The first mode's name and rules were never shown

`ActiveTrigger.text` / `.rules` (the ability name and `triggerPrompt`) were rendered on the first card, which *is* mode 1's card. So on Mark: Benefit the player saw "Mark: Benefit (1 Focus) / Choose one Mark benefit." where "Additional Damage / The ability deals N additional damage." should have been. Mode 1's rules text was not even recorded on the prompt -- only its name, as `activateText`.

### 3. Option cards drew blank cost diamonds

The option cards read `option.cost`, which is only set for `powerRollModifier` triggers (whose options are extra resource spends). Modes carry no cost of their own, so `option.cost` was `nil`: the diamond rendered with no number, and the hide-when-zero check (`cond(option.cost == 0, "hidden")`) never fired because `nil ~= 0`. Every mode card showed an empty diamond.

### 4. Hovering any mode card highlighted the first card too

An option card sets `pseudohover` on the first card, which had a `borderColor = "white"` rule -- so two cards looked hovered at once.

The class itself is load-bearing and stays: it runs the first card's `hover` handler (ability preview + line-of-sight rays, which should follow whichever mode you point at) and tells that card's `dehover` an option is still hovered, so the preview is not torn down as the pointer crosses between cards. Only the border rule was removed.

### 5. Latent crash on an empty `modeList`

`activateText = modeList[1].text` indexed without a guard. Guarded.

---

## Added

- **`Condition Reason`** -- a new field under Mode Condition in the ability editor's Modes section (`AbilityEditor.lua`). Holds player-facing text explaining why a mode cannot be used. When set, a mode whose condition fails is offered anyway: dimmed, annotated with that text, and still pressable so the table can allow it. **Blank (the default) keeps the existing behaviour of hiding the mode.**
- `ActiveTrigger:ModeIndexForTriggered(triggered)` -- resolves an option's position to its `modeList` index.
- `ActiveTrigger:UsesModeHeading()` -- true for a mode-driven trigger that has additional modes.
- `ActiveTrigger.activateRules` -- mode 1's rules text, alongside the existing `activateText`.
- `modes[i]` gains `modeIndex`, and optionally `unavailable` / `conditionReason`.
- Heading boxes above the card stack carrying the trigger's name and prompt, so every card can carry its own mode's name and rules. They take the card's outer width and butt against the first card; a hairline divides title from prompt so the header reads as one block, distinct from the doubled seam between cards. A trigger with no prompt text gets no prompt box.
- Styling: `unavailableMode` (dimmed card/label/button) and `triggerUnavailableNote` (the reason line).

## Fixed

- Mode selection resolving to the wrong `modeList` entry (bug 1).
- Mode 1 showing the trigger's name and prompt instead of its own (bug 2).
- Blank cost diamonds on option cards (bug 3). An option with no cost of its own now shows the trigger's, since picking any mode costs the same; a free multi-mode trigger now draws no diamonds rather than a column of empty ones.
- Two cards appearing hovered at once (bug 4).
- Unguarded `modeList[1]` index (bug 5).

## Removed

- The `{"triggerPanel", "pseudohover"}` border rule (bug 4). The class remains as a state flag with no styling.
- A leftover `print("TARGETS:: OPTION", option)` debug line in the option cost diamond.
- An IIFE around the first card's cost diamond, no longer needed now that the trigger's resource cost is hoisted and shared with the option cards.

## Refactor note

The card and heading geometry now derives from `g_triggerCardWidth` / `g_triggerCardHPad` / `g_triggerCardOuterWidth` at module scope, rather than repeating `178` and its padding in two places. `triggerPanel` declares its width without `borderBox`, so its padding lands outside the declared width -- the heading boxes need the resulting outer width to line up, and deriving it keeps the two from drifting apart.

---

## Backwards compatibility

**This changes no existing content and requires no migration.**

- **Existing multi-mode triggers behave exactly as before.** Every mode in the compendium has a blank `Condition Reason`, so an unmet condition still hides the mode. The greyed-out presentation is strictly opt-in, per mode.
- **Prompts serialized before this change keep working.** `modes[i].modeIndex` is absent on them, and `ModeIndexForTriggered` falls back to the old positional `triggered + 1` -- so a prompt already in flight when the code loads resolves exactly as it did (including bug 1), rather than breaking mid-session.
- **New fields are additive with safe defaults.** `ActiveTrigger.activateRules` defaults to `""`, so reads on older records are safe; `modeList[i].conditionReason` is simply absent on existing abilities.
- **Single-mode and single-card triggers are untouched.** Heading boxes appear only when `UsesModeHeading()` is true (a mode-driven trigger with additional modes); anything else renders exactly as before, with the trigger's own name and prompt on its card.
- **`powerRollModifier` triggers are untouched.** Their options price themselves, they never take heading boxes, and their affordability filter is unchanged.
- **No YAML/compendium data was modified.**

---

## Known issues *not* addressed

- **Mode 1's condition is never evaluated.** The build loop starts at index 2, so a `condition` (and now a `Condition Reason`) authored on the first mode is silently ignored. Pre-existing; left alone to keep this branch scoped, but it is a trap for the next author of a multi-mode trigger.
- **`powerRollModifier` options are still filtered by affordability** (`if amount <= available` in `ActiveTrigger:EnhancementOptions`). Same "hidden because unavailable" shape as modes, and it could take the same opt-in treatment, but those options carry no index-mapping risk so nothing is broken today.

---

## Testing

Exercised against a live DMHub instance over the MCP bridge, driving real and synthetic `ActiveTrigger` records on a Tactician token:

- Multi-mode trigger: heading + prompt boxes render, each card shows its own mode's name and rules, all four diamonds show the cost. Confirmed on a genuine Mark: Benefit prompt raised in play, not only on synthetic records.
- Trigger with no prompt text: title box only, keeping the full card seam against the first card.
- Single-card (non-mode) trigger: unchanged -- own name and prompt on the card, no headings.
- Free multi-mode trigger: no diamonds.
- `Condition Reason` set on one mode and blank on another: the blank one is hidden, the annotated one is greyed with its text and remains pressable.
- `ModeIndexForTriggered` verified directly across all cases -- hidden mode above (Shift resolves to `modeList[3]`, not the 2 the old math gave), `triggered == true` (mode 1), and a legacy record with no `modeIndex` (positional fallback).
- The new editor row builds for all four real modes (modes list went from 21 children to 25).

The repo's `luac` is not present on this machine, so parse checking was done via full Lua reloads (46 mods, no load errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
