### PR TITLE
Fix crash when a power-roll modifier has Potency set to None (report 9DVY25AW)

### DIFF
--- a/Draw Steel Core Rules/MCDMAbilityRollBehavior.lua
+++ b/Draw Steel Core Rules/MCDMAbilityRollBehavior.lua
@@ -1917,7 +1917,7 @@ function ActivatedAbilityPowerRollBehavior:Cast(ability, casterToken, targets, o
 
                     --Check modifiers actually applied to roll for this target
                     for _, mod in ipairs(m_rollInfo.properties.multitargets[numTarget].modifiersUsed or {}) do
-                        potencyApplied = potencyApplied + mod:try_get("potencymod", 0)
+                        potencyApplied = potencyApplied + (tonumber(mod:try_get("potencymod", 0)) or 0)
                     end
 
                     options.symbols.cast:SetPotencyApplied(targetToken, potencyApplied)


### PR DESCRIPTION
**Symptom:** A user-made "Modify Power Roll" trigger whose Potency dropdown is set to `None` makes the targeted ability show "Error" in the Action Log and cancel outright -- the roll resolves, then no effects are applied.

**Root cause:** `potencymod` on a power-roll `CharacterModifier` is a dropdown *id string*, not a number. `Draw Steel Core Rules/MCDModifyPowerRolls.lua` writes `modifier.potencymod = element.idChosen`, where the ids are `"none"`, `"1"`, `"2"`, `"-1"`, `"-2"`, `"custom"`. In `MCDMAbilityRollBehavior.lua` the `Cast` per-target loop did:

```lua
potencyApplied = potencyApplied + mod:try_get("potencymod", 0)
```

Numeric-string ids coerce silently in Lua arithmetic, but `"none"` and `"custom"` do not, so this raises `attempt to add a 'number' with a 'string'`. The error is thrown inside the cast coroutine, which kills the entire ability resolution.

**Fix:** Coerce the read, matching what every other consumer of `potencymod` in the repo already does (`MCDModifyPowerRolls.lua:1070`, `MCDMActivatedAbility.lua:861`):

```lua
potencyApplied = potencyApplied + (tonumber(mod:try_get("potencymod", 0)) or 0)
```

Numeric ids behave exactly as before; non-numeric ids now contribute `0` to the `Cast.PotencyApplied` bookkeeping value instead of crashing. (Evaluating the `"custom"` potency GoblinScript is out of scope here -- the lookup function isn't available at this point, so `custom` is treated as 0 for this bookkeeping value, same as it was intended to be.)

One line, one file. `luac -p` on the file exits 0.

Report id: `9DVY25AW`. Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
