### PR TITLE
Fix Dead End shifting the wall onto a target that never moved (report QE88ZEJR)

### DIFF
--- a/Draw Steel Ability Behaviors/AbilityBuildWall.lua
+++ b/Draw Steel Ability Behaviors/AbilityBuildWall.lua
@@ -598,13 +598,19 @@ ActivatedAbility.RegisterType
     end
 }
 
+--Loc:Equals() is a C# Equals(object) override, which the Lua binding always
+--passes nil for, so it always returns false. Compare tiles by value instead.
+local function LocsEqual(a, b)
+    return a ~= nil and b ~= nil and a.x == b.x and a.y == b.y and a.floor == b.floor
+end
+
 --the straight-line squares from origLoc to (exclusive of) destLoc, including
 --origLoc itself. Approximates the squares a pushed creature vacated.
 local function VacatedSquares(origLoc, destLoc)
     local result = {}
     local loc = origLoc
     local sanity = 0
-    while loc ~= nil and (not loc:Equals(destLoc)) and sanity < 100 do
+    while loc ~= nil and (not LocsEqual(loc, destLoc)) and sanity < 100 do
         result[#result+1] = loc
         local dx = 0
         local dy = 0
@@ -670,7 +676,7 @@ function ActivatedAbilityShiftWallVoxelBehavior:Cast(ability, casterToken, targe
                 currentLoc = creatureTarget.token.loc
             end
 
-            if origLoc ~= nil and currentLoc ~= nil and (not origLoc:Equals(currentLoc)) then
+            if origLoc ~= nil and currentLoc ~= nil and (not LocsEqual(origLoc, currentLoc)) then
                 local vacated = VacatedSquares(origLoc, currentLoc)
 
                 local destLoc = nil


### PR DESCRIPTION
**Symptom:** The Wallmaster's Dead End pushed a high-stability hero, stability reduced the push to 0 squares (the hero correctly did not move), but the wall voxel still shifted -- onto the square the hero was standing in.

**Root cause:** `Loc:Equals(other)` always returns `false` when called from Lua. `LuaLoc.Equals` is a `public override bool Equals(object other)`; the Lua binder maps an `object` parameter to `ParamType.Void`, and `PopStackIntoParamType(Void)` pops the stack and returns `null`, so `other as LuaLoc` is always null. `AbilityBuildWall.lua` relied on that comparison in two places:
- the `ActivatedAbilityShiftWallVoxelBehavior:Cast` guard `not origLoc:Equals(currentLoc)` -- the "creature did not move" check never fired, so the wall always shifted;
- the `VacatedSquares` loop terminator -- with a 0-square push it returned `{origLoc}`, i.e. the square the target is still standing in.

**Fix:** Add a local `LocsEqual(a, b)` helper in `Draw Steel Ability Behaviors/AbilityBuildWall.lua` that compares `x`, `y` and `floor` by value, and use it at both call sites. Now a 0-square push skips the shift entirely (matching the ability text "shifts into any square they leave behind"), and for a real push `VacatedSquares` stops before appending the destination square, so the candidate list no longer offers the square the target now occupies. No engine change; other `:Equals` call sites are untouched.

**Report:** `QE88ZEJR`

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
