### PR TITLE
Standalone session fixes: summon placement naming, cast-prompt guards, DocumentSystem rebuild guard

### DIFF
--- a/DMHub Game Rules/AbilityInvokeAbility.lua
+++ b/DMHub Game Rules/AbilityInvokeAbility.lua
@@ -391,10 +391,26 @@ function ActivatedAbilityInvokeAbilityBehavior:Cast(ability, casterToken, target
 
             print("INVOKE:: ChooseTarget:: prompting...")
             targets = nil
+
+            --The chooser's caption. An explicit Prompt When Resolving text wins;
+            --otherwise borrow the invoke's own prompt text (what the chosen
+            --target will be offered, e.g. "Move Speed or Make Free Strike") so
+            --the Director sees what they are picking a target FOR rather than a
+            --bare "Choose Target".
+            local chooserPrompt = self:try_get("promptWhenResolvingText", "")
+            if chooserPrompt == "" then
+                local promptText = self:try_get("promptText", "")
+                if promptText ~= "" then
+                    chooserPrompt = "Choose the next target: " .. StringInterpolateGoblinScript(promptText, casterToken.properties:LookupSymbol{})
+                else
+                    chooserPrompt = "Choose Target"
+                end
+            end
+
             GameHud.instance.actionBarPanel:FireEventTree("chooseTargetToken", {
                 sourceToken = casterToken,
                 targets = table.shallow_copy(targetChoices),
-                prompt = self:try_get("promptWhenResolvingText", "Choose Target"),
+                prompt = chooserPrompt,
                 choose = function(targetToken)
                     print("ChooseTarget:: chosen")
                     targets = {

--- a/DMHub Game Rules/AbilitySummon.lua
+++ b/DMHub Game Rules/AbilitySummon.lua
@@ -333,6 +333,90 @@ function ActivatedAbilitySummonBehavior:SummarizeBehavior(ability, creatureLooku
 	return "Summon Creatures"
 end
 
+--Memo for SummonedCreatureName below. The bestiary sweep is a full
+--assets.monsters scan with a GoblinScript evaluation per monster, and the
+--callers (the targeting prompt, the hovered-square label) run on every
+--targeting refresh. Keyed by monster type + filter + caster, since a filter may
+--reference the caster. Only invalidated by a reload; the value is display text
+--on a targeting prompt, so a bestiary edit mid-session going unnoticed is
+--acceptable.
+local g_summonNameCache = {}
+
+--- The name of the creature this behavior will summon, when that is knowable
+--- before the cast: nil when the filter matches several creatures (the caster
+--- picks one during the cast, so no single name is right yet) or when this is a
+--- duplicate-token behavior.
+--- @param casterToken CharacterToken
+--- @param symbols nil|table
+--- @return nil|string
+function ActivatedAbilitySummonBehavior:SummonedCreatureName(casterToken, symbols)
+    if self.duplicateMode or casterToken == nil then
+        return nil
+    end
+
+    if self.monsterType ~= "custom" then
+        local monster = assets.monsters[self.monsterType]
+        if monster == nil then
+            return nil
+        end
+        return monster.properties:try_get("monster_type")
+    end
+
+    local key = string.format("%s|%s|%s", tostring(self.monsterType), tostring(self.bestiaryFilter), tostring(casterToken.id))
+    local cached = g_summonNameCache[key]
+    if cached ~= nil then
+        return cached.name
+    end
+
+    --Mirror the candidate sweep in Cast (same filter, same beast symbol), but
+    --stop at the second match: we only care whether exactly one creature can be
+    --summoned. A malformed filter must not take the targeting UI down with it.
+    local name = nil
+    pcall(function()
+        local extra = {}
+        if symbols ~= nil then
+            for k,v in pairs(symbols) do
+                extra[k] = v
+            end
+        end
+
+        local found = nil
+        for k,monster in pairs(assets.monsters) do
+            if not assets:GetMonsterNode(k).hidden then
+                extra.beast = GenerateSymbols(monster.properties)
+                if monster.properties:has_key("monster_type") and ExecuteGoblinScript(self.bestiaryFilter, GenerateSymbols(casterToken.properties, extra), 0, string.format("Bestiary filter naming summons for filter %s", self.bestiaryFilter)) ~= 0 then
+                    if found ~= nil then
+                        --more than one candidate; the caster chooses at cast time.
+                        found = nil
+                        break
+                    end
+                    found = monster.properties:try_get("monster_type")
+                end
+            end
+        end
+
+        name = found
+    end)
+
+    g_summonNameCache[key] = { name = name }
+    return name
+end
+
+--- @param casterToken CharacterToken
+--- @param symbols nil|table
+--- @return nil|string
+function ActivatedAbilitySummonBehavior:BehaviorPlacementName(casterToken, symbols)
+    --Only the squares the ability itself targets are named here. When
+    --choosePlacement is set the behavior runs its own "Place creature N of M"
+    --prompt during the cast instead, and the ability's own target is something
+    --else entirely (often the caster).
+    if self.choosePlacement or self.replaceCaster then
+        return nil
+    end
+
+    return self:SummonedCreatureName(casterToken, symbols)
+end
+
 --- Displays the squad-selection dialog for a Summoner caster.
 --- Returns nil if cancelled, otherwise a result table with the chosen squad and warning flags.
 --- @param casterToken CharacterToken

--- a/DMHub Game Rules/ActivatedAbility.lua
+++ b/DMHub Game Rules/ActivatedAbility.lua
@@ -3093,6 +3093,36 @@ function ActivatedAbility:GetMovementType(token, symbols)
     return nil
 end
 
+--- The display name of what this behavior PLACES in the ability's targeted
+--- square -- a summoned creature, a conjured object -- or nil when the behavior
+--- places nothing. Square-targeted abilities preview as a movement by default
+--- ("Movement: 3 squares"), which is wrong for an ability that moves nobody, so
+--- behaviors that put something new on the map name it here and the targeting
+--- prompt and hovered-square label speak about placement instead.
+--- @param casterToken CharacterToken
+--- @param symbols nil|table
+--- @return nil|string
+function ActivatedAbilityBehavior:BehaviorPlacementName(casterToken, symbols)
+    return nil
+end
+
+--- The name of the creature/object this ability places in its targeted square,
+--- or nil if it places nothing (or places something whose identity is not known
+--- until the caster picks during the cast).
+--- @param casterToken CharacterToken
+--- @param symbols nil|table
+--- @return nil|string
+function ActivatedAbility:GetPlacementName(casterToken, symbols)
+    for _,behavior in ipairs(self:try_get("behaviors", {})) do
+        local name = behavior:BehaviorPlacementName(casterToken, symbols)
+        if name ~= nil then
+            return name
+        end
+    end
+
+    return nil
+end
+
 --- Per-tier targeting rings drawn while this behavior's ability is being
 --- targeted, or nil for ordinary single-ring targeting. Each entry:
 --- {tier: integer, tiles: integer, height: integer, radius: number,

--- a/DMHub Game Rules/Aura.lua
+++ b/DMHub Game Rules/Aura.lua
@@ -2024,6 +2024,17 @@ end
 --- @param targets table
 --- @param options table
 function ActivatedAbilityAuraBehavior:Cast(ability, casterToken, targets, options)
+    --The aura payload is only created when the author opens "Edit Aura" in the
+    --behavior editor, so content that sets only the duration ships with no aura
+    --field at all. Reading it would raise ("Attempt to read unknown field aura
+    --in type ActivatedAbilityBehavior") and kill the cast coroutine, taking
+    --every later behavior of the ability down with it. There is nothing to
+    --place, so log it for the author and let the rest of the cast resolve.
+    if not self:has_key("aura") then
+        print(string.format("AURA:: '%s' has a Create Aura behavior with no aura configured; skipping it.", tostring(ability.name)))
+        return
+    end
+
     --Purge before placing anything. This lives here rather than in CastOnArea
     --because one cast can cover several areas (targetAreaList), and purging
     --per-area would make a multi-area cast delete its own earlier areas.
@@ -2146,9 +2157,12 @@ function ActivatedAbilityAuraBehavior:CastOnArea(ability, casterToken, targets, 
             end
         end
 
+        --"none" is the Aura default meaning "no object" (see Aura.objectid);
+        --passing it through to SpawnObjectLocal just logs a spawn failure.
         local obj = nil
-        if self.aura.objectid ~= nil then
-            obj = targetFloor:SpawnObjectLocal(self.aura.objectid)
+        local auraObjectId = self.aura:try_get("objectid", "none")
+        if auraObjectId ~= nil and auraObjectId ~= "none" then
+            obj = targetFloor:SpawnObjectLocal(auraObjectId)
             if obj ~= nil then
                 auraInstance.object = {
                     floorid = obj.floorid,

--- a/DocumentSystem/DocumentSystem.lua
+++ b/DocumentSystem/DocumentSystem.lua
@@ -7207,7 +7207,7 @@ end
 --windows past the right rail. Falls back to the aspect formula before
 --the first layout pass.
 local function IconRailUIWidth()
-    if GameHud.instance ~= nil and GameHud.instance.documentsPanel ~= nil and GameHud.instance.documentsPanel.valid then
+    if GameHud.instance and GameHud.instance.documentsPanel ~= nil and GameHud.instance.documentsPanel.valid then
         local w = GameHud.instance.documentsPanel.renderedWidth
         if type(w) == "number" and w > 100 then
             return w
@@ -7219,7 +7219,7 @@ end
 --the height of the rail's coordinate space, measured the same way (the
 --layer is ~1048 units tall, not 1080; see IconRailUIWidth).
 local function IconRailUIHeight()
-    if GameHud.instance ~= nil and GameHud.instance.documentsPanel ~= nil and GameHud.instance.documentsPanel.valid then
+    if GameHud.instance and GameHud.instance.documentsPanel ~= nil and GameHud.instance.documentsPanel.valid then
         local h = GameHud.instance.documentsPanel.renderedHeight
         if type(h) == "number" and h > 100 then
             return h
@@ -16241,7 +16241,7 @@ RailShowAddPicker = function(element, side)
     --left edge. Anchoring to the full-screen documents layer makes
     --center mean the middle of the screen -- the library is a
     --destination surface, not a flyout of the + button.
-    if GameHud.instance ~= nil and GameHud.instance.documentsPanel ~= nil then
+    if GameHud.instance and GameHud.instance.documentsPanel ~= nil then
         element.popupPositioning = GameHud.instance.documentsPanel
     end
     element.popup = gui.Panel{

--- a/Draw Steel Ability Behaviors/AbilityPersistentCast.lua
+++ b/Draw Steel Ability Behaviors/AbilityPersistentCast.lua
@@ -65,6 +65,26 @@ function ActivatedAbilityPersistenceControlBehavior:Cast(ability, casterToken, t
     local finished = false
     local canceled = false
 
+    --Persistent recasts whose every target is already dead or gone have nothing
+    --left to maintain; end them now, before the persistence cost is settled, so
+    --the caster is not charged essence for them. Multi-target entries survive
+    --while any target still lives (see creature:PersistentAbilityTargetsAllDead).
+    local autoEnded = casterToken.properties:AutoEndPersistentAbilitiesWithDeadTargets()
+    if #autoEnded > 0 then
+        casterToken:ModifyProperties{
+            description = "Persistent Ability Ended",
+            undoable = false,
+            execute = function()
+                casterToken.properties:FloatLabel(string.format(tr("%s ended: target dead"), table.concat(autoEnded, ", ")), "#C49A5A")
+            end,
+        }
+    end
+
+    --Nothing left to decide: behave as if the trigger had never fired.
+    if #(casterToken.properties:try_get("persistentAbilities") or {}) == 0 then
+        return
+    end
+
     local caster = casterToken:GetCreature()
     local casterClasses = caster:GetClassesAndSubClasses()
     local startOfTurnHeroicResource = 0

--- a/Draw Steel Core Rules/MCDMActivatedAbility.lua
+++ b/Draw Steel Core Rules/MCDMActivatedAbility.lua
@@ -3638,6 +3638,27 @@ function ActivatedAbility:PromptText(casterToken, targets, symbols, synthesizedS
         return ""
     end
 
+    --Square-targeted abilities that PLACE something (a summon) rather than move
+    --a creature: "Choose Target 1/2" says nothing about what is being placed, so
+    --name it -- "Choose where Goblin Runner 2 appears". GetPlacementName is nil
+    --for every other ability, and for a summon whose creature the caster has yet
+    --to pick, so the generic wording below still covers those.
+    if self.targetType == "emptyspace" or self.targetType == "anyspace" then
+        local placementName = self:GetPlacementName(casterToken, symbols)
+        if placementName ~= nil then
+            local index = #targets + 1
+            if self.sequentialTargeting and symbols ~= nil and symbols.targetnumber ~= nil then
+                index = symbols.targetnumber
+            end
+
+            if numTargets == 1 then
+                return string.format("Choose where %s appears", placementName)
+            end
+
+            return string.format("Choose where %s %d appears", placementName, index)
+        end
+    end
+
     if numTargets == 1 and #targets == 0 then
         return nil
     end

--- a/Draw Steel Core Rules/MCDMCreature.lua
+++ b/Draw Steel Core Rules/MCDMCreature.lua
@@ -6692,26 +6692,41 @@ function creature:PersistentAbilities()
 
             local targets = nil
 
+            --Set when a recast_target persistence has nobody left to recast on
+            --(every original target is dead, removed from the map, or -- with the
+            --"Target Must Be In Range" option -- out of range). The trigger is
+            --not offered at all in that case: previously it still prompted and
+            --opened a targeting flow whose filter matched no token, leaving the
+            --player with nothing to do but Skip.
+            local noValidTargets = false
+
             local filterstr = ""
             if persistenceMode == "recast_target" then
                 targeting = "inherit"
                 targets = {}
-                for i, targetid in ipairs(a.targets or {}) do
-                    if i == #a.targets then
-                        filterstr = string.format("%s %s", filterstr,
-                            string.format("self.id = %s", Utils.HashGuidToNumber(targetid)))
-                    else
-                        filterstr = string.format("%s or %s", filterstr,
-                            string.format("self.id = %s", Utils.HashGuidToNumber(targetid)))
-                    end
-                end
+                local selfToken = dmhub.LookupToken(self)
+                local filterParts = {}
                 for _, targetid in ipairs(a.targets or {}) do
                     local targetToken = dmhub.GetTokenById(targetid)
-                    if targetToken ~= nil then
+                    local usable = targetToken ~= nil and targetToken.valid and targetToken.properties ~= nil
+                        and (not targetToken.properties:IsDead())
+                    if usable and persistence.inrange == true and selfToken ~= nil then
+                        local range = ability:GetRange(self)
+                        if type(range) == "number" and selfToken:Distance(targetToken) > range then
+                            usable = false
+                        end
+                    end
+                    if usable then
                         targets[#targets + 1] = {
                             token = targetToken,
                         }
+                        filterParts[#filterParts + 1] = string.format("self.id = %s", Utils.HashGuidToNumber(targetid))
                     end
+                end
+                if #filterParts == 0 then
+                    noValidTargets = true
+                else
+                    filterstr = table.concat(filterParts, " or ")
                 end
                 ability.targetFilter = filterstr
             elseif persistenceMode == "recast_with_one_target" then
@@ -6739,9 +6754,24 @@ function creature:PersistentAbilities()
                 end
             end
 
+            --Prompt shown at the bottom of the screen while the recast is being
+            --targeted. An ability can supply its own wording through
+            --persistence.promptText (authored in the ability data); it is
+            --appended after the ability name so the player sees what the recast
+            --lets them do. Conditions the engine has already checked before
+            --offering the trigger (start of turn, target alive) should not be
+            --restated there.
+            local promptText
+            local customPrompt = persistence.promptText
+            if type(customPrompt) == "string" and trim(customPrompt) ~= "" then
+                promptText = string.format("%s: %s; %s", tr("Persistence"), ability.name, customPrompt)
+            else
+                promptText = string.format(tr("Persistence: Recast %s"), ability.name)
+            end
+
             local invoke = ActivatedAbilityInvokeAbilityBehavior.new {
                 customAbility = ability,
-                promptText = string.format(tr("Persistence: Recast %s"), ability.name),
+                promptText = promptText,
                 targeting = "prompt",
                 --targetingFormula = filterstr,
                 --targets = targets,
@@ -6766,7 +6796,9 @@ function creature:PersistentAbilities()
                 domains = {},
             }
 
-            result[#result + 1] = mod
+            if not noValidTargets then
+                result[#result + 1] = mod
+            end
         end
     end
 
@@ -6864,6 +6896,100 @@ function creature:EndPersistentAbilityById(guid)
     }
 
     return false
+end
+
+--- True when this persistent entry exists only to recast on specific targets
+--- (mode recast_target) and EVERY one of those targets is dead or gone from
+--- the map, so there is nothing left to maintain it for. Conservative on
+--- purpose:
+---  * one surviving target out of several keeps the entry alive;
+---  * an out-of-range target is not "gone" (it can come back into range);
+---  * an entry that is also keeping something else alive -- a linked aura or
+---    object, or a behavior with a "persistence" duration (e.g. the area of
+---    Web of All That's Come Before) -- is never reported, since ending it
+---    would drop that effect too;
+---  * an entry with no recorded targets is never reported.
+--- @param entry Persistence
+--- @return boolean
+function creature:PersistentAbilityTargetsAllDead(entry)
+    if type(entry) ~= "table" then
+        return false
+    end
+
+    --Entries are normally Persistence instances, but tolerate a plain table
+    --(older/partial data) rather than raising on a missing field.
+    local function field(key)
+        if entry.try_get ~= nil then
+            return entry:try_get(key)
+        end
+        return rawget(entry, key)
+    end
+
+    local ability = field("ability")
+    if ability == nil or type(ability) ~= "table" or getmetatable(ability) == nil then
+        return false
+    end
+
+    local persistence = ability:Persistence()
+    if persistence == nil or persistence.mode ~= "recast_target" then
+        return false
+    end
+
+    local targets = field("targets") or {}
+    if #targets == 0 then
+        return false
+    end
+
+    if #(field("objects") or {}) > 0 then
+        return false
+    end
+
+    for _, aura in ipairs(self:try_get("auras", {})) do
+        if aura:try_get("persistenceId") == entry.guid then
+            return false
+        end
+    end
+
+    for _, behavior in ipairs(ability:try_get("behaviors") or {}) do
+        if type(behavior) == "table" and behavior:try_get("duration") == "persistence" then
+            return false
+        end
+    end
+
+    for _, targetid in ipairs(targets) do
+        local targetToken = dmhub.GetTokenById(targetid)
+        if targetToken ~= nil and targetToken.valid and targetToken.properties ~= nil
+            and (not targetToken.properties:IsDead()) then
+            return false
+        end
+    end
+
+    return true
+end
+
+--- Ends every persistent ability whose recast targets are all dead or gone
+--- (see PersistentAbilityTargetsAllDead), so the caster is no longer charged
+--- for maintaining it. Returns the names of the abilities that were ended.
+--- Intended to run at the start of the caster's turn, before the persistence
+--- cost is settled.
+--- @return string[]
+function creature:AutoEndPersistentAbilitiesWithDeadTargets()
+    local ended = {}
+    local persistentAbilities = self:try_get("persistentAbilities", {})
+    for i = #persistentAbilities, 1, -1 do
+        local entry = persistentAbilities[i]
+        if self:PersistentAbilityTargetsAllDead(entry) then
+            local name = nil
+            if entry.try_get ~= nil then
+                name = entry:try_get("abilityName")
+            else
+                name = rawget(entry, "abilityName")
+            end
+            ended[#ended + 1] = name or "Persistent Ability"
+            self:EndPersistentAbilityById(entry.guid)
+        end
+    end
+    return ended
 end
 
 creature.RegisterSymbol {


### PR DESCRIPTION
Split out of #266 per review feedback - these are standalone fixes that had ridden along in the overview branch and are unrelated to that feature. Based directly on current main; applies cleanly.

## What's here

**Session fixes** (one batch commit):
- **Summon placement naming** (`AbilitySummon`, `ActivatedAbility`, `AbilityInvokeAbility`): `GetPlacementName` / `SummonedCreatureName` so summon placement prompts name the creature being placed.
- **Persistent-cast guard** (`AbilityPersistentCast`): `recast_target` no longer errors when no valid targets remain.
- **Aura guard** (`Aura`): tolerate a missing payload instead of raising.
- **Targeting-prompt fixes** (`MCDMCreature`, `MCDMActivatedAbility`): villain-action casts no longer build their target prompt inside a hidden bar; related prompt caption fixes.

**DocumentSystem**: IconRail size helpers tolerate `GameHud.instance == false` during a HUD rebuild (3-line nil-guard).

## Not here

- The `DrawSteelTokenHud` pick-not-claim change from the original batch is already on main (03fd7669, via #253) - dropped.
- The `DrawSteelActionBar` hunks stay with #266, whose later commits build on them.
