### PR TITLE
feat(hide): show enemy sight-line arrows on "you may hide" cast prompts

### DIFF
--- a/DMHub Game Rules/AbilityInvokeAbility.lua
+++ b/DMHub Game Rules/AbilityInvokeAbility.lua
@@ -131,6 +131,13 @@ ActivatedAbility.RegisterType
 ActivatedAbilityInvokeAbilityBehavior.summary = 'Invoke Ability'
 ActivatedAbilityInvokeAbilityBehavior.promptText = ''
 
+--Set on invokes whose prompt asks the player to decide a hide that depends on
+--cover or concealment: the invoked ability shows the Hide maneuver's red enemy
+--sight-line arrows while its prompt is up. It lives here rather than on the
+--invoked ability because the "may hide" helper abilities are shared by content
+--whose rules differ -- some grant the hide with no cover needed at all.
+ActivatedAbilityInvokeAbilityBehavior.hideSightlines = false
+
 --if true we will invoke on the caster token.
 ActivatedAbilityInvokeAbilityBehavior.invokeOnCaster = false
 ActivatedAbilityInvokeAbilityBehavior.runOnController = false
@@ -549,6 +556,7 @@ function ActivatedAbilityInvokeAbilityBehavior:Cast(ability, casterToken, target
                         abilityAttr = {
                             promptOverride = cond(self.promptText ~= "", StringInterpolateGoblinScript(self.promptText, casterToken.properties:LookupSymbol{})),
                             disableSquadCoordination = cond(not self:try_get("useSquadCoordination", false), true),
+                            hideSightlines = cond(self:try_get("hideSightlines", false), true),
                         }
                     }
 
@@ -715,6 +723,10 @@ function ActivatedAbilityInvokeAbilityBehavior:Cast(ability, casterToken, target
 
                         if self.promptText ~= "" then
                             abilityClone.promptOverride = StringInterpolateGoblinScript(self.promptText, casterToken.properties:LookupSymbol{})
+                        end
+
+                        if self:try_get("hideSightlines", false) then
+                            abilityClone.hideSightlines = true
                         end
 
                         -- Apply forced movement bonuses if this is a forced movement ability
@@ -1624,6 +1636,14 @@ function ActivatedAbilityInvokeAbilityBehavior:EditorItems(parentPanel)
 		value = self:try_get("useSquadCoordination", false),
 		change = function(element)
 			self.useSquadCoordination = element.value
+		end,
+	}
+
+	result[#result+1] = gui.Check{
+		text = "Show Hide Sight-Lines",
+		value = self:try_get("hideSightlines", false),
+		change = function(element)
+			self.hideSightlines = element.value
 		end,
 	}
 

--- a/Draw Steel Core Rules/MCDMActivatedAbility.lua
+++ b/Draw Steel Core Rules/MCDMActivatedAbility.lua
@@ -4,6 +4,14 @@ local mod = dmhub.GetModLoading()
 --kept as a default so old serialized data doesn't error on access.
 ActivatedAbility.effectImplemented = true
 
