### PR TITLE
Token HUD: a click on a target candidate picks it, never claims its turn

### DIFF
--- a/Draw Steel UI/DrawSteelTokenHud.lua
+++ b/Draw Steel UI/DrawSteelTokenHud.lua
@@ -16,6 +16,36 @@ local function MinionDeathPending(creatureProps)
     return confirmedAt ~= nil and dmhub.Time() - confirmedAt < g_minionDeathPendingTimeout
 end
 
+--True while some targeting prompt is offering this token as a pick: the action
+--bar (chooseTarget, ability targeting) stamps token.sheet.data.targetInfo on
+--every candidate and TokenUI's tokenClick executes it. While that is set, a
+--click on the token means "pick this token" -- never "claim its turn". The
+--claim-turn swords and the nameplate sit above the token and would otherwise
+--swallow the click and SelectTurn the creature (e.g. the Goblin Monarch's
+--villain action asks the Director to click each ally; every unmoved ally is
+--ActiveAndReady, so each pick claimed that ally's turn and they showed as
+--already moved).
+local function TokenIsTargetCandidate(token)
+    if token == nil or not token.valid then
+        return false
+    end
+    local sheet = token.sheet
+    if sheet == nil or not sheet.valid or sheet.data == nil then
+        return false
+    end
+    return sheet.data.targetInfo ~= nil
+end
+
+--Route a press to the same path a direct token click takes (TokenUI tokenClick
+--executes the pending targetInfo). Returns true if it was routed.
+local function RoutePressToTargetPick(token)
+    if not TokenIsTargetCandidate(token) then
+        return false
+    end
+    token.sheet:FireEvent("tokenClick", false)
+    return true
+end
+
 local g_deadMinionPulseSpeed = 0.5
 local g_deadMinionIconStyles = {
     gui.Style{
@@ -445,6 +475,9 @@ TokenHud.RegisterPanel{
                         element.interactable = token.canControl
                     end,
                     press = function(element)
+                        if RoutePressToTargetPick(token) then
+                            return
+                        end
                         element.parent.parent:GetChildrenWithClassRecursive("nameplate")[1]:FireEvent("press")
                     end,
                     hover = function(element)
@@ -470,6 +503,18 @@ TokenHud.RegisterPanel{
                         element.selfStyle.opacity = element.data.startOpacity*(1-t)
                         return
                     end
+                    --Step aside while the token is a target candidate: the pick
+                    --click must reach the token, and showing a claim affordance
+                    --over a "click this ally" prompt invites the wrong action.
+                    --updateInitiative owns the real show/hide; this only masks
+                    --while targeting is live, and think keeps running (thinkTime
+                    --is still set) so the swords come back when targeting ends.
+                    local targeting = TokenIsTargetCandidate(token)
+                    element:SetClass("hidden", targeting)
+                    if targeting then
+                        return
+                    end
+
                     local r = math.sin(dmhub.Time()*2*math.pi)
                     if element:HasClass("highlight") or element:HasClass("childHover") then
                         r = 1
@@ -575,6 +620,9 @@ TokenHud.RegisterPanel{
                 end,
 
                 press = function(element)
+                    if RoutePressToTargetPick(token) then
+                        return
+                    end
                     if token.canControl then
                         element.data.clickTime = dmhub.Time()
                         audio.FireSoundEvent("Mouse.Click")


### PR DESCRIPTION
## Problem (Ricky's field report: villain action marks allies as already moved)

Goblin Monarch's *What Are You Waiting For?* asks the Director to click each ally in turn (Prompt When Resolving). While that chooser is up, every unmoved ally is `ActiveAndReady`, so its token HUD shows the pulsing **claim-turn swords** (16x16 hit area at the token centre) and a clickable **nameplate**. Both sit above the token and swallow the click, so clicking the ally to pick it ran `SelectTurn` + `BeginTurn` for that ally (`DrawSteelTokenHud.lua` nameplate `press`) instead of the target pick. When the turn later ended, the ally showed as already moved.

Reproduced live with `SelectTurn` instrumented: pressing the swords hit area during the chooser → `TURNTRACE:: SelectTurn` from `DrawSteelTokenHud:583`. The VA's own Move Speed / free-strike path was driven end to end and never touches initiative.

## Fix (`Draw Steel UI/DrawSteelTokenHud.lua`)

- `TokenIsTargetCandidate(token)`: true while `token.sheet.data.targetInfo` is set (the action bar stamps this on every candidate of an active targeting prompt / chooser).
- Swords `think`: mask the swords while the token is a candidate; `think` keeps running so they come back when targeting ends (`updateInitiative` still owns the real show/hide).
- Swords hit-area `press` and nameplate `press`: if the token is a candidate, route to `token.sheet:FireEvent("tokenClick", false)` (TokenUI executes the pending `targetInfo`) and return — no claim.

## Verification

Live, same instrumented repro after hot-reload: swords hidden while the ally is a candidate; swords-hit-area press and nameplate press both log `EXECUTE:: CLICK → ChooseTarget:: chosen` and `currentTurn` stays unset; swords visible again once targeting ends. `luac -p` clean.