### PR TITLE
Fix Prepare Combat EV ignoring monster level adjustments (report 9A4JYBGU)

### DIFF
--- a/Draw Steel UI/DSInitiativeRoll.lua
+++ b/Draw Steel UI/DSInitiativeRoll.lua
@@ -1473,13 +1473,16 @@ local function ShowCombatSetupDialog(selectedTokens, preselectEncounter, presele
                     for i,child in ipairs(children) do
                         local group = child.data.group
                         for _,tok in ipairs(group.tokens) do
-                            local monsterEV = tok.valid and tok.properties:try_get("ev")
-                            if monsterEV == nil then
+                            local authoredEV = tok.valid and tok.properties:try_get("ev")
+                            if authoredEV == nil then
                                 evvalid = false
-                            elseif tok.properties.minion then
-                                ev = ev + monsterEV/GameSystem.minionsPerSquad
                             else
-                                ev = ev + monsterEV
+                                local monsterEV = tok.properties:EV()
+                                if tok.properties.minion then
+                                    ev = ev + monsterEV/GameSystem.minionsPerSquad
+                                else
+                                    ev = ev + monsterEV
+                                end
                             end
                         end
                     end


### PR DESCRIPTION
**Symptom:** The Prepare Combat / "Drawsteel!" dialog reports a lower encounter EV (and therefore a lower difficulty tier) than the selected-tokens side panel for the same monsters.

**Root cause:** In `Draw Steel UI/DSInitiativeRoll.lua`, the monster-side `refreshSurprise` handler accumulated `tok.properties:try_get("ev")` -- the raw stored field. `MCDMMonster.lua` documents that EV must be read through `monster:EV()` so that "Modify Attributes" CharacterModifiers targeting the `ev` attribute are applied, and `MCDMMonsterScaling.BuildAdjustmentFeature` generates exactly such a modifier for every level-adjusted monster. So level-adjusted monsters were counted at their authored EV rather than their effective EV.

In the reported game: 24 Dwarf Driver minions (authored ev 3, adjusted to an effective 5) + 2 Dwarf Gunner captains (ev 6) + 1 Dwarf Marauder Lord (ev 20). Raw total = 50, which is what Prepare Combat printed; effective total = 62, which is what the side panel printed.

**The fix:** Read the per-token EV via `tok.properties:EV()` when accumulating. The `try_get("ev")` probe is kept as the validity check and renamed to `authoredEV` -- `EV()` falls back to `self.ev or 1` and never returns `nil`, so using it for the nil check would silently turn "this monster has no authored EV" into "EV 1" and defeat the existing `evvalid = false` guard that blanks the label. The minion `/GameSystem.minionsPerSquad` rule, the `tok.valid` short-circuit, and the difficulty-tier logic are unchanged.

This makes the dialog agree with the two places that already do this: the selected-tokens EV chip (`MCDMCharacterPanel.lua:9219`) and `Encounter.PartyStrengthFromTokens` (`MCDMEncounter.lua:458`), both of which use `:EV()` with the identical minion rule -- as does this dialog's own hero side.

Verified with `luac -p`; diff is ASCII-only.

Report: `9A4JYBGU`. Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
