### PR TITLE
fix(conditions): show rules text for conditions applied as timed effects

### DIFF
--- a/DMHub Game Rules/OngoingEffect.lua
+++ b/DMHub Game Rules/OngoingEffect.lua
@@ -168,6 +168,26 @@ function CharacterOngoingEffect:GetDisplayDisplay()
 	return self.display
 end
 
+--Rules text for tooltips. A duration-only effect ("Frightened (save ends)") has no
+--description of its own, so fall back to the linked condition's rules.
+--Static, not a method: hot reload does not add methods to already-deserialized table
+--entries, so effect:GetDisplayDescription() would raise until the next restart.
+function CharacterOngoingEffect.GetDisplayDescription(effect)
+	local desc = effect:try_get("description", "")
+	if desc ~= "" then
+		return desc
+	end
+
+	if effect.condition ~= "none" then
+		local cond = effect:GetCondition()
+		if cond ~= nil then
+			return cond:try_get("description", "")
+		end
+	end
+
+	return ""
+end
+
 function CharacterOngoingEffect:GetEndAbility()
 	if self.canEndWithAction then
 		local resourceid = self.endActionType

--- a/DMHub Token UI/TokenUI.lua
+++ b/DMHub Token UI/TokenUI.lua
@@ -338,36 +338,34 @@ local CalculateStatusIcons = function(token)
                         casterid = casterInfo.tokenid
                     end
 
+					--Rules text first, caster appended -- the caster used to replace the rules.
+					local title = ongoingEffectInfo.name
+					if condInfo ~= nil then
+						title = condInfo.name
+					end
+
+					local stacksText = ""
+					if ongoingEffectInfo.stackable and cond.stacks > 1 then
+						stacksText = string.format(" (%d)", cond.stacks)
+					end
+
+					local descText = CharacterOngoingEffect.GetDisplayDescription(ongoingEffectInfo)
+					if descText ~= "" then
+						hoverText = string.format("%s%s: %s", title, stacksText, descText)
+					else
+						hoverText = string.format("%s%s", title, stacksText)
+					end
+
 					if condInfo ~= nil and casterInfo ~= nil and casterInfo.tokenid ~= nil then
 						local casterToken = dmhub.GetTokenById(casterInfo.tokenid)
 						if casterToken ~= nil then
-							hoverText = string.format("%s: %s", condInfo.name, casterToken.description)
-							casterid = casterInfo.tokenid
-						else
-							hoverText = "no caster"
+							hoverText = string.format("%s\n\nInflicted by %s", hoverText, casterToken.description)
 						end
-					elseif condInfo ~= nil then
-						if condInfo.description ~= "" then
-							hoverText = string.format("%s: %s", condInfo.name, condInfo.description)
-						else
-							hoverText = condInfo.name
-						end
-					else
-
-						local stacksText = ""
-						if ongoingEffectInfo.stackable and cond.stacks > 1 then
-							stacksText = string.format(" (%d)", cond.stacks)
-						end
-						if ongoingEffectInfo.description ~= "" then
-							hoverText = string.format("%s%s: %s", ongoingEffectInfo.name, stacksText, ongoingEffectInfo.description)
-						else
-							hoverText = ongoingEffectInfo.name
-						end
-
-                        if rawget(cond, "sourceDescription") ~= nil and cond.sourceDescription ~= "" then
-                            hoverText = hoverText .. "\n\n" .. cond.sourceDescription
-                        end
 					end
+
+                    if rawget(cond, "sourceDescription") ~= nil and cond.sourceDescription ~= "" then
+                        hoverText = hoverText .. "\n\n" .. cond.sourceDescription
+                    end
 
 					result[#result+1] = {
 						id = cond.ongoingEffectid,

--- a/Draw Steel Core Rules/MCDMCharacterPanel.lua
+++ b/Draw Steel Core Rules/MCDMCharacterPanel.lua
@@ -9494,7 +9494,7 @@ function TacPanel.StatusEffectTooltipText(entry, info, creature)
     end
     return string.format('<b>%s</b>%s: %s%s%s',
         info.name, stacksText,
-        StringInterpolateGoblinScript(info.description, creature),
+        StringInterpolateGoblinScript(CharacterOngoingEffect.GetDisplayDescription(info), creature),
         casterText, timeText)
 end
 


### PR DESCRIPTION
## The bug

Hovering a condition showed its rules for some applications and not others. Werewolf's Howl is the clean repro: tier 2 (`Frightened (EoT)`) hovered with the full rules, tier 1 (`frightened (save ends)`) hovered as the bare string **`Frightened: Werewolf`**.

## Why

A condition reaches a creature by one of two routes, rendered by different code:

| Route | Where it lands | Tooltip source |
|---|---|---|
| Applied outright, e.g. tier text `Frightened (EoT)` | `inflictedConditions` | `creature:FillCalculatedStatusIcons` -> `conditionInfo.description` ✅ |
| Applied with a duration, e.g. `frightened (save ends)` | a `CharacterOngoingEffect` wrapper | its own `description`, which is `""` ❌ |

The duration wrapper links the real condition through its `condition` field but carries no rules text of its own. **14 such wrappers exist**, covering Dazed, Frightened, Grabbed, Hidden, Invisible, On Fire, Prone, Restrained, Slowed and Taunted — so any of those applied as save-ends or EoT showed nothing.

The token HUD compounded it: when the effect tracked a caster it printed the caster's name *instead of* the rules, which is where `Frightened: Werewolf` came from.

## The fix

`CharacterOngoingEffect.GetDisplayDescription(effect)` returns the effect's own description, or falls back to the linked condition's rules when it has none — mirroring the existing `GetDisplayIcon` / `GetDisplayDisplay` fallbacks, so rules text stays single-sourced on the condition rather than being copied into 14 wrappers.

Wired into both tooltip surfaces:
- `DMHub Token UI/TokenUI.lua` — token-HUD hover; caster is now appended **below** the rules instead of replacing them
- `Draw Steel Core Rules/MCDMCharacterPanel.lua` — `TacPanel.StatusEffectTooltipText`, the character-panel chip

### Why a static and not a method

A hot reload does not attach newly-added methods to table entries that were already deserialized — `effect:GetDisplayDescription()` raises `Attempt to read unknown field ... in type CharacterFeature` until the next restart, which took out the token HUD mid-session while I was testing. Static lookup goes through the type table and resolves immediately. There is a comment on the function saying so.

## Verified

Live, against the session that produced the report:

- Eleven's `Frightened (save ends)` renders 476 chars of rules + `Inflicted by Werewolf` + `save ends`
- All 16 condition-linked ongoing effects resolve to real rules text; **0 blank** (was 14)
- Forced full token-HUD rebuild, no errors on the tooltip path
- `luac -p` clean on all three files

## Not in this PR

Compendium description fixes ride in `draw-steel-data` separately: Grabbed and Hidden were placeholder/incomplete, and Careful Observation, Vengeance Sigil and Mark were empty or stub text. Those need a submodule pointer bump once merged.