### PR TITLE
fix(movement): keep the movement tooltip off the cursor during ability targeting

### DIFF
--- a/DMHub Game Hud/GameHud.lua
+++ b/DMHub Game Hud/GameHud.lua
@@ -424,6 +424,87 @@ local function DiagramRender(diagramPanel, token, path, alternates, damages)
 	return true
 end
 
+--Where to put the movement tooltip so it never covers the mover, the destination or
+--the arrow: just outside the bounding box of the whole path, on whichever side has
+--the most room inside dmhub.cameraUsableBounds -- the same rect Panel.ShowTooltip
+--clamps to, so the clamp cannot drag it back over the box. Anchoring at the box EDGE
+--makes the clearance independent of the tooltip's size. All world coordinates:
+--valign 'top' = higher world y, halign 'right' = higher world x. The returned anchor
+--is a world point, which FloatTooltipNearTile accepts in place of a Loc.
+--Shared by the drag-move flow (GameHud.TokenMoving) and ability movement targeting
+--(ShowMovementDiagram in DrawSteelActionBar.lua).
+--- @param token CharacterToken the moving token
+--- @param path LuaPath the (previewed) movement path
+--- @return Vector2 anchor, string halign, string valign
+function GameHud.MovementTooltipPlacement(token, path)
+	--Bounding box of the whole path, expanded by the mover's footprint (+ a bit for the arrow ribbon).
+	local pad = (token.tileSize or 1)*0.5 + 0.15
+	local minx, miny, maxx, maxy = nil, nil, nil, nil
+	for _,step in ipairs(path.steps) do
+		local p = token:PosAtLoc(step)
+		if minx == nil then
+			minx, miny, maxx, maxy = p.x, p.y, p.x, p.y
+		else
+			if p.x < minx then minx = p.x elseif p.x > maxx then maxx = p.x end
+			if p.y < miny then miny = p.y elseif p.y > maxy then maxy = p.y end
+		end
+	end
+	if minx == nil then
+		local p = token:PosAtLoc(path.destination)
+		minx, miny, maxx, maxy = p.x, p.y, p.x, p.y
+	end
+	minx, miny, maxx, maxy = minx - pad, miny - pad, maxx + pad, maxy + pad
+
+	--Keep the hovered tile inside the box too: during ability targeting it can be well
+	--outside the path -- a jump that lands short at a wall while the user aims past it --
+	--and a tooltip just off the path box would then sit on the cursor. mouseLoc is nil
+	--when the pointer is over UI rather than the map.
+	local mouseLoc = dmhub.mouseLoc
+	if mouseLoc ~= nil then
+		local cursorPad = 1.2
+		if mouseLoc.x - cursorPad < minx then minx = mouseLoc.x - cursorPad end
+		if mouseLoc.x + cursorPad > maxx then maxx = mouseLoc.x + cursorPad end
+		if mouseLoc.y - cursorPad < miny then miny = mouseLoc.y - cursorPad end
+		if mouseLoc.y + cursorPad > maxy then maxy = mouseLoc.y + cursorPad end
+	end
+
+	local cx = (minx + maxx)*0.5
+	local cy = (miny + maxy)*0.5
+	local gap = 0.3
+
+	--rough OVER-estimate of the tooltip's world size (text + diagram), used only to pick the roomiest
+	--side. Over-estimating is safe: it just biases us away from a side that is too tight.
+	local worldPerPixel = 0.1
+	local screenDims = dmhub.screenDimensions
+	if dmhub.cameraZoom ~= nil and screenDims ~= nil and screenDims.y > 0 then
+		worldPerPixel = (dmhub.cameraZoom*2) / screenDims.y
+	end
+	local ttW = 430 * worldPerPixel
+	local ttH = 640 * worldPerPixel
+
+	--Four candidate placements: tooltip fully outside the box, one per side. `slack` is how much room is
+	--left over after fitting the tooltip on that side (positive = fits without the clamp shoving it back).
+	local halign, valign, anchorx, anchory
+	local bounds = dmhub.cameraUsableBounds
+	if bounds == nil then
+		halign, valign, anchorx, anchory = 'right', 'center', maxx + gap, cy
+	else
+		local candidates = {
+			{ slack = (bounds.x2 - maxx) - ttW, halign = 'right',  valign = 'center', anchorx = maxx + gap, anchory = cy },
+			{ slack = (minx - bounds.x1) - ttW, halign = 'left',   valign = 'center', anchorx = minx - gap, anchory = cy },
+			{ slack = (bounds.y2 - maxy) - ttH, halign = 'center', valign = 'top',    anchorx = cx, anchory = maxy + gap },
+			{ slack = (miny - bounds.y1) - ttH, halign = 'center', valign = 'bottom', anchorx = cx, anchory = miny - gap },
+		}
+		local best = candidates[1]
+		for i = 2, #candidates do
+			if candidates[i].slack > best.slack then best = candidates[i] end
+		end
+		halign, valign, anchorx, anchory = best.halign, best.valign, best.anchorx, best.anchory
+	end
+
+	return core.Vector2(anchorx, anchory), halign, valign
+end
+
 --The diagram panel that lives inside the map tooltip. Updates (or collapses)
 --in response to the "args" event fired on the tooltip tree by the tiletooltip
 --handler below.
