### PR TITLE
Fix Invoke Ability standard-ability dropdown failing to open (report RK4HMAS8)

### DIFF
--- a/DMHub Core UI/Dropdown.lua
+++ b/DMHub Core UI/Dropdown.lua
@@ -198,7 +198,14 @@ function gui.Dropdown(args)
 						end
 					end
 
-					return ResolveFunction(a.text) < ResolveFunction(b.text)
+					--Guard against a malformed option with a nil/non-string text.
+					--One such option used to make this comparator throw, which
+					--aborts table.sort and leaves the popup unbuilt.
+					local atext = ResolveFunction(a.text)
+					local btext = ResolveFunction(b.text)
+					if type(atext) ~= "string" then atext = "" end
+					if type(btext) ~= "string" then btext = "" end
+					return atext < btext
 				end)
 			end
 

--- a/DMHub Game Rules/AbilityInvokeAbility.lua
+++ b/DMHub Game Rules/AbilityInvokeAbility.lua
@@ -1292,7 +1292,13 @@ function ActivatedAbilityInvokeAbilityBehavior:EditorItems(parentPanel)
 
 	local standardAbilities = {}
 	for k,v in unhidden_pairs(dmhub.GetTable("standardAbilities") or {}) do
-		standardAbilities[#standardAbilities+1] = { text = v.name, id = k }
+		--A nameless standardAbilities row would put a nil into the dropdown's
+		--sort comparator and stop the menu from opening at all.
+		local abilityName = v.name
+		if type(abilityName) ~= "string" or abilityName == "" then
+			abilityName = "(Unnamed)"
+		end
+		standardAbilities[#standardAbilities+1] = { text = abilityName, id = k }
 	end
 
 	result[#result+1] = gui.Panel{


### PR DESCRIPTION
**Symptom:** In the ability editor, an Invoke Ability effect with Type = "Standard Ability" shows an Ability dropdown stuck reading "(Invalid)" that will not open, so no standard ability can be picked.

**Root cause:** `ActivatedAbilityInvokeAbilityBehavior:EditorItems` builds the option list as `{ text = v.name, id = k }` over the `standardAbilities` table, and the dropdown is created with `sort = true`. A single row with a nil `name` makes the sort comparator in `DMHub Core UI/Dropdown.lua` raise `attempt to compare string with nil`; `table.sort` then aborts the dropdown's press handler, so the popup is never built. The label reads "(Invalid)" because the default `idChosen` matches no option, which is the dropdown's `textDefault`.

The reporter's log shows 72 occurrences of:

```
Error executing lua: [string "DMHub Core UI : Dropdown"]:201: attempt to compare string with nil
  [string "DMHub Core UI : Dropdown"]:201: in function <[string "DMHub Core UI : Dropdown"]:192>
  [C]: in function 'table.sort'
  [string "DMHub Core UI : Dropdown"]:192: in function <[string "DMHub Core UI : Dropdown"]:146>
```

alongside a `standardAbilities` row repeatedly failing to merge (`NewTable:: standardAbilities key 14c386b6-...; fork = True, False`) - very likely the offending row.

**What this changes:**
- `DMHub Core UI/Dropdown.lua` - the sort comparator coerces a nil/non-string `text` to `""` instead of raising, so one malformed option can no longer stop a sorted dropdown from opening. Well-formed options sort exactly as before; the `unsorted` grouping is untouched.
- `DMHub Game Rules/AbilityInvokeAbility.lua` - a `standardAbilities` row with a missing name now gets the label `(Unnamed)` rather than a nil `text`.

This is the defensive half only. A nameless `standardAbilities` row is a known data fault - b028d4a6 added the same guard in `MCDMUtils` for report KHWRUUM5 and noted that the fork-merge path which drops the `name` field is engine-side and unfixed. This is the second consumer of those rows and had no guard.

Both files pass `luac -p`; no non-ASCII bytes added.

Report RK4HMAS8. Originated from automated feedback triage.