### PR TITLE
Fix UVTT import placing doors half a door-length off the opening (report JUKJFVK6)

### DIFF
--- a/DMHub Core Panels/CreateMapDialog.lua
+++ b/DMHub Core Panels/CreateMapDialog.lua
@@ -1130,8 +1130,10 @@ mod.shared.ImportMapToFloorCo = function(info)
                             local foundryDoorState = portal.foundryDoorState or (flags and flags.foundry_door_state)
                             -- TODO: Apply Foundry open/locked door state when DMHub exposes a door-state API.
                             local delta = core.Vector2(x2 - x1, y1 - y2)
-                            portalObj.x = area.x1 + ((x1 + x2) / 2)
-                            portalObj.y = area.y2 - ((y1 + y2) / 2)
+                            -- A portal object's position is its hinge, not its center,
+                            -- so anchor it at the first endpoint of the portal segment.
+                            portalObj.x = area.x1 + x1
+                            portalObj.y = area.y2 - y1
                             portalObj.rotation = delta.angle + (tonumber(dmhub.GetSettingValue("mapimport:portal_rotation_offset")) or 90)
                             portalObj.scale = portalObjectScale(nodeId, delta.length)
                             portalObj:Upload()


### PR DESCRIPTION
**Symptom:** Importing a UVTT/dd2vtt map with "Doors -> asset" spawns each door roughly half a door-length off its actual opening (same for windows and secret doors).

**Root cause:** In the engine a portal object's position *is its hinge*, not its centre. `ObjectComponentPortal.GetSegment` computes the opening as `a = transform.position; b = a + dir * doorLength * scale` (rotated), and the engine's own manual placement, `ObjectTool.SnapObjectPlacement`, sets `obj.objectInstance.pos = portalInfo.hingePos` -- the *start* of the wall opening. The importer instead anchored the object at the midpoint of the UVTT portal segment, so the door leaf extended a full door-length past that midpoint.

This is a regression: the pre-refactor importer anchored at `bounds[1]` (the first endpoint) for both doors and windows. Commit 3d35b7f6 ("Improve Foundry UVTT map imports") changed it to the midpoint while the rotation and scale logic -- which assume the endpoint anchor -- were left unchanged.

**The fix:** In `DMHub Core Panels/CreateMapDialog.lua`, anchor the spawned portal object at the segment's first endpoint (`area.x1 + x1`, `area.y2 - y1`) instead of its midpoint. Rotation (`delta.angle + offset`) and `portalObjectScale(nodeId, delta.length)` are unchanged and already correct: the door extends *from* its position *along* `b1 -> b2` and is scaled so its length equals the segment length, so anchoring at `b1` makes the door span the opening exactly. Doors, secret doors and windows all go through this path and are all corrected identically.

Report id: JUKJFVK6. Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
