### PR TITLE
Restore three upstream commits reverted as collateral by 1a566f03

### DIFF
--- a/DMHub Game Rules/AbilitySummon.lua
+++ b/DMHub Game Rules/AbilitySummon.lua
@@ -1717,7 +1717,9 @@ function ActivatedAbilitySummonBehavior:Cast(ability, casterToken, targets, args
         local choices = {}
         if self.monsterType == "custom" then
             for k,monster in pairs(assets.monsters) do
-                if not assets:GetMonsterNode(k).hidden then
+                --GetMonsterNode can return nil mid-import/reload; skip rather than throw.
+                local node = assets:GetMonsterNode(k)
+                if node ~= nil and not node.hidden and monster.properties ~= nil then
                     args.symbols.beast = GenerateSymbols(monster.properties)
                     if monster.properties:has_key("monster_type") and ExecuteGoblinScript(self.bestiaryFilter, GenerateSymbols(casterToken.properties, args.symbols), 0, string.format("Bestiary filter for %s summons filter %s", ability.name, monster.properties.monster_type)) ~= 0 then
                         choices[#choices+1] = monster

--- a/Draw Steel Core Rules/MCDMCreature.lua
+++ b/Draw Steel Core Rules/MCDMCreature.lua
@@ -876,7 +876,12 @@ function creature:RefreshInitiativeInfo(token)
         if initiativeEntry ~= nil and initiativeEntry.initiativeid == initiativeid then
             self._tmp_initiativeStatus = "OurTurn"
         elseif not q:HasInitiative(initiativeid) then
-            self._tmp_initiativeStatus = "NonCombatant"
+            if self:try_get("treatAsObject", false) then
+                --Object-tagged creatures are scenery, not skipped combatants; don't grey them out.
+                self._tmp_initiativeStatus = nil
+            else
+                self._tmp_initiativeStatus = "NonCombatant"
+            end
         elseif q:HasHadTurn(initiativeid) then
             self._tmp_initiativeStatus = "Done"
         elseif q:ChoosingTurn() and q:IsPlayersTurn() == q:IsEntryPlayer(initiativeid) and (q:has_key("priorityids") == false or q:EntriesUnmoved()[initiativeid]) then

--- a/Draw Steel Core Rules/MCDMCreature.lua
+++ b/Draw Steel Core Rules/MCDMCreature.lua
@@ -5966,6 +5966,15 @@ function creature.TakeDamage(self, amount, note, info)
                     end
                 end
 
+                --Victim-side: the squad records its own losses (round-bucketed, so
+                --the victory screen can tell a squad wiped in round 1). Recorded
+                --with or without an attacker so environmental deaths count; the
+                --stat routes to the squad's initiative group.
+                local victimToken = dmhub.LookupToken(self)
+                if victimToken ~= nil then
+                    LiveEncounter.TrackHeroStats(victimToken.charid, "deaths", minionsKilled)
+                end
+
                 --batch for the squadminiondeaths trigger; see the batching
                 --machinery above TakeDamage. The batch flushes only once the
                 --director confirms the deaths.
@@ -6171,6 +6180,18 @@ function creature.TakeDamage(self, amount, note, info)
                     roundNumber = roundNumber,
                     dailyLimit = 20,
                 })
+
+                --Per-encounter combat stat: the attacker drove a hero to dying.
+                --Read by the victory screen's monster roles (Heartbreaker); the
+                --routing in TrackHeroStats credits a monster attacker's
+                --initiative group. Runs once here on the resolving client, at
+                --the not-dying -> dying transition.
+                if eventArg.attacker ~= nil then
+                    local attackerToken = dmhub.LookupToken(eventArg.attacker)
+                    if attackerToken ~= nil then
+                        LiveEncounter.TrackHeroStats(attackerToken.charid, "heroesDowned")
+                    end
+                end
             end
 
             self:DispatchEvent("dying", eventArg)
@@ -6234,22 +6255,38 @@ function creature.TakeDamage(self, amount, note, info)
             eventArg.usedability = eventArg.ability
             eventArg.hasattacker = eventArg.attacker ~= nil
 
