### PR TITLE
Fix downtime project roll stacking a +2 per selected skill (report CWBJQZ5P)

### DIFF
--- a/Downtime Projects/DTProjectRollDialog.lua
+++ b/Downtime Projects/DTProjectRollDialog.lua
@@ -573,7 +573,7 @@ function DTProjectRollDialog._createPanel(options)
                                                                 for i = 2, #curSelected do
                                                                     description = description .. ", " .. skillLookup[curSelected[i]]
                                                                 end
-                                                                local value = 2 * #curSelected
+                                                                local value = 2
 
                                                                 local item = {
                                                                     id = element.id,


### PR DESCRIPTION
**Symptom:** In the downtime project roll dialog, each skill picked in the "Select a skill..." multiselect adds another +2, so three skills produce `Skills: Magic, History, Timescape (+6)`.

**Root cause:** `Downtime Projects/DTProjectRollDialog.lua` computed the skill bonus as `local value = 2 * #curSelected` in the multiselect's `change` handler. Draw Steel (Heroes, ch. 9 "Applying Skills") allows only one skill to apply to a test, for a flat +2 -- and the rest of the codex already implements that (`MCDMCreature.lua` stops after the first proficient skill; `globalrulemods/tests.yaml` declares a single `plustwo` "Skilled" modifier for `project_roll`). This dialog was the only site multiplying the bonus by the selection count.

**Fix:** One line -- `local value = 2`. The bonus row keeps listing every selected skill by name but now totals a single +2 (e.g. `Skills: Magic, History, Timescape (+2)`). `value` feeds only this one `bonuses` item, which `updateForm`/`calculateRoll` sum into the `2d10%+d` string, so nothing else is affected. The control is left as a multiselect.

Report: CWBJQZ5P

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
