### PR TITLE
Fix beastheart companion melee bonus picker never showing (report EGEZ9CRC)

### DIFF
--- a/Draw Steel Character Builder/KitDetail.lua
+++ b/Draw Steel Character Builder/KitDetail.lua
@@ -48,7 +48,7 @@ end
 --- @return Panel
 function CBKitDetail._overviewPanel()
 
-    local BEASTHEART_CLASS_ID = "9a583e69-2775-4b39-a52d-1b1dce0dd39e"
+    local BEASTHEART_CLASS_ID = "0380181e-acad-4cdb-ae6d-c7cd11df6ad2"
     local COMPANION_DEFAULT_MELEE_TEXT = "+0/+0/+4"
 
     local function isBeastheartHero(hero)


### PR DESCRIPTION
**Symptom:** A beastheart player has no way to swap their companion's melee damage bonus from the kit's bonus to the rules' +0/+0/+4 -- the "Companion Melee" picker never appears in the character builder's kit overview.

**Root cause:** `Draw Steel Character Builder/KitDetail.lua` declared `local BEASTHEART_CLASS_ID = "9a583e69-2775-4b39-a52d-1b1dce0dd39e"`. That GUID matches nothing in the codex repo, the data repo, or the engine. The shipped beastheart class is `objectTables/classes/beastheart.yaml` with `id: 0380181e-acad-4cdb-ae6d-c7cd11df6ad2` (confirmed against a live game log, where the reporter's beastheart hero has `properties/classes -> classid: 0380181e-...`). So `isBeastheartHero()` always returned false and the container panel's `updateSelectedKit` handler always hit `element:SetClass("collapsed", true)`.

**Fix:** One-line change of the constant to the real beastheart class id. The constant is used in exactly one place (`isBeastheartHero`, called only from that panel). The downstream machinery already exists and is correct: the picker writes `levelChoices.companionBonusChoices.melee = "kit"|"default"`, and `AnimalCompanion:GetCompanionMeleeBonus` in `Draw Steel Beastheart/DSCompanion.lua` already reads that key and returns `{0, 0, 4}` for `"default"`.

**Out of scope:** The same report also notes the companion not inheriting the kit's +1 melee distance bonus. That needs rework of the `excludeKitModifications` path and is deliberately not addressed here.

Report id: EGEZ9CRC. Originated from automated feedback triage.

Syntax-checked with `luac -p`; diff is ASCII-only and preserves the file's CRLF line endings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