+--hideSightlines: while this ability waits at its cast confirmation prompt, the
+--action bar draws red sight-line arrows from every enemy with a clear view of
+--the caster -- the same arrows the Hide maneuver's cover-or-concealment gate
+--shows on hover. Set it on "you may hide" prompt abilities (e.g. the one Black
+--Ash Teleport invokes after the teleport) so the player can see who would spot
+--them before deciding to hide.
+ActivatedAbility.hideSightlines = false
+
 local g_settingTargetObjects = setting {
     id = "targetobjects",
     default = false,

--- a/DrawSteelActionBar/DrawSteelActionBar.lua
+++ b/DrawSteelActionBar/DrawSteelActionBar.lua
@@ -10763,7 +10763,7 @@ CreateAbilityController = function()
             FreeTargetLineOfSightRays()
 
             --Free any hide-prompt sight-line arrows owned by the cast prompt.
-            if g_filterSightlineOwner == "castPrompt" then
+            if g_filterSightlines.owner == "castPrompt" then
                 ClearFilterSightlineRays()
             end
             element.mapfocus = false
@@ -13178,7 +13178,7 @@ CalculateSpellTargeting = function(forceCast, initialSetup)
             --arrows; cancelCasting clears them.
             if g_currentAbility:try_get("hideSightlines", false) then
                 ShowFilterSightlineRays("castPrompt")
-            elseif g_filterSightlineOwner == "castPrompt" then
+            elseif g_filterSightlines.owner == "castPrompt" then
                 ClearFilterSightlineRays()
             end
 

--- a/DrawSteelActionBar/DrawSteelActionBar.lua
+++ b/DrawSteelActionBar/DrawSteelActionBar.lua
@@ -10761,6 +10761,11 @@ CreateAbilityController = function()
             g_currentAbility = nil
             g_currentSymbols = {}
             FreeTargetLineOfSightRays()
+
+            --Free any hide-prompt sight-line arrows owned by the cast prompt.
+            if g_filterSightlineOwner == "castPrompt" then
+                ClearFilterSightlineRays()
+            end
             element.mapfocus = false
             element.captureEscape = false
 
@@ -13164,6 +13169,18 @@ CalculateSpellTargeting = function(forceCast, initialSetup)
             end
             g_castMessage.data.promptText = promptText
             g_castMessage:FireEvent("refresh")
+
+            --A hideSightlines ability (e.g. the "you may hide" prompt Black Ash
+            --Teleport invokes after the teleport lands) shows the Hide gate's red
+            --enemy sight-line arrows while its confirmation prompt is up, so the
+            --player can see who would spot them before choosing to hide. The
+            --"castPrompt" owner string keeps these distinct from hover-owned
+            --arrows; cancelCasting clears them.
+            if g_currentAbility:try_get("hideSightlines", false) then
+                ShowFilterSightlineRays("castPrompt")
+            elseif g_filterSightlineOwner == "castPrompt" then
+                ClearFilterSightlineRays()
+            end
 
             g_castModesPanel:FireEvent("refreshModes")
             g_forcedMovementTypePanel:FireEvent("refreshForcedMovement")


### PR DESCRIPTION
## What

The Hide maneuver already draws red arrows from every enemy with a clear view of the caster when its cover-or-concealment gate blocks it. Abilities that *offer* a hide as part of their resolution put the same decision in front of the player with no such feedback -- **Black Ash Teleport** most visibly, where there was no way to tell whether the square you just teleported into actually let you hide.

This adds an opt-in `hideSightlines` flag. While a flagged ability waits at its cast confirmation prompt, the action bar shows the Hide gate's arrows.

## How

- `DrawSteelActionBar.lua` calls the existing `ShowFilterSightlineRays` from `CalculateSpellTargeting`'s confirmation branch, so the arrows' verdict always matches the Hide maneuver's own gate -- same hider-favoring cover bias (`GetCoverInfo(..., favorTarget = true)`), same early-out when the caster is already concealed.
- Arrows are owned by a `"castPrompt"` key so they never clobber, or get clobbered by, the hover-owned arrows on a suppressed ability heading. They are freed in `cancelCasting`, which both **Confirm** (via `finishCasting`) and **Skip** route through.
- The switch lives on `ActivatedAbilityInvokeAbilityBehavior`, per invoke site. It is copied onto the invoked ability's clone next to `promptOverride`, and passed through `abilityAttr` on the remote path so a player-controlled hero sees the arrows on their own client. A **"Show Hide Sight-Lines"** checkbox makes it authorable in the ability editor.
- `ActivatedAbility.hideSightlines` is declared as a default in `MCDMActivatedAbility.lua`; every read goes through `try_get`.

## Why per invoke site, not on the shared helper

The obvious approach -- flagging the shared "may hide" standard abilities -- is too blunt. Those helpers are used by content whose rules differ. The demon's **Vanish** ("hidden *regardless of whether they have cover or concealment*") and the Insurgent's **"Squad! Hit and Run!"** ("even if they have *no* cover or concealment") both route through `Shift and Hide`; red arrows there would tell the player the opposite of the rule. Per-site opt-in keeps those untouched.

Note that an invoke with no `promptText` has no confirmation step, so it can never show these arrows -- that is why the base Defensive Roll invoke is not flagged.

## Data

The matching data already landed in `draw-steel-data` (`475b953`), and the `data` submodule pointer on `main` already contains it. Flagged sites are hero-only: Black Ash Teleport, Cinderstorm (x2), Smoke Bomb, and the level-5 Defensive Roll. Monster content is deliberately untouched.

## Testing

Verified live in a running game, both directions:
- Black Ash Teleport from a Polder Shadow with cover from the only enemy in the initiative queue -> prompt appears, no arrows (correct).
- Repositioned into the open with clear line of sight -> red arrow drawn from that enemy; Skip cleared it.
- Re-verified after rebase in a second game against a 10-enemy encounter: arrows drew from exactly the enemies with a clear view of the destination square.
- Cancel path exercised explicitly (the cleanup runs through `cancelCasting`), no console errors.

## Notes

- Pure additions: 3 files, 45 lines. An ability without the flag is entirely unaffected.
- Known limitation: arrows appear at the prompt (after the move), not while aiming the destination. Showing them for a *hovered square* would need an engine change -- `MarkLineOfSight`/`GetCoverInfo` are token-to-token only and have no location-based form.
- Rebased onto current `main`. This matters: `main` has since consolidated the sight-line locals into a single `g_filterSightlines` table (the file is at Lua's 200 top-level-locals ceiling), and the branch uses `g_filterSightlines.owner` accordingly.