### PR TITLE
Fix Hide maneuver treating allies as enemies out of combat (report GFSKDQST)

### DIFF
--- a/Draw Steel Core Rules/MCDMCreature.lua
+++ b/Draw Steel Core Rules/MCDMCreature.lua
@@ -3610,7 +3610,9 @@ creature.RegisterSymbol {
 }
 
 --The living enemy tokens relevant to this creature: every token on the map
---that is not friendly to this creature's token and is not dead. When an
+--that is not friendly to this creature's token and is not dead. Friendliness
+--uses token:IsFriend, which consults the initiative queue when an encounter
+--is running and otherwise falls back to party allegiance. When an
 --initiative encounter is active (an unhidden initiative queue exists), only
 --enemies participating in the initiative queue count; out of combat, all
 --enemy tokens on the current map count. Neutral (non-friendly) tokens count
@@ -3628,7 +3630,7 @@ function creature:GetRelevantEnemyTokens()
     for _,tok in ipairs(dmhub.allTokens) do
         if tok.valid and tok.properties ~= nil and tok.charid ~= token.charid
                 and (not tok.properties:IsDead())
-                and (not dmhub.TokensAreFriendly(token, tok)) then
+                and (not token:IsFriend(tok)) then
             local include = true
             if combatActive then
                 local initiativeid = InitiativeQueue.GetInitiativeId(tok)


### PR DESCRIPTION
**Symptom:** Outside combat, the Hide maneuver is permanently blocked with "You cannot hide: you need concealment or cover from every enemy who can see you", and red sight-line arrows are drawn from the reporter's own party members.

**Root cause:** `creature:GetRelevantEnemyTokens()` filtered candidate tokens with `dmhub.TokensAreFriendly(token, tok)`. That codex hook (`Draw Steel Core Rules/MCDMInitiativeQueue.lua`) deliberately returns **nil** to mean "no opinion - use the engine default": nil when `dmhub.initiativeQueue` is nil or hidden, and nil when either token has no entry in the queue. Out of combat the codex keeps the queue alive but hidden (gameMode `exploration`/`respite`/`downtime`), so the hook always returns nil - and `not nil == true`, so every living token on the map, including the player's own party, was classified as an enemy. The report's log shows exactly this: `HideGate:: cover check: 5 relevant enemies (combat=false)` followed by five party-member names.

**Fix:** One condition changed, from `(not dmhub.TokensAreFriendly(token, tok))` to `(not token:IsFriend(tok))`. `CharacterToken.IsFriend` (engine, `CharacterToken.cs`) invokes the same `TokensAreFriendly` Lua hook first and only falls back to `charInfo.IsFriend` (`Party.IsFriendly`) when the hook does not return a boolean. So in-combat behaviour is unchanged, and out of combat friendliness now resolves by party allegiance instead of defaulting to hostile. No recursion risk: the engine method calls the hook, not the reverse. The doc comment above the function was updated to describe the fallback.

Scope is limited to this function, which has exactly two consumers, both Hide-related: `creature:CalculateCoverFromEnemies()` (the `Cover From All Enemies` / `Cover From Any Enemy` GoblinScript symbols used by the Hide maneuver's abilityFilter) and the sight-line arrow drawing in `DrawSteelActionBar/DrawSteelActionBar.lua`. The other `dmhub.TokensAreFriendly` call sites (Monster AI) are untouched - they run during combat, where the hook returns a real boolean.

**Known caveat:** Director-run allied NPCs that are not actually assigned to the players' party will still classify as enemies under party allegiance. That is a separate, pre-existing question about token party assignment; PCs are now correctly excluded either way.

Report id: GFSKDQST. Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
