### PR TITLE
fix(monsters): scale a converted Solo from its authored organization

### DIFF
--- a/Draw Steel Core Rules/MCDMMonster.lua
+++ b/Draw Steel Core Rules/MCDMMonster.lua
@@ -1843,7 +1843,30 @@ creature.RegisterFeatureCalculation{
             return
         end
 
-        local org, role = MCDMMonsterScaling.ParseOrgRole(c:try_get("role", ""), c:try_get("minion", false))
+        --For a monster promoted by the Make Solo button, read the deltas from the
+        --organization it was authored as, NOT from Solo. The creature's authored
+        --Stamina/EV are still on the pre-conversion curve; the Instant Solo
+        --template is what lifts them onto the Solo curve, and it runs AFTER this
+        --calculation (templates are filled after custom feature calculations in
+        --creature:FillBaseActiveModifiers). Reading the Solo rows here applies a
+        --post-multiply delta to a pre-multiply baseline, which drives Stamina and
+        --EV negative on a level-down (report TFCBW9MC: a solo'd Force of Earth at
+        --level 1 landed on 80 Stamina / -12 EV instead of 230 / 36).
+        --
+        --This is exact, not an approximation: within a tier the elite/leader rows
+        --step by 20 Stamina per level and the solo rows by 50 = 2.5 x 20 (EV: 4
+        --and 12 = 3 x 4), so the pre-conversion delta multiplied by the template
+        --is identical to the solo delta added after it.
+        local roleString = c:try_get("role", "")
+        local minionFlag = c:try_get("minion", false)
+        local isSoloConversion = false
+        pcall(function() isSoloConversion = c:HasSoloConversion() end)
+        if isSoloConversion then
+            roleString = c:try_get("soloConversionPriorRole", roleString)
+            minionFlag = c:try_get("soloConversionPriorMinion", minionFlag)
+        end
+
+        local org, role = MCDMMonsterScaling.ParseOrgRole(roleString, minionFlag)
         local deltas = MCDMMonsterScaling.ComputeDeltas(org, role, base, target)
 
         -- Resolve the characteristic bump. Read the highest characteristic from


### PR DESCRIPTION
Fixes the negative Stamina/EV reported in **TFCBW9MC** ("When lowering a Mindkiller solo to lvl3 it's stamina goes negative").

## The bug

A monster promoted by the **Make Solo** button keeps its authored Stamina and EV, which sit on the pre-conversion (Elite/Leader) curve. The Instant Solo template is what lifts them onto the Solo curve (`set hitpoints = floor(Maximum Stamina * 2.5)`, `set ev = EV*3`).

But `monsterLevelScaling` is a *custom feature calculation*, and those run **before** templates in `creature:FillBaseActiveModifiers`. It was reading the **Solo** rows and applying a post-multiply delta to a pre-multiply baseline.

On a level-down that drives both stats negative:

| Monster (authored) | Solo → level | Before | After |
|---|---|---|---|
| Mindkiller, Elite Hexer L6, 140 | L3 | -25 | 200 |
| Crux of Fire, Elite Artillery L3, 80 | L1 | -50 | 100 |
| Force of Earth, Elite Brute L3, 132 | L1 | 80 Stamina / **-12 EV** | 230 / 36 |

## The fix

When `HasSoloConversion()` is true, read the deltas from `soloConversionPriorRole` / `soloConversionPriorMinion` instead of the current `Solo` role.

This is **exact, not an approximation**: within a tier the elite/leader rows step by 20 Stamina per level and the solo rows by 50 = 2.5 × 20 (EV: 4 and 12 = 3 × 4), so the pre-conversion delta multiplied by the template is identical to the Solo delta added after it. Both routes were checked against each other on all three monsters above.

The `HasSoloConversion` call is `pcall`-guarded, since it is a `monster` method and the instance type is not guaranteed.

## Testing

Verified live over the MCP bridge against a Force of Earth made Solo and set to level 1:

- Stamina **230**, EV **36** (were 80 and -12)
- Level Adjustment modifiers now carry the elite deltas: `hitpoints -40`, `ev -8` (were the solo `-100` / `-24`)
- `132 - 40 = 92`, `floor(92 × 2.5) = 230`; `20 - 8 = 12`, `12 × 3 = 36`
- Clean `reload_lua` (45 mods, no Lua errors)

Depends on draw-steel-data#49 (`operation: set` on the Instant Solo Stamina modifier) for the numbers above; the fix is independent of it and corrects the sign either way.

## Not included

A `math.max(1, ...)` clamp on scaled Stamina. A global clamp in `creature.MaxHitpoints` would break minion squads (0 live minions legitimately means 0), and residual negatives now need a stat block hand-tuned far off its curve — a pre-existing hazard for any scaled-down monster, not solo-specific. Better as its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
