### PR TITLE
Fix collision damage treating creature-vs-creature slam as an object hit (report KGWAZ29N)

### DIFF
--- a/DMHub Game Rules/AbilityRelocateCreature.lua
+++ b/DMHub Game Rules/AbilityRelocateCreature.lua
@@ -687,8 +687,8 @@ function ActivatedAbilityRelocateCreatureBehavior:Cast(ability, casterToken, tar
                     tok.properties._tmp_forcedMovementCast = options.symbols.cast
 					tok.properties:TriggerEvent("collide", {
 						speed = collisionInfo.speed,
-                        withobject = withobject,
-                        withcreature = not withobject,
+                        withobject = casterToken.isObject,
+                        withcreature = not casterToken.isObject,
                         nocollisiondamage = suppressCollisionDamage,
                         pusher = options.symbols.invoker,
                         haspusher = options.symbols.invoker ~= nil,


### PR DESCRIPTION
**Symptom:** A creature that blocks a forced-movement push takes extra collision damage (4 instead of 2) whenever a Targetable object happens to be standing in the same pile.

**Root cause:** In `ActivatedAbilityRelocateCreatureBehavior:Cast`, the loop that fires the `collide` event on each token the mover ran into reused the aggregate `withobject` local, which is true if the collide list is empty (a wall) or if *any* entry in it is an object. So a blocking creature was told `withobject = true` even though the same event table sets `target = casterToken.properties` and `collidedwith = {casterToken.properties}` -- the only thing it actually collided with is the mover. The Collision global rule rolls `Speed + (2 when WithObject)`, so the blocker got a spurious +2.

**The fix:** In that loop only, the two flags now describe what that token actually collided with -- the mover -- using `casterToken.isObject` instead of the aggregate `withobject`. This matches Draw Steel's Slamming rule ("Into creature: both take 1 damage per remaining square" vs "Into solid object: 2 + 1 per remaining square") and the intent already documented in the comment just above the block ("The mover sees everything it ran into; each thing it ran into sees the mover.").

The mover's own `collide` event is deliberately left untouched -- its aggregate `withobject` is intentional.

Report id: `KGWAZ29N`

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
