### PR TITLE
fix(audio): report uncategorised tracks in the dock, and give glyph controls their click

### DIFF
--- a/DMHub Core Panels/Audio.lua
+++ b/DMHub Core Panels/Audio.lua
@@ -674,15 +674,38 @@ local function PrunePlayOrder()
 	end
 end
 
+--The category bucket an audio asset really belongs to, or nil for uncategorised.
+--An unset category reads back as nil (never set) OR "" (cleared through the
+--AudioAssetLua setter, which stringifies nil to ""); both mean uncategorised, so
+--they collapse to nil here and callers can test it directly. NB Lua treats "" as
+--truthy, so a bare `asset.category or fallback` misses the empty-string case.
+local function NormalizedAudioCategory(asset)
+	local c = asset.category
+	if c == nil or c == "" then
+		return nil
+	end
+	return c
+end
+
 --All clips currently playing for a category (Music/Ambience/Effects), found by
 --scanning audio.currentlyPlaying. Sorted by play-start order ascending
 --(oldest first) -- stable across loop restarts.
-local function PlayingTracksForCategory(cat)
+--
+--includeUncategorised also picks up clips with no category. Those belonged to no
+--lane at all before, so the dock rendered its idle "Nothing playing" CTA over the
+--top of an audible track (report RXC87T4Y). They ride the music lane rather than a
+--lane of their own so they pick up the hero card's transport and playlist chrome
+--too; the hero subtitle names the real state, since an uncategorised clip is still
+--unrouted engine-side (no Levels fader, no Anthem duck).
+local function PlayingTracksForCategory(cat, includeUncategorised)
 	local list = {}
 	for assetid,_ in pairs(audio.currentlyPlaying) do
 		local a = assets.audioTable[assetid]
