### PR TITLE
Fix Hidden creatures being skipped by map-wide abilities (report W3XG4YSE)

### DIFF
--- a/Draw Steel Core Rules/MCDMRules.lua
+++ b/Draw Steel Core Rules/MCDMRules.lua
@@ -1316,7 +1316,12 @@ function GameSystem.AllowTargeting(casterToken, targetToken, ability)
 	-- enemies lose non-Area targeting (including free strikes), while allies
 	-- can still target them normally. Area abilities are unaffected, so a
 	-- hidden creature standing in a swept area is still hit.
-	if (not targetToken.isObject) and (not ability:HasKeyword("Area"))
+	-- Map-wide effects (targetType "map", e.g. goblin malice "Swamp Stink") are
+	-- area effects that carry no keywords in their stat block, so the Area
+	-- keyword alone does not recognise them. They affect everyone on the map
+	-- and target no one in particular, so Hidden must not exempt a creature.
+	local isAreaAbility = ability:HasKeyword("Area") or ability.targetType == "map"
+	if (not targetToken.isObject) and (not isAreaAbility)
 		and (not casterToken:IsFriend(targetToken))
 		and targetToken.properties:HasCondition(g_hiddenConditionId) ~= false then
 		return false


### PR DESCRIPTION
**Symptom:** A creature with the Hidden condition is never prompted for its resistance roll by map-wide abilities such as the goblin malice ability "Swamp Stink".

**Root cause:** For `targetType == "map"`, the Director's client builds the shape via `dmhub.CalculateShape{shape = "map"}` and then filters every token through `ActivatedAbility:TargetPassesFilter`, which calls `GameSystem.AllowTargeting`. The Hidden gate in that function exempts a hidden creature from any ability that lacks the `Area` keyword. Map-wide malice abilities like Swamp Stink have `targetType: map` and no keywords at all in their stat block, so `HasKeyword("Area")` is false and every hidden creature is filtered out before the resistance roll is requested.

**Fix:** In `Draw Steel Core Rules/MCDMRules.lua`, `GameSystem.AllowTargeting` now treats `targetType == "map"` as an area ability for the purposes of the Hidden gate, exactly like the `Area` keyword. Map-wide effects affect everyone on the map and target no one in particular, so Hidden must not exempt a creature from them.

This only *widens* the set of allowed targets, and only for abilities that already affect the entire encounter map, so no existing single-target or strike behaviour changes. The other checks in the function (isObject / IsFriend / HasCondition, Untargetable By Strikes, Targeting Group) are untouched, and the change deliberately does not use the broader `IsTargetTypeAOE()`.

Report id: W3XG4YSE

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
