### PR TITLE
Fix multi-target tier filter dropping all but the last resolved tier (report EW6NNVGG)

### DIFF
--- a/DMHub Game Rules/ActivatedAbility.lua
+++ b/DMHub Game Rules/ActivatedAbility.lua
@@ -3632,7 +3632,24 @@ function ActivatedAbilityBehavior:IsFiltered(ability, casterToken, options)
 	if options and options.symbols and options.symbols.cast and options.symbols.cast.tier ~= 0 and #self:try_get("tiersSelected", {}) > 0 then
         --see if the tier filter filters it out.
         if not table.contains(self.tiersSelected, options.symbols.cast.tier) then
-            return true
+            --cast.tier is a scalar written by SetTierResult on a last-writer-wins basis, so
+            --with a multi-target roll it only reflects one target. Consult the per-target map
+            --before dropping the behavior: if ANY target landed on a selected tier, let the
+            --behavior through and let ApplyToTargets do the per-target filtering it already does.
+            local anyTierMatches = false
+            local tokenToTier = options.symbols.cast:try_get("tokenToTier")
+            if type(tokenToTier) == "table" then
+                for _,tier in pairs(tokenToTier) do
+                    if table.contains(self.tiersSelected, tier) then
+                        anyTierMatches = true
+                        break
+                    end
+                end
+            end
+
+            if not anyTierMatches then
+                return true
+            end
         end
     end
 


### PR DESCRIPTION
**Symptom:** The Glass Spider malice ability "Stained Glass Brilliance" applied no debuff to a target whose Might test landed on a Tier 1 result when other targets landed on Tier 2.

**Root cause:** `ActivatedAbilityBehavior:IsFiltered` gates tier-restricted behaviors on the scalar `options.symbols.cast.tier`. `ActivatedAbilityCast:SetTierResult` writes that scalar once per target on a last-writer-wins basis (while also recording the authoritative per-target map `cast.tokenToTier`). On a multi-target power roll the scalar therefore only reflects whichever target resolved last, so any behavior restricted to a different tier was filtered out for *every* target -- not just the mismatched ones. In the report's log, three targets rolled Tier 2 / Tier 2 / Tier 1 and the `tiersSelected:[1]` behavior was logged `filtered=true`, so the Tier 1 target received nothing.

This is general, not content-specific: any multi-target power roll with per-tier behaviors silently loses every tier except the last one resolved. The Glass Spider content data itself is correct.

**What the fix changes:** In `DMHub Game Rules/ActivatedAbility.lua`, when the scalar tier fails the `tiersSelected` check, consult `cast:try_get("tokenToTier")` and let the behavior through if *any* target landed on a selected tier. This is safe because both `IsFiltered` call sites (`ActivatedAbility.lua:2255` and `:3211`) always pair the gate with `behavior:ApplyToTargets(...)`, which already filters targets by `cast.tokenToTier[target.token.charid]` against `self.tiersSelected` -- so a behavior that now survives the gate can still only reach targets whose own tier matches. Single-target casts, and multi-target casts where all targets share a tier, are unaffected: `tokenToTier` then agrees with the scalar and behavior is identical.

**Verification plan (not run here -- this PR was produced without running the app):** Reproduce with the Glass Spider 7-Malice ability "Stained Glass Brilliance" (`data/objectTables/monstergroup/glass-spider.yaml`, guid `0cc7e24f-a2ce-4d30-8a12-9f8bd974d4ca`) against three or more enemies whose Might tests land on different tiers. Before the fix the log shows `CastCoroutine:: Stained Glass Brilliance behavior 2/3 type=ActivatedAbilityApplyOngoingEffectBehavior ... filtered=true` and no application of ongoing effect `2378b77e-dc66-4f7b-9851-ba4365a4d969` (Double Bane On All Power Rolls). After the fix that behavior should report `filtered=false` and apply the double bane to the Tier 1 target only, while the Tier 2 targets still receive `54455d3b-5abe-46a3-90db-20ada18c4e95` (Bane On All Power Rolls), with no target receiving both.

Syntax-checked with the bundled `luac -p` (clean); diff is ASCII-only.

Report id: **EW6NNVGG**

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