-		if a ~= nil and a.category == cat then
-			list[#list+1] = { id = assetid, asset = a, order = PlayOrderOf(assetid) }
+		if a ~= nil then
+			local c = NormalizedAudioCategory(a)
+			if c == cat or (includeUncategorised and c == nil) then
+				list[#list+1] = { id = assetid, asset = a, order = PlayOrderOf(assetid) }
+			end
 		end
 	end
 	if #list > 1 then
@@ -1450,7 +1473,9 @@ g_drawSteelAudioBar = {
 	--newest playing music track, else newest playing ambience bed, else nil.
 	PrimaryPlayingName = function()
 		PrunePlayOrder()
-		local list = PlayingTracksForCategory("music")
+		--Same lane rule as the dock: an uncategorised clip is still the thing the
+		--table can hear, so this readout must not report silence over the top of it.
+		local list = PlayingTracksForCategory("music", true)
 		if #list == 0 then
 			list = PlayingTracksForCategory("ambience")
 		end
@@ -1540,7 +1565,10 @@ end
 --live instance from audio.currentlyPlaying at every call site.
 local function MusicChannelInstances()
 	local list = {}
-	local tracks = PlayingTracksForCategory("music")
+	--Uncategorised clips are included because the dock's hero card shows them in the
+	--music lane; without them here the hero's pause button would be a dead control
+	--whenever an uncategorised track is the one playing.
+	local tracks = PlayingTracksForCategory("music", true)
 	for i=1,#tracks do
 		local instance = audio.currentlyPlaying[tracks[i].id]
 		if instance ~= nil then
@@ -3224,16 +3252,10 @@ local m_poolPendingRename = nil    --poolid whose card row should auto-open rena
 local m_poolCueIndex = {}          --per-pool DM-cue cycle index (module-local, session-only)
 local g_poolsCardExpandPool = nil  --function(poolid): expand that pool row + rebuild the card
 
---Normalise the stored category to a dropdown option id. An unset category reads back
---as nil (never set) OR "" (set to nil through the current AudioAssetLua setter, which
---stringifies nil to ""); both mean "uncategorised". NB Lua treats "" as truthy, so a
---bare `category or "none"` would surface a blank option for the empty-string case.
+--The stored category as a dropdown option id -- uncategorised becomes the "none"
+--option (see NormalizedAudioCategory for what counts as uncategorised).
 local function GetAssetCategoryId(asset)
-	local c = asset.category
-	if c == nil or c == "" then
-		return "none"
-	end
-	return c
+	return NormalizedAudioCategory(asset) or "none"
 end
 
 --Builds the category dropdown for one asset. opts carries only presentation
@@ -4179,7 +4201,11 @@ local function CreatePlayerSoundPanel()
 
 		PrunePlayOrder()
 
-		local musicList = PlayingTracksForCategory("music")
+		--Uncategorised clips ride the music lane (see PlayingTracksForCategory), so a
+		--player sees what the table is actually hearing instead of "Nothing playing".
+		--No "Uncategorised" subtitle on this side: a player cannot set a category, and
+		--the nudge to fix it belongs on the DM's dock.
+		local musicList = PlayingTracksForCategory("music", true)
 		local mid, ma = nil, nil
 		local musicExtrasList = {}
 		if #musicList > 0 then
@@ -4482,6 +4508,9 @@ local function BuildSoundPanelContent()
 	--progress slider's drag-preview math can read it without re-deriving from
 	--audio.currentlyPlaying on every frame. Written only by UpdateNowPlaying.
 	local m_heroPaused = false
+	--True while the hero card is showing a clip with no category, which the subtitle
+	--names and its tooltip explains. Written only by UpdateNowPlaying.
+	local m_heroUncategorised = false
 	--True while the user is actively dragging the progress slider. The 0.5s poll
 	--(UpdateNowPlaying) must not overwrite the slider's value while this is true, or
 	--the tick fights the drag and the thumb stutters back mid-scrub.
@@ -4526,6 +4555,9 @@ local function BuildSoundPanelContent()
 		textWrap = false,
 		textOverflow = "ellipsis",
 	}
+	--Names the hero's lane ("Music", or "Uncategorised" for a clip with no category).
+	--The tooltip only appears in the uncategorised case, and reuses the Studio row
+	--dropdown's wording so both surfaces explain the same gap the same way.
 	local subtitleLabel = gui.Label{
 		classes = {"sizeXs", "fgMuted"},
 		text = "",
@@ -4534,6 +4566,11 @@ local function BuildSoundPanelContent()
 		halign = "left",
 		valign = "center",
 		hmargin = 4,
+		linger = function(element)
+			if m_heroUncategorised then
+				gui.Tooltip("Set a Category. This clip will ignore Levels faders until you set a category.")(element)
+			end
+		end,
 	}
 
 	--Playlist transport lines (H-dock). Both start collapsed -- UpdateNowPlaying
@@ -5108,8 +5145,10 @@ local function BuildSoundPanelContent()
 
 		--Music hero = the most recently STARTED track (starting a new track is
 		--an intentional act, so it takes the big slot); earlier tracks remain
-		--as extra rows in start order.
-		local musicList = PlayingTracksForCategory("music")
+		--as extra rows in start order. The lane includes uncategorised clips, so
+		--one can win the hero slot -- the subtitle below then reads "Uncategorised"
+		--rather than claiming a Music routing the clip does not have.
+		local musicList = PlayingTracksForCategory("music", true)
 		local mid, ma = nil, nil
 		local musicExtrasList = {}
 		if #musicList > 0 then
@@ -5136,7 +5175,12 @@ local function BuildSoundPanelContent()
 			end
 			titleLabel.text = DisplayNameForAsset(ma)
 			titleLabel:SetClass("fgMuted", false)
-			subtitleLabel.text = "Music"
+			m_heroUncategorised = NormalizedAudioCategory(ma) == nil
+			if m_heroUncategorised then
+				subtitleLabel.text = "Uncategorised"
+			else
+				subtitleLabel.text = "Music"
+			end
 			stopButton:SetClass("hidden", false)
 			pauseButton:SetClass("hidden", false)
 			pauseButton.bgimage = paused and "ui-icons/ph-play-fill.png" or "ui-icons/ph-play-pause-fill.png"
@@ -5154,6 +5198,7 @@ local function BuildSoundPanelContent()
 			stopButton:SetClass("hidden", true)
 			pauseButton:SetClass("hidden", true)
 			m_heroPaused = false
+			m_heroUncategorised = false
 			timeCurrent.text = ""
 			timeTotal.text = ""
 			if not m_scrubbing then

--- a/DMHub Core Panels/Audio.lua
+++ b/DMHub Core Panels/Audio.lua
@@ -3315,6 +3315,15 @@ local function CreateCategoryDropdown(asset, opts)
 	return dropdown
 end
 
+--Press click for this file's hand-rolled glyph controls (transport, cue, play,
+--pin, ...). Text buttons get their click from the {label, button, press} rule in
+--DefaultStyles; these are raw gui.Panels matching no button selector, so they were
+--silent. Splice it into a control's own styles list to opt it in. A style rule and
+--not an audio.FireSoundEvent in the press handler on purpose: the engine mutes
+--style sounds while the app is unfocused, and these should behave like every other
+--button rather than clicking in the background.
+local GLYPH_PRESS_SOUND = { selectors = {"press"}, soundEvent = "Mouse.Click" }
+
 --Unified soundboard button style rules (chunk F1a/F1d). Shared verbatim by BOTH
 --surfaces: the dock attaches these via ThemeEngine.MergeTokens on soundboardBody
 --(chunk F, P1 -- NOT the dock content root, to avoid duplicating the full base
@@ -3658,6 +3667,7 @@ CreateSoundboardButton = function(getBoardOrLegacyBoard, slot, opts)
 			},
 		}
 		muteButton = gui.Panel{
+			styles = { GLYPH_PRESS_SOUND },
 			classes = {"audioSbMute", "hoverable"},
 			bgimage = "ui-icons/ph-speaker-high-fill.png",
 			width = 12,
@@ -4066,6 +4076,7 @@ local function CreatePlayerSoundPanel()
 			{ bgimage = "ui-icons/ph-speaker-high-fill.png" },
 			{ selectors = {"muted"}, bgimage = "ui-icons/ph-speaker-slash-fill.png" },
 			{ selectors = {"hover"}, brightness = 2 },
+			GLYPH_PRESS_SOUND,
 		},
 	}
 
