### PR TITLE
Fix Map Markup props error on startup with no map loaded (report AUSH9E8E)

### DIFF
--- a/MapMarkup/MapMarkupPanel.lua
+++ b/MapMarkup/MapMarkupPanel.lua
@@ -11599,7 +11599,7 @@ CreateMarkupEditor = function()
     local PropsOnCurrentFloor = function(assetid)
         local result = {}
         local floor = game.currentFloor
-        if floor == nil then
+        if floor == nil or floor.valid == false then
             return result
         end
         for _,obj in pairs(floor.objects) do
@@ -11621,7 +11621,7 @@ CreateMarkupEditor = function()
             return nil
         end
         local floor = game.currentFloor
-        if floor == nil then
+        if floor == nil or floor.valid == false then
             return nil
         end
         local obj = floor:GetObject(m_props.editingId)
@@ -11644,7 +11644,7 @@ CreateMarkupEditor = function()
             return result
         end
         local floor = game.currentFloor
-        if floor == nil then
+        if floor == nil or floor.valid == false then
             return result
         end
         for _,objid in ipairs(ids) do


### PR DESCRIPTION
**Symptom:** On launch, over the Director/Player role-selection screen (before any map or game is loaded), an error popup appears: `Error in index: ... at MapFloorLua.get_objects`, followed by `bad argument #1 to 'for iterator' (table expected, got nil)`.

**Root cause:** Three Map Markup Props helpers guard the current floor with `if floor == nil then`, a test that can never fire. `game.currentFloor` always returns a `MapFloorLua` userdata for `GameController.currentFloorId` (`GetFloorFromCache` fabricates and caches a wrapper for any id). At startup the id is still the initial literal `"default"`, which resolves to no floor, so the wrapper is non-nil but every member access on it NREs inside the engine (`MapFloorLua.objects` dereferences a null `mapFloor`). The Props list ticks on a 1Hz `think` timer, so the panel hits this without any user action.

**Fix:** In `MapMarkup/MapMarkupPanel.lua`, additionally test the floor's `valid` property in `PropsOnCurrentFloor`, `GetEditingProp` and `GetEditingProps`: `if floor == nil or floor.valid == false then`. Engine-side, `valid` is exactly `gameDetails.GetFloor(floorid) != null` - the same lookup `objects` / `GetObject` dereference - so `valid == false` is precisely the crashing case and no working case is lost (preview/fake floors resolve through `mapDetailsController` and still report valid). Existing early-return bodies are unchanged; the other occurrences of the same idiom in the file are user-action paths only reachable with a map loaded and were left alone.

A deeper engine-side nil guard (`MapFloorLua` members against a null `mapFloor`, and `game.currentFloor` returning nil for an unresolvable id) is tracked separately and deliberately not attempted here.

Report id: AUSH9E8E. Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