@@ -1503,6 +1584,28 @@ dmhub.CreateGameHud = function(dialog, tokenInfo)
 							interactable = false,
 							halign = halign,
 							valign = valign,
+
+							--Cursor dodge: while the cursor is inside the tooltip's
+							--bounds, fade the tree so the map stays readable. Opacity
+							--does not cascade, so the class goes on every panel
+							--(SetClassTree). Fading rather than hiding or moving keeps
+							--the geometry stable, so this cannot oscillate.
+							styles = {
+								{
+									selectors = {"cursor-under-tooltip"},
+									opacity = 0.1,
+									transitionTime = 0.1,
+								},
+							},
+							thinkTime = 0.05,
+							think = function(element)
+								--mousePoint is normalized within the panel; values outside
+								--(0,1) -- including the (0,0) reported when the mouse is
+								--elsewhere -- mean the cursor is not over the tooltip.
+								local p = element.mousePoint
+								local over = p ~= nil and p.x > 0 and p.x < 1 and p.y > 0 and p.y < 1
+								element:SetClassTree("cursor-under-tooltip", over)
+							end,
 						}
 					)
 				)

--- a/Draw Steel UI/DSHud.lua
+++ b/Draw Steel UI/DSHud.lua
@@ -350,76 +350,14 @@ function GameHud.TokenMoving(self, token, path)
         text = path.properties.overrideText
     end
 