+            --Per-encounter combat stat: a dying monster records its own death for
+            --its initiative group (round-bucketed, so the victory screen can tell
+            --a group that fell entirely in round 1). Recorded with or without an
+            --attacker so environmental deaths count; minions never reach this
+            --path (their squad's losses are recorded in the minion branch above).
+            if not self:IsHero() then
+                local victimToken = dmhub.LookupToken(self)
+                if victimToken ~= nil then
+                    LiveEncounter.TrackHeroStats(victimToken.charid, "deaths")
+                end
+            end
+
             if eventArg.attacker ~= nil then
                 --NOTE: We have to TriggerEvent here not DispatchEvent because
                 --DispatchEvent does not currently have support for dispatching
                 --creature objects and other self-referential objects.
                 eventArg.attacker:TriggerEvent("kill", eventArg)
 
-                --Per-encounter hero stat: credit the killer with a monster kill.
-                --Guarded to non-hero victims (a dying hero is not a "kill"); minions
-                --are counted separately as minionKills and never reach this path.
+                --Per-encounter combat stat: credit the killer. A non-hero victim
+                --is a "kill" (for a hero killer this feeds the hero roles; for a
+                --monster killer -- e.g. downing a hero's companion -- it routes to
+                --the monster's initiative group). A HERO victim is instead a
+                --"heroKill", the victory screen's Hero Slayer role. Minions are
+                --counted separately as minionKills and never reach this path.
                 --This runs once on the resolving client as the victim transitions
-                --to dead. TrackHeroStats self-guards to heroes, so a monster killing
-                --a monster is dropped.
-                if not self:IsHero() then
-                    local killerToken = dmhub.LookupToken(eventArg.attacker)
-                    if killerToken ~= nil then
+                --to dead.
+                local killerToken = dmhub.LookupToken(eventArg.attacker)
+                if killerToken ~= nil then
+                    if not self:IsHero() then
                         LiveEncounter.TrackHeroStats(killerToken.charid, "kills")
+                    else
+                        LiveEncounter.TrackHeroStats(killerToken.charid, "heroKills")
                     end
                 end
             end


### PR DESCRIPTION
## What this does

Restores three upstream commits that were reverted as collateral by `1a566f03` (the squad-minion-deaths commit, merged via #191).

That branch was built by copying whole files over a fresh branch off `main`, and the working copies were based on an older `main` — so anything merged in between was silently reverted by the copy. #189 landed the day before the branch was cut, which is why it was hit.

Five upstream changes were affected in total. Two were already corrected in `cbe31aeb` (the #189 `GroupingHud` ordering and the `CalculateNamedCustomAttribute` cache fix). This PR restores the remaining three, one commit each.

## Commits

**`28545165` — "Creatures treated as objects do not grey out"**
Restores the `treatAsObject` branch in `RefreshInitiativeInfo`, so object-tagged creatures read as scenery rather than as skipped combatants.

**`fb62407e` — "Monster-side stat tracking and a defeat outcome screen"**
Restores all four hooks:
- minion branch: victim-side squad `deaths` (recorded with or without an attacker, so environmental deaths count)
- dying transition: attacker credited `heroesDowned`
- death path: non-hero victim records its own `deaths`
- death path: killer credit split into `kills` vs `heroKills` by victim type

Worth noting: `DSVictoryScreen` still *reads* `heroesDowned` and `heroKills`, but nothing has written them since July 31 — so the Heartbreaker and Hero Slayer roles have been silently reading zero.

One nuance: this commit's structural change to the minion branch (counting kills without requiring an attacker) is already present on `main`, because the squad-minion-deaths rework happened to reintroduce it. Only the victim-side stat was actually missing there; it now sits alongside the `AccumulateSquadMinionDeaths` call.

**`dd499912` — "Speculative fix for Summoner Call Forth"**
Restores the nil-guard on `assets:GetMonsterNode` in the custom-summon bestiary loop, so a node resolving to nil mid-import/reload is skipped rather than throwing.

## How this was built

Hand-applied hunk by hunk onto current `main` — no file copies this time. Verified that every line added by the three original commits is present again (40/40, 4/4, 3/3), and `luac -p` passes on both files.

I also swept every upstream commit touching these four files since April, comparing against the pre-`1a566f03` base, that commit's tree, and current `main`, to confirm nothing else was caught in the same revert. Everything else that flagged resolved as intentional — signature and call-site changes from the squad-minion-deaths work, comment rewrites, and the condition-immunity fallback rewrite.

## Testing

Not runtime-tested: this restores code that already shipped and was in use before the revert. Happy to verify in-app if preferred — the observable check is that Heartbreaker / Hero Slayer start recording again on the victory screen, and that object-tagged creatures no longer grey out in initiative.
