### PR TITLE
Fix confirm-delete dialogs appearing in main window instead of popout (report D2DHERJE)

### DIFF
--- a/DMHub Core UI/Gui.lua
+++ b/DMHub Core UI/Gui.lua
@@ -520,20 +520,21 @@ function gui.Button(options)
 					local oldClick = args[clickid]
 					args[clickid] = function(element)
 						gui.ModalMessage{
+							owner = element,
 							title = cfg.title,
 							message = cfg.message,
 							options = {
 								{
 									text = "Cancel",
 									execute = function()
-										gui.CloseModal()
+										gui.CloseModal(element)
 									end,
 								},
 								{
 									text = cfg.actionText,
 									execute = function()
 										oldClick(element)
-										gui.CloseModal()
+										gui.CloseModal(element)
 									end,
 								},
 							},
@@ -842,20 +843,21 @@ function gui.DeleteItemButton(options)
             local oldClick = args[clickid]
             args[clickid] = function(element)
                 gui.ModalMessage{
+                    owner = element,
                     title = "Confirm Delete",
                     message = "Are you sure you want to delete this item?",
                     options = {
                         {
                             text = "Cancel",
                             execute = function()
-                                gui.CloseModal()
+                                gui.CloseModal(element)
                             end,
                         },
                         {
                             text = "Delete",
                             execute = function()
                                 oldClick(element)
-                                gui.CloseModal()
+                                gui.CloseModal(element)
                             end,
                         },
                     },


### PR DESCRIPTION
**Symptom:** With the Compendium popped out into its own OS window, clicking a delete (trash) button shows the "Confirm Delete" dialog in the main app window instead of in the popout the click came from.

**Root cause:** `Hud.ResolveModalLayer(owner)` (`DMHub Core UI/Hud.lua`) returns a popout window's own `popoutModalLayer` only when it is given an `owner` element that lives under that window's root; with no owner it returns the global main-window `modalPanel`. `Hud:ModalMessage` forwards `args.owner` to `ShowModal`, but the two shared confirmation wrappers -- the `requireConfirm` path in `gui.Button` and `gui.DeleteItemButton` -- called `gui.ModalMessage{...}` without an `owner`, so their dialogs always landed on the main window.

**Fix:** In both wrappers, pass the clicked button panel as `owner = element` to `gui.ModalMessage`, and pass the same element to the `gui.CloseModal` calls in the Cancel/confirm option handlers. `element` is always a live panel in the same hierarchy as the button, and `ResolveModalLayer` nil/validity-guards its argument, so for any button in the main window the resolved layer is byte-for-byte the same global `modalPanel` as before. Only buttons living under a native popout root change behaviour, and they now parent into that window's own modal layer. This covers every `requireConfirm` delete button in any popped-out window (Compendium, character sheet, document system, PDF viewer) at once.

Report id: D2DHERJE

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