-	--Place the movement tooltip so it can NEVER cover the moving token, the destination, or any part of
-	--the arrow. We build the axis-aligned bounding box of the WHOLE path -- every tile the mover steps
-	--through, each expanded by the mover's footprint (so both end tokens sit fully inside) plus a little
-	--for the arrow ribbon -- and then place the tooltip entirely OUTSIDE that box on one of its four
-	--sides. Anchoring at the box EDGE (rather than the old midpoint + perpendicular nudge) pins the
-	--tooltip's near, box-facing edge to the box boundary independent of the tooltip's size, so it clears
-	--the entire path at any move angle or length; it also removes the one-frame size-lag wobble the old
-	--version had (where the previously hovered tile appeared to influence the placement). We choose the
-	--side with the most room for the tooltip, computed from the camera's usable world bounds (the same
-	--rect Panel.ShowTooltip clamps to) so the on-screen clamp won't drag it back over the box. Everything
-	--here is in world coordinates: PosAtLoc, cameraUsableBounds and the ShowTooltip anchor share that
-	--space (valign 'top' = higher world y, halign 'right' = higher world x).
-
-	--Bounding box of the whole path, expanded by the mover's footprint (+ a bit for the arrow ribbon).
-	local pad = (token.tileSize or 1)*0.5 + 0.15
-	local minx, miny, maxx, maxy = nil, nil, nil, nil
-	for _,step in ipairs(path.steps) do
-		local p = token:PosAtLoc(step)
-		if minx == nil then
-			minx, miny, maxx, maxy = p.x, p.y, p.x, p.y
-		else
-			if p.x < minx then minx = p.x elseif p.x > maxx then maxx = p.x end
-			if p.y < miny then miny = p.y elseif p.y > maxy then maxy = p.y end
-		end
-	end
-	if minx == nil then
-		local p = token:PosAtLoc(path.destination)
-		minx, miny, maxx, maxy = p.x, p.y, p.x, p.y
-	end
-	minx, miny, maxx, maxy = minx - pad, miny - pad, maxx + pad, maxy + pad
-
-	local cx = (minx + maxx)*0.5
-	local cy = (miny + maxy)*0.5
-	local gap = 0.3
-
-	--rough OVER-estimate of the tooltip's world size (text + diagram), used only to pick the roomiest
-	--side. Over-estimating is safe: it just biases us away from a side that is too tight.
-	local worldPerPixel = 0.1
-	local screenDims = dmhub.screenDimensions
-	if dmhub.cameraZoom ~= nil and screenDims ~= nil and screenDims.y > 0 then
-		worldPerPixel = (dmhub.cameraZoom*2) / screenDims.y
-	end
-	local ttW = 430 * worldPerPixel
-	local ttH = 640 * worldPerPixel
-
-	--Four candidate placements: tooltip fully outside the box, one per side. `slack` is how much room is
-	--left over after fitting the tooltip on that side (positive = fits without the clamp shoving it back).
-	local halign, valign, anchorx, anchory
-	local bounds = dmhub.cameraUsableBounds
-	if bounds == nil then
-		halign, valign, anchorx, anchory = 'right', 'center', maxx + gap, cy
-	else
-		local candidates = {
-			{ slack = (bounds.x2 - maxx) - ttW, halign = 'right',  valign = 'center', anchorx = maxx + gap, anchory = cy },
-			{ slack = (minx - bounds.x1) - ttW, halign = 'left',   valign = 'center', anchorx = minx - gap, anchory = cy },
-			{ slack = (bounds.y2 - maxy) - ttH, halign = 'center', valign = 'top',    anchorx = cx, anchory = maxy + gap },
-			{ slack = (miny - bounds.y1) - ttH, halign = 'center', valign = 'bottom', anchorx = cx, anchory = miny - gap },
-		}
-		local best = candidates[1]
-		for i = 2, #candidates do
-			if candidates[i].slack > best.slack then best = candidates[i] end
-		end
-		halign, valign, anchorx, anchory = best.halign, best.valign, best.anchorx, best.anchory
-	end
+	--Anchor the tooltip outside the path's bounding box so it never covers the mover, the
+	--destination or the arrow. Shared with ability movement targeting; see GameHud.MovementTooltipPlacement.
+	local anchor, halign, valign = GameHud.MovementTooltipPlacement(token, path)
 
 	self.dialog.sheet:FireEvent("tiletooltip", {
-		--anchor at the chosen edge of the path bounding box (a world-space point, which
-		--FloatTooltipNearTile accepts as well as a Loc); halign/valign then push the tooltip off that
-		--edge, away from the box.
-		loc = core.Vector2(anchorx, anchory),
+		--a world-space point, which FloatTooltipNearTile accepts as well as a Loc;
+		--halign/valign push the tooltip off that edge, away from the box.
+		loc = anchor,
 		text = text,
 		halign = halign,
 		valign = valign,

--- a/DrawSteelActionBar/DrawSteelActionBar.lua
+++ b/DrawSteelActionBar/DrawSteelActionBar.lua
@@ -951,7 +951,8 @@ local g_movementDiagramShown = false
 ---        placement reads "Goblin Runner appears here"). The elevation suffix is
 ---        still appended.
 local function ShowMovementDiagram(token, path, label, alternates, damages, textOverride)
-    if token == nil or path == nil or GameHud.instance == nil then
+    --truthiness check: GameHud.instance is false (not nil) while the hud rebuilds.
+    if token == nil or path == nil or not GameHud.instance then
         return
     end
     local dialog = GameHud.instance.dialog
@@ -982,8 +983,14 @@ local function ShowMovementDiagram(token, path, label, alternates, damages, text
         end
     end
 
+    --Anchor outside the path's bounding box rather than at the destination tile,
+    --which is exactly where the user is aiming. Same placement as the drag-move tooltip.
+    local anchor, halign, valign = GameHud.MovementTooltipPlacement(token, path)
+
     sheet:FireEvent("tiletooltip", {
-        loc = path.destination,
+        loc = anchor,
+        halign = halign,
+        valign = valign,
         text = text,
         movingToken = token,
         movingPath = path,
@@ -998,7 +1005,8 @@ local function ClearMovementDiagram()
         return
     end
     g_movementDiagramShown = false
-    if GameHud.instance ~= nil then
+    --truthiness check: GameHud.instance is false (not nil) while the hud rebuilds.
+    if GameHud.instance then
         GameHud.instance:FinishTokenMoving()
     end
 end


### PR DESCRIPTION
## Problem

Ability movement previews (jump, teleport, forced movement) anchored the movement tooltip - the text plus the movement cross-section diagram - at `path.destination`, which is exactly the tile the user is aiming at. For a large creature (e.g. the size 3 Werewolf using Wall Leap) the ~390px tooltip sat directly on top of the cursor and the landing square, hiding both.

## Fix

- **Shared placement helper.** The drag-move flow already solved this: build the axis-aligned bounding box of the whole path (every step expanded by the mover's footprint plus a little for the arrow), then anchor the tooltip entirely outside that box on the side with the most screen room (via `dmhub.cameraUsableBounds`, so the on-screen clamp cannot shove it back over the box). That logic moves out of `GameHud.TokenMoving` (DSHud.lua) into `GameHud.MovementTooltipPlacement` (GameHud.lua), and `ShowMovementDiagram` (DrawSteelActionBar.lua) now uses it too, so ability targeting places the tooltip the same way drags always have.
- **Include the hovered tile in the box.** During ability targeting the cursor can be well outside the path: a Wall Leap aimed past a wall lands short, so the path box is small and a tooltip placed just off it lands right on the pointer. The box is expanded to contain `dmhub.mouseLoc` (padded ~1 tile) before picking a side.
- **Cursor-dodge backstop.** If the tooltip still ends up under the pointer (e.g. zoomed in so far no side has room), a think on the tooltip detects the cursor inside its bounds via `mousePoint` and fades the whole tooltip tree to 10% opacity. Opacity does not cascade to children in this engine, so the class is applied tree-wide with `SetClassTree`. Fading rather than moving keeps the geometry stable, so it cannot oscillate.
- **Truthiness guards** for `GameHud.instance` in `ShowMovementDiagram`/`ClearMovementDiagram` - it is `false` (not nil) during hud rebuild, so the old `~= nil` guards passed and then indexed a boolean during Lua reloads.

## Testing

Verified live in a running game with a size 3 Werewolf casting Wall Leap: reproduced the obscured-cursor state, confirmed the tooltip now anchors off the side of the footprint clear of the token and arrow, confirmed the short-landing case places the tooltip away from the hovered tile, and confirmed the fade backstop engages only when the pointer actually sits inside the tooltip. All three files pass `luac -p` (preprocessor-aware for GameHud.lua) and are pure ASCII.