### PR TITLE
Fix "prone and can't stand" never applying the Cannot Stand rider (report T7DVA2XG)

### DIFF
--- a/Draw Steel Core Rules/MCDMAbilityBehavior.lua
+++ b/Draw Steel Core Rules/MCDMAbilityBehavior.lua
@@ -717,7 +717,7 @@ local g_rulePatterns = {
         end,
     },
     {
-        pattern = "^prone( and)? can't stand \\((?<duration>eot|eoe|save ends)\\)",
+        pattern = "^prone( and)? cant stand \\((?<duration>eot|eoe|save ends)\\)",
         execute = function(behavior, ability, casterToken, targetToken, options, match)
             ability:CommitToPaying(casterToken, options)
 


### PR DESCRIPTION
**Symptom:** An ability whose power-roll tier reads `... prone and can't stand (save ends)` knocks the target Prone but never attaches the Cannot Stand rider, so Stand Up stays available and no rider icon appears (reported against Time Raider Mind Punk's Mindpunk and a homebrew monster).

**Root cause:** `ActivatedAbilityDrawSteelCommandBehavior:ExecuteCommandInternal` normalizes every rule string with `rule = rule:gsub("'", "")` before iterating `g_rulePatterns`, mirroring the apostrophe stripping `GetTableNameRegex` performs on condition/rider names. The dedicated static pattern for this clause still contained a literal apostrophe (`^prone( and)? can't stand \(...\)`), so after normalization it could never match - unreachable dead code. The generic condition+rider pattern does not cover for it either, because the Cannot Stand rider's `powerTableText` is `and cannot stand`, which does not match `and cant stand`. The clause therefore fell through to the bare `^(?<condition>prone|grabbed)` pattern, which applies Prone alone and discards the rest. The reporter's log confirms it: the tail arrives as `" and cant stand (save ends)"` and there is no `Rider::` line anywhere in the 10 MB log.

**Fix:** Re-spell that one pattern's `can't` as `cant` so it matches post-normalization text. Nothing else changes - the entry's `execute` already inflicts Prone with the `Cannot Stand` rider and is correct. The pattern deliberately still does not match the `cannot stand` spelling, which is already handled by the dynamically built condition+rider pattern. Since the pattern was unreachable before this change, it cannot regress any path that works today.

**Known residual gap (not addressed here):** the duration-less spelling `prone and can't stand` (no `(eot)`/`(save ends)` suffix) still will not attach the rider, because this pattern requires an explicit duration (`match.duration` is passed to `string.lower`) and the generic rider matcher only knows the `cannot` spelling. A follow-up would teach the generic rider matcher both spellings; note that globally rewriting `cant` -> `cannot` is not safe, as the rider "and the target can't use triggered actions" relies on the stripped `cant` form.

Report: `T7DVA2XG`

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
