### PR TITLE
Action bar: keep the Prompt When Resolving chooser visible for off-turn casts

### DIFF
--- a/DMHub Game Rules/AbilityInvokeAbility.lua
+++ b/DMHub Game Rules/AbilityInvokeAbility.lua
@@ -378,10 +378,26 @@ function ActivatedAbilityInvokeAbilityBehavior:Cast(ability, casterToken, target
 
             print("INVOKE:: ChooseTarget:: prompting...")
             targets = nil
+
+            --The chooser's caption. An explicit Prompt When Resolving text wins;
+            --otherwise borrow the invoke's own prompt text (what the chosen
+            --target will be offered, e.g. "Move Speed or Make Free Strike") so
+            --the Director sees what they are picking a target FOR rather than a
+            --bare "Choose Target".
+            local chooserPrompt = self:try_get("promptWhenResolvingText", "")
+            if chooserPrompt == "" then
+                local promptText = self:try_get("promptText", "")
+                if promptText ~= "" then
+                    chooserPrompt = "Choose the next target: " .. StringInterpolateGoblinScript(promptText, casterToken.properties:LookupSymbol{})
+                else
+                    chooserPrompt = "Choose Target"
+                end
+            end
+
             GameHud.instance.actionBarPanel:FireEventTree("chooseTargetToken", {
                 sourceToken = casterToken,
                 targets = table.shallow_copy(targetChoices),
-                prompt = self:try_get("promptWhenResolvingText", "Choose Target"),
+                prompt = chooserPrompt,
                 choose = function(targetToken)
                     print("ChooseTarget:: chosen")
                     targets = {

--- a/DrawSteelActionBar/DrawSteelActionBar.lua
+++ b/DrawSteelActionBar/DrawSteelActionBar.lua
@@ -5465,6 +5465,27 @@ CreateAbilityController = function()
             local cancel = options.cancel or function() end
 
             gui.SetFocus(nil)
+
+            --The chooser lives inside the action bar, and "refresh" hides the
+            --whole bar when there is no token to show. An off-turn cast fired
+            --from the initiative bar (villain actions) with nothing selected
+            --pops its caster the moment the cast begins, so a behavior that
+            --then prompts for a target (Prompt When Resolving) would build its
+            --prompt inside a hidden bar: the cast silently waits on a choice
+            --nobody can see. Push the prompt's source token as the caster for
+            --the life of the chooser so the bar shows it; popped in destroy.
+            local pushedSourceToken = false
+            if options.sourceToken ~= nil and options.sourceToken.valid then
+                local shownToken = g_token
+                if #g_casterTokenStack == 0 then
+                    shownToken = dmhub.selectedOrPrimaryTokens[1]
+                end
+                if shownToken == nil or not shownToken.valid then
+                    PushCasterToken(options.sourceToken)
+                    pushedSourceToken = true
+                end
+            end
+
             g_actionBar:FireEvent("refresh")
 
             g_actionBar:SetClassTree("choosingTarget", true)
@@ -5508,6 +5529,13 @@ CreateAbilityController = function()
                     end
                     gui.SetFocus(nil)
                     g_actionBar:SetClassTree("choosingTarget", false)
+                    if pushedSourceToken then
+                        pushedSourceToken = false
+                        TryPopCasterToken()
+                        if g_actionBar ~= nil and g_actionBar.valid then
+                            g_actionBar:FireEvent("refresh")
+                        end
+                    end
                 end,
             }
 


### PR DESCRIPTION
## Problem

A villain action fired from the initiative bar's VA drawer with no token selected (e.g. Goblin Monarch, *What Are You Waiting For?*) pops its caster the moment the cast begins. When the invoke behavior then asks the Director to pick the next ally (Prompt When Resolving), the action bar's `refresh` hides the whole bar because there is no token to show, and the chooser is built inside it - invisible. The cast silently waits on a choice nobody can see; a second click on the drawer defocuses the chooser, cancels it, and the villain action resolves on zero targets (`INVOKE:: Casting on 0`).

## Fix

- `DrawSteelActionBar.lua` `chooseTarget`: when nothing would otherwise be shown (empty caster stack and no selection), push the prompt's `sourceToken` as the bar's caster for the life of the chooser; pop it (and refresh) in the chooser's `destroy`.
- `AbilityInvokeAbility.lua`: chooser caption - explicit `promptWhenResolvingText` wins, else `Choose the next target: <promptText>`, else the old `Choose Target`.

## Verification

Reproduced live (chooser fired with nothing selected: bar hidden, nothing on screen), then with the fix the "Choose Target" strip with ally portraits appears and the cast proceeds ally by ally; cancel path pops the caster and the bar hides again. Both files `luac -p` clean.

Related data change (pushed to draw-steel-data main, 9629848): Goblin Monarch VA1 gets `promptWhenResolvingText: Select the next ally to move or use their free strike`.