### PR TITLE
Fix ForgeSteel import losing career skill choices (report XB89XF76)

### DIFF
--- a/THC Forge Steel Character Importer/FSCIChoiceImporter.lua
+++ b/THC Forge Steel Character Importer/FSCIChoiceImporter.lua
@@ -316,7 +316,7 @@ function FSCIChoiceImporter:_processTableLookupChoice(tableName, choiceType, ite
         local shouldAdd = false
 
         -- Check 1: Is this item explicitly allowed via individualSkills?
-        local inIndividualList = individualSkills and self:_itemInFlagList(itemId, individualSkills)
+        local inIndividualList = individualSkills and next(individualSkills) ~= nil and self:_itemInFlagList(itemId, individualSkills)
         if inIndividualList then
             shouldAdd = true
             debugReason = "individual"


### PR DESCRIPTION
**Symptom:** Heroes imported from ForgeSteel `.ds-hero` files come in with career/class skill choices left unfilled - on an Agent + Shadow character, both "Agent Intrigue Skill" and "Agent Interpersonal Skill" show an empty `Choose...` box even though ForgeSteel had both filled, and some picked skills are silently dropped.

**Root cause:** In `FSCIChoiceImporter:_processTableLookupChoice`, the "Check 1" test was

```lua
local inIndividualList = individualSkills and self:_itemInFlagList(itemId, individualSkills)
```

`_itemInFlagList(selected, available)` (same file) starts with `local foundMatch = true` and only consults the list `if next(available) then`, so it returns `true` for an **empty** table - the "empty means no restriction" semantics that are correct for its other caller, the `categories` check. Many Codex skill choices are authored with an explicit empty list (e.g. `individualSkills: []` on "Agent Intrigue Skill" in `data/objectTables/careers/agent.yaml`, and likewise on explorer, farmer, laborer, watch-officer, beastheart, elementalist and shadow). Such a choice therefore reported "this item is explicitly allowed" for *every* skill, the `categories` restriction was skipped entirely, and `_findMatchingFeature` broke on that first match. Being the first `CharacterSkillChoice` in the career, "Agent Intrigue Skill" swallowed every skill reported for that career and "Agent Interpersonal Skill" was never reached.

**Fix:** Treat an empty `individualSkills` as "no individual-skill allowlist" so the `categories` branch below runs, matching the documented contract in `Draw Steel Core Rules/DSSkillChoice.lua` (`individualSkills string[] Specific skill ids available for selection (overrides categories if non-empty)`), which that file's own `CharacterSkillChoice:HasFilters()` already guards with `next(ind) ~= nil`.

`_itemInFlagList` itself is deliberately unchanged. Choices with a genuinely non-empty `individualSkills` behave exactly as before, and `individualSkills` only exists on `CharacterSkillChoice`, so the language/perk/deity/subclass/ancestry callers of `_processTableLookupChoice` pass `nil` and are unaffected. The change can only make matching less permissive, never more.

Report: XB89XF76

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
