### PR TITLE
Fix unreadable builder trait tooltip on cream background (report ZA23JNFR)

### DIFF
--- a/Draw Steel Character Builder/FeatureSelector.lua
+++ b/Draw Steel Character Builder/FeatureSelector.lua
@@ -511,6 +511,7 @@ function CBFeatureSelector.SelectionPanel(selector, feature)
                         fontSize = 16,
                         bgimage = true,
                         bgcolor = CBStyles.COLORS.GOLD,
+                        color = CBStyles.COLORS.BLACK02,
                     }(element)
                 elseif element.data.panelFn then
                     -- element.tooltip = gui.TooltipFrame(element.data.panelFn(), {


### PR DESCRIPTION
**Symptom:** In the Character Builder, hovering a trait card while an ancestry is only previewed shows the "Select your Ancestry before choosing features." tooltip as near-white text on a light cream background - effectively unreadable.

**Root cause:** The `blockFeatureSelection` tooltip in `Draw Steel Character Builder/FeatureSelector.lua` sets `bgcolor = CBStyles.COLORS.GOLD`, which the gold-to-cream recolour remapped from the original dark gold `#966D4B` to the light cream `srgb:#DFCFC0`. The tooltip never set a text colour, so the label kept the default `@fgStrong` (`#F2EDE1`) from `DMHub Core UI/DefaultStyles.lua` - roughly 1.2:1 contrast against the new background. This is the only tooltip in the builder with a light background; every other one uses the default near-black `#000000fa` from `CreateTooltipPanel`.

**Fix:** Add `color = CBStyles.COLORS.BLACK02` (`#10110F`, already used for dark-on-cream text elsewhere in the builder) to that one tooltip's args. `gui.Tooltip` forwards every key except `text` into the label's inline style via `CreateTooltipPanel` (`DMHub Core UI/Gui.lua`), so `color` is honoured the same way the already-effective `bgcolor` is. One line, one style field, no logic or layout change; only the blocked-selection tooltip is affected.

Report id: `ZA23JNFR` (v0.0.814, WindowsPlayer).

Originated from automated feedback triage.