### PR TITLE
Fix dropdown menu failing to open when an option has no text (report RK4HMAS8)

### DIFF
--- a/DMHub Core UI/Dropdown.lua
+++ b/DMHub Core UI/Dropdown.lua
@@ -198,7 +198,15 @@ function gui.Dropdown(args)
 						end
 					end
 
-					return ResolveFunction(a.text) < ResolveFunction(b.text)
+					local atext = ResolveFunction(a.text)
+					local btext = ResolveFunction(b.text)
+					if type(atext) ~= "string" then
+						atext = tostring(atext or "")
+					end
+					if type(btext) ~= "string" then
+						btext = tostring(btext or "")
+					end
+					return atext < btext
 				end)
 			end
 


### PR DESCRIPTION
**Symptom:** In the Invoke Ability behavior editor, choosing Type = "Standard Ability" shows an "Ability:" dropdown reading "(Invalid)" that does nothing when clicked.

**Root cause:** `gui.Dropdown`'s press handler sorts its options with a comparator that assumes every option's `text` resolves to a string. The Invoke Ability editor builds its list as `{ text = v.name, id = k }` over the `standardAbilities` table (`DMHub Game Rules/AbilityInvokeAbility.lua`), so a single row in that table with no `name` yields `text = nil`. `table.sort` then throws `attempt to compare string with nil`, which aborts the entire press handler, so the option menu is never built and the dropdown appears dead. The user's log shows 20+ repeats of `[string "DMHub Core UI : Dropdown"]:201: attempt to compare string with nil`. A nameless row in this exact table is a known real-world occurrence -- `Draw Steel Core Rules/MCDMUtils.lua` already carries a defensive guard for it with the comment "A corrupt/nameless entry used to make string.lower throw here".

**Fix:** In `DMHub Core UI/Dropdown.lua`, coerce non-string resolved option text to a string (nil becomes "") before comparing. For well-formed options the comparison is byte-for-byte identical to before; the new branches only run on values that currently raise an error, so no working dropdown changes behaviour. The `unsorted` precedence block is untouched.

Report id: RK4HMAS8

This PR originated from automated feedback triage of an in-app bug report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
