### PR TITLE
Fix inventory Available Items search not filtering (report ST8AHWMX)

### DIFF
--- a/Draw Steel Inventory/DrawSteelInventory.lua
+++ b/Draw Steel Inventory/DrawSteelInventory.lua
@@ -1989,20 +1989,18 @@ function GameHud.CreateInventoryDialog(self, options)
 					width = '100%',
 					height = 20,
 					editlag = 0.25,
-					events = {
-						edit = function(element)
+					edit = function(element)
+						npage = 1
+						search = element.text
+						resultPanel:FireEventTree('refreshInventory')
+					end,
+					change = function(element)
+						if search ~= element.text then
 							npage = 1
 							search = element.text
 							resultPanel:FireEventTree('refreshInventory')
-						end,
-						change = function(element)
-							if search ~= element.text then
-								npage = 1
-								search = element.text
-								resultPanel:FireEventTree('refreshInventory')
-							end
-						end,
-					},
+						end
+					end,
 				},
 
 			}


### PR DESCRIPTION
**Symptom:** On the character sheet's Inventory -> Available Items, typing in the search box accepts text but never filters the list.

**Root cause:** `Draw Steel Inventory/DrawSteelInventory.lua` (in `GameHud.CreateInventoryDialog`) passed the search field's `edit`/`change` handlers through the legacy `events = { ... }` sub-table. `gui.SearchInput` (`DMHub Core UI/Gui.lua`) unconditionally installs its **own** top-level `edit`/`change` defaults, which only `FireEvent("search", ...)` -- an event this panel does not listen to. The engine's arg-table walk merges an `events` sub-table and bare top-level function keys into the same `panel.events` map in arbitrary Lua hash order, so with this table shape the SearchInput defaults could land last and silently overwrite the inventory's handlers. Because Lua 5.4 randomizes its string-hash seed per state, this is a coin flip per app launch, which is why it reproduces for some users and not others.

This was a regression from the "one canonical search field everywhere" change (e4279d19), which converted this `gui.Input` to a `gui.SearchInput` but left the legacy `events = {}` form in place. A sweep of the ~45 `gui.SearchInput` call sites shows this was the last one still using it -- `DMHub Core Panels/Objects.lua` already carries a comment documenting the same hazard after hitting it.

**The fix:** Move the two handlers from the `events = {}` sub-table to top-level keys on the same `gui.SearchInput` call and drop the now-empty table. The handler bodies are unchanged. At the top level, `gui.SearchInput`'s `for k,v in pairs(options) do args[k] = v end` copy replaces its own defaults outright (what all other call sites do), and the `withClearRefresh` wrapper still wraps them so the built-in clear "x" keeps working. Panel structure is untouched, so `searchInput.children[1]` still resolves to the input.

Verified with `luac -p`; the diff introduces no non-ASCII bytes.

**Not addressed here:** the same reports also mention the search box not fitting inside the dialog (`inventory-main` hardcodes `width = 500` while the basic-inventory dialog's `dialogWidth` defaults to 350). That is a separate layout issue needing judgement about the character-sheet grid, and is deliberately left alone.

Reports: ST8AHWMX, CDYEK5KG (reported independently by two users). Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
