### PR TITLE
Fix inert toolbar buttons for dockable panels like Maps (report 5TP4AAD6)

### DIFF
--- a/DMHub Game Hud/GameHud.lua
+++ b/DMHub Game Hud/GameHud.lua
@@ -712,7 +712,20 @@ function GameHud:CreateToolbarPanel()
 					end
 				end,
 				press = function()
+					--Commands.GetCommandInfo only knows the launchable-panel and
+					--command registries; panels like Maps and the Measuring Tool
+					--are dockable panels now, so fall back to the toolbar's own
+					--candidate list (which covers both registries) or the button
+					--is inert.
 					local info = Commands.GetCommandInfo(itemName)
+					if info == nil then
+						for _,candidate in ipairs(ToolbarCandidates()) do
+							if candidate.name == itemName then
+								info = candidate
+								break
+							end
+						end
+					end
 					if info ~= nil and info.click ~= nil then
 						info.click()
 					end


### PR DESCRIPTION
**Symptom:** The Director toolbar's "Maps" button does nothing when clicked, so the user cannot open the Maps panel to create a new map.

**Root cause:** In `GameHud:CreateToolbarPanel`, `ToolbarCandidates()` deliberately offers items from BOTH `LaunchablePanel.GetMenuItems()` and `DockablePanel.GetMenuItems()`, but the button's `press` handler resolves its action by name through `Commands.GetCommandInfo(itemName)` -- an engine-side helper that searches only the launchable-panel/command registry. Panels that are dockable panels now (Maps, Measuring Tool -- both in the shipped default Director toolbar) resolve to `nil`, and the press is silently discarded. The tooltip still renders, so the button looks normal but is inert.

**Fix:** Purely additive nil-fallback in the `press` handler: when `Commands.GetCommandInfo` returns nil, re-scan the toolbar's own `ToolbarCandidates()` list (which covers both registries) for a matching name. Buttons that resolve today (Leave Game, Settings, Undo, Redo, ...) are unchanged; only the previously-dead nil branch gains behavior. A dockable panel menu item's `click(operation)` with no argument is the same toggle call the Game/Tools menu makes.

Report: 5TP4AAD6

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