@@ -4452,6 +4463,7 @@ local function BuildSoundPanelContent()
 			{ bgimage = "ui-icons/ph-speaker-high-fill.png" },
 			{ selectors = {"muted"}, bgimage = "ui-icons/ph-speaker-slash-fill.png" },
 			{ selectors = {"hover"}, brightness = 2 },
+			GLYPH_PRESS_SOUND,
 		},
 	}
 
@@ -4460,6 +4472,7 @@ local function BuildSoundPanelContent()
 	--glyph). Hidden entirely when nothing is playing so the status row does not
 	--show a dead control at rest.
 	local stopAllButton = gui.Panel{
+		styles = { GLYPH_PRESS_SOUND },
 		classes = {"hidden"},
 		bgimage = "panels/square.png",
 		bgcolor = "white",
@@ -4606,6 +4619,7 @@ local function BuildSoundPanelContent()
 	--which one shows.
 	local pauseButton
 	pauseButton = gui.Panel{
+		styles = { GLYPH_PRESS_SOUND },
 		classes = {"hidden"},
 		bgimage = "ui-icons/ph-play-pause-fill.png",
 		width = 18,
@@ -4621,6 +4635,7 @@ local function BuildSoundPanelContent()
 		end,
 	}
 	local stopButton = gui.Panel{
+		styles = { GLYPH_PRESS_SOUND },
 		classes = {"hidden"},
 		bgimage = "ui-icons/ph-stop-fill.png",
 		bgcolor = "white",
@@ -4728,6 +4743,7 @@ local function BuildSoundPanelContent()
 	--valign=center inside the 18-tall transportRow so they sit flush with the
 	--other transport controls.
 	local shuffleChip = gui.Panel{
+		styles = { GLYPH_PRESS_SOUND },
 		classes = {"collapsed"},
 		bgimage = "ui-icons/ph-shuffle-fill.png",
 		--Default white; UpdateNowPlaying tints it to the theme accent while shuffle
@@ -4754,6 +4770,7 @@ local function BuildSoundPanelContent()
 		end,
 	}
 	local nextChip = gui.Panel{
+		styles = { GLYPH_PRESS_SOUND },
 		classes = {"collapsed"},
 		bgimage = "ui-icons/ph-skip-forward-fill.png",
 		bgcolor = "white",
@@ -4813,6 +4830,7 @@ local function BuildSoundPanelContent()
 				textOverflow = "ellipsis",
 			},
 			gui.Panel{
+				styles = { GLYPH_PRESS_SOUND },
 				bgimage = "ui-icons/ph-stop-fill.png",
 				bgcolor = "white",
 				width = 11,
@@ -4868,6 +4886,7 @@ local function BuildSoundPanelContent()
 				textOverflow = "ellipsis",
 			},
 			gui.Panel{
+				styles = { GLYPH_PRESS_SOUND },
 				bgimage = "ui-icons/ph-stop-fill.png",
 				bgcolor = "white",
 				width = 11,
@@ -5563,6 +5582,7 @@ local function BuildSoundPanelContent()
 			end
 
 			previewButton = gui.Panel{
+				styles = { GLYPH_PRESS_SOUND },
 				bgimage = "ui-icons/ph-headphones-fill.png",
 				bgcolor = "white",
 				width = 14,
@@ -6324,6 +6344,7 @@ local function BuildSoundPanelContent()
 			end
 
 			previewButton = gui.Panel{
+				styles = { GLYPH_PRESS_SOUND },
 				bgimage = "ui-icons/ph-headphones-fill.png",
 				bgcolor = "white",
 				width = 14,
@@ -6359,6 +6380,7 @@ local function BuildSoundPanelContent()
 
 			local onOffButton
 			onOffButton = gui.Panel{
+				styles = { GLYPH_PRESS_SOUND },
 				bgimage = "ui-icons/ph-speaker-slash-fill.png",
 				bgcolor = "white",
 				width = 16,
@@ -7384,6 +7406,7 @@ local CreateAudioStudioRow = function(audioAsset, opts)
 	local playButton
 	if not slim then
 		playButton = gui.Panel{
+			styles = { GLYPH_PRESS_SOUND },
 			classes = {"audioBroadcastButton"},
 			bgimage = "ui-icons/ph-play-fill.png",
 			width = 18,
@@ -7413,6 +7436,7 @@ local CreateAudioStudioRow = function(audioAsset, opts)
 	--so it clears when the clip ends or another row takes over.
 	local cueButton
 	cueButton = gui.Panel{
+		styles = { GLYPH_PRESS_SOUND },
 		classes = {"audioCueButton"},
 		bgimage = "ui-icons/ph-headphones-fill.png",
 		width = 18,
@@ -7465,6 +7489,7 @@ local CreateAudioStudioRow = function(audioAsset, opts)
 	local loopButton
 	if not slim then
 		loopButton = gui.Panel{
+			styles = { GLYPH_PRESS_SOUND },
 			classes = {"audioRowLoopButton", cond(audioAsset.loop, nil, "disabled")},
 			bgimage = "game-icons/infinity.png",
 			width = 16,
@@ -7494,6 +7519,7 @@ local CreateAudioStudioRow = function(audioAsset, opts)
 	local muteButton
 	if not slim then
 		muteButton = gui.Panel{
+			styles = { GLYPH_PRESS_SOUND },
 			classes = {"hoverable", "audioRowMuteButton"},
 			bgimage = "ui-icons/ph-speaker-high-fill.png",
 			bgcolor = "white",
@@ -7650,6 +7676,7 @@ local CreateAudioStudioRow = function(audioAsset, opts)
 			end
 		end
 		plusButton = gui.Panel{
+			styles = { GLYPH_PRESS_SOUND },
 			classes = {"audioAddTrackButton"},
 			bgimage = alreadyIn and "icons/standard/Icon_App_Check.png" or "ui-icons/Plus.png",
 			width = 18,
@@ -7725,6 +7752,7 @@ local CreateAudioStudioRow = function(audioAsset, opts)
 			end
 		end
 		plusButton = gui.Panel{
+			styles = { GLYPH_PRESS_SOUND },
 			classes = {"audioAddTrackButton"},
 			bgimage = alreadyIn and "icons/standard/Icon_App_Check.png" or "ui-icons/Plus.png",
 			width = 18,
@@ -10117,6 +10145,7 @@ local CreateStudioPlaylistsCard = function(heightSpec)
 
 		local pin
 		pin = gui.Panel{
+			styles = { GLYPH_PRESS_SOUND },
 			classes = {"audioPlPin", cond(pl.pinned, "pinned", nil)},
 			bgimage = "ui-icons/ph-push-pin-fill.png",
 			width = 16,
@@ -10215,6 +10244,7 @@ local CreateStudioPlaylistsCard = function(heightSpec)
 
 		local playButton
 		playButton = gui.Panel{
+			styles = { GLYPH_PRESS_SOUND },
 			classes = {"audioBroadcastButton"},
 			bgimage = "ui-icons/ph-play-fill.png",
 			width = 18,
@@ -10344,6 +10374,7 @@ local CreateStudioPlaylistsCard = function(heightSpec)
 			--already honors it); false = the playlist stops after its last track.
 			local loopToggle
 			loopToggle = gui.Panel{
+				styles = { GLYPH_PRESS_SOUND },
 				classes = {"audioRowLoopButton", cond(pl.loop ~= false, nil, "disabled")},
 				bgimage = "game-icons/infinity.png",
 				width = 16,
@@ -10902,6 +10933,7 @@ local CreateStudioVariantPoolsCard = function(heightSpec)
 		local lastFiredAssetId = nil
 		local cueButton
 		cueButton = gui.Panel{
+			styles = { GLYPH_PRESS_SOUND },
 			classes = {"audioCueButton"},
 			bgimage = "ui-icons/ph-headphones-fill.png",
 			width = 18,
@@ -11750,6 +11782,7 @@ local function CreateStudioNowPlayingStrip()
 				textOverflow = "ellipsis",
 			},
 			gui.Panel{
+				styles = { GLYPH_PRESS_SOUND },
 				bgimage = "panels/square.png",
 				bgcolor = "white",
 				width = 11,
@@ -11804,6 +11837,7 @@ local function CreateStudioNowPlayingStrip()
 				textOverflow = "ellipsis",
 			},
 			gui.Panel{
+				styles = { GLYPH_PRESS_SOUND },
 				bgimage = "panels/square.png",
 				bgcolor = "white",
 				width = 11,


### PR DESCRIPTION
## Summary
Two audio-panel fixes, both confined to `DMHub Core Panels/Audio.lua`.

The first is user report RXC87T4Y: a clip with no Category matched neither the
"music" nor the "ambience" lane, so the AUDIO dock rendered its idle "Nothing
playing" call-to-action on top of an audible track and left the playlist
transport chrome collapsed. A custom playlist built from such clips looked like
it did nothing.

The second is the glyph controls - transport, cue, play, loop, mute, pin,
add-track, stop - being the only buttons on the panel that press silently.

## Changes

**Uncategorised tracks now ride the music lane**
- `PlayingTracksForCategory` gains an `includeUncategorised` flag, backed by a new
  `NormalizedAudioCategory` helper that also de-duplicates the nil-vs-`""` handling
  the category dropdown was doing separately.
- Folded at four call sites: the DM dock, the player dock, `MusicChannelInstances`
  (without it the hero pause button is a dead control on an uncategorised track),
  and `PrimaryPlayingName`, which feeds the title-bar popover and told the same lie.
- The hero subtitle reads **"Uncategorised"** rather than "Music" for such a clip,
  with a tooltip reusing the Studio row dropdown's existing wording. The clip really
  is unrouted engine-side (`mixGroupId = nil`: no Levels fader, no Anthem duck), so
  the dock should not claim a Music routing it does not have.
- The player dock folds without the subtitle change - a player cannot set a
  category, so the nudge belongs on the DM side.
- One-shot effects stay out of the lane and still show the idle CTA, by design.

**Glyph controls press audibly**
- The app's generic click comes from a single rule in `DefaultStyles`,
  `{label, button, press} -> Mouse.Click`, which only text buttons match. Icon-only
  `gui.Button`s miss it as well (`{iconButton, press}` sets brightness but no
  `soundEvent`), so routing these through `gui.Button` would not have helped.
- One shared `GLYPH_PRESS_SOUND` rule spliced into 25 controls' own `styles` lists.
- A style rule rather than an `audio.FireSoundEvent` call in each press handler on
  purpose: the engine suppresses style sounds while the app is unfocused
  (`SheetPanel.UpdateStyle`), and these should behave like every other button
  instead of clicking in the background.
- Left silent deliberately: soundboard pads and the playlist track row (a row, not
  a button - and a pad already answers with its own clip), and the loop glyph, which
  is a no-op on pool pads and would click while doing nothing.

## Testing
Verified live in a running Codex over the MCP bridge - clean reload, no new console
errors:

- An uncategorised clip drives the hero card with the "Uncategorised" subtitle and
  its tooltip; `PrimaryPlayingName()` returns its name where it previously returned
  nil; pause, resume and stop all act on it.
- Glyph presses fire `Mouse.Click` and still perform their action. Note for anyone
  reproducing this: the bridge's default virtual input transport leaves the app
  unfocused, which suppresses these sounds and reads as a false negative - use
  `transport=os`.

## Notes for reviewer
Known residual on the second fix: a stop control that hides itself on press - the
hero stop on the last track, stop-all, a row's stop - stays silent, because the
panel is gone before the engine observes the style transition. Confirmed by
elimination: the same button does click when a second lane track keeps it on
screen. The audio stopping is its own feedback, so this is accepted rather than
hand-fired.

Not addressed here, deliberately: clips can still be created with no category at
all. `gui.AudioEditor`'s "Upload Audio" button stamps none (the Studio's own
"+ Add audio" does), and any clip uploaded before the category feature is
uncategorised forever with no backfill. That is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)