### PR TITLE
Fix action bar breaking on a malformed triggered ability (report Q3Y6HTZ4)

### DIFF
--- a/DMHub Game Rules/CharacterModifier.lua
+++ b/DMHub Game Rules/CharacterModifier.lua
@@ -3935,11 +3935,25 @@ end
 
 function CharacterModifier:FillTriggeredAbilities(modContext, creature, result)
 	if self:has_key("triggeredAbility") then
+		--A modifier whose behavior was switched away from "trigger" can retain a
+		--stale, half-initialized triggeredAbility that deserializes as a plain Lua
+		--table with no game type, so it has no try_get/IsLocalOnly. Handing it to
+		--callers breaks GetActivatedAbilities{manualTriggers=true}, which aborts the
+		--action bar refresh and leaves the player unable to act. Skip such entries.
+		--pcall: reading a missing field on a game-typed instance raises, so a plain
+		--nil-check is not safe here (same pattern as creature:ApplyAbilityModifiers).
+		local ability = self.triggeredAbility
+		local tryGet = nil
+		pcall(function() tryGet = ability.try_get end)
+		if tryGet == nil then
+			return
+		end
+
 		result[#result+1] = {
 			modifier = self,
 			available = self:HasResourcesAvailable(creature),
 			resources = self:DescribeResourceAvailability(creature),
-			ability = self.triggeredAbility,
+			ability = ability,
 		}
 	end
 end


### PR DESCRIPTION
**Symptom:** A player could not control his character during combat -- selecting his token produced no action bar controls at all.

**Root cause:** A custom character feature on that hero carries a leftover, half-initialized `triggeredAbility` that deserializes as a plain Lua table with no `__typeName` (behavior was switched away from `trigger`, but the sub-object stayed behind). `CharacterModifier:FillTriggeredAbilities` gated only on `self:has_key("triggeredAbility")`, so it pushed that raw table into `creature:GetTriggeredAbilities()`. `GetActivatedAbilities{manualTriggers=true}` (`Draw Steel Core Rules/MCDMCreature.lua` ~3159) then calls `trigger.ability:try_get(...)` on it and throws:

```
attempt to call a nil value (method 'try_get')
  in upvalue '_origGetActivatedAbilities'
  ... in method 'GetActivatedAbilities'
  [DrawSteelActionBar : DrawSteelActionBar]:1808
```

That aborted the whole ability list every time the token was selected, so the action bar never populated.

**The fix:** `CharacterModifier:FillTriggeredAbilities` now skips a `triggeredAbility` that has no `try_get`, using the same `pcall` probe already used by `creature:ApplyAbilityModifiers` in `DMHub Game Rules/Creature.lua` (a plain nil-check is not safe -- reading a missing field on a game-typed instance raises).

Behavior is unchanged for all valid data: every legitimate `triggeredAbility` is created by `CharacterModifier.TypeInfo.trigger.init` as `TriggeredAbility.Create()`, a registered game type deriving from `ActivatedAbility`, so `.try_get` is always present. The only values dropped are malformed plain tables that no consumer of `GetTriggeredAbilities()` can use -- `MCDMCreature.lua:3159`, `DSActionBar.lua:6122`, `MCDMTriggersPanel.lua:557` and `DSModifyTriggerDisplay.lua:327` all call `TriggeredAbility` methods on `entry.ability` and would throw. `CharacterModifier:Trigger` / `:TriggerEvent` are deliberately untouched: they already short-circuit on `self.triggeredAbility.trigger == eventName`, which is nil for a malformed table.

Report id: Q3Y6HTZ4

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
