### PR TITLE
fix(character-builder): stop orphaned levelChoices entries from hiding unique perks

### DIFF
--- a/Draw Steel Character Builder/FeatureCache.lua
+++ b/Draw Steel Character Builder/FeatureCache.lua
@@ -213,12 +213,35 @@ function CBFeatureCache._processFeatures(opts, hero, features)
         return result
     end
 
+    -- levelChoices can hold orphaned entries under a guid that no longer
+    -- resolves (e.g. homebrew content whose guid changed). Track which guids
+    -- are actually live so the uniqueness sweep below can ignore stale ones.
+    local liveFeatureGuids = {}
+    local function collectLiveGuid(feature)
+        if feature.IsDerivedFrom("CharacterChoice") and passesPrereq(feature) then
+            liveFeatureGuids[feature.guid] = true
+        end
+    end
+    for _,item in ipairs(features) do
+        local itemFeatures = _safeGet(item, "features")
+        local itemFeature = _safeGet(item, "feature")
+        if itemFeatures ~= nil then
+            for _,feature in ipairs(itemFeatures) do
+                collectLiveGuid(feature)
+            end
+        elseif itemFeature ~= nil then
+            collectLiveGuid(item.feature)
+        else
+            collectLiveGuid(item)
+        end
+    end
+
     local function addFeature(feature, level)
         if not passesPrereq(feature) then return end
         if level == nil or level == 0 then
             level = levelFromPrereq(feature) or level
         end
-        local cacheFeature = CBFeatureWrapper.CreateNew(hero, feature, level)
+        local cacheFeature = CBFeatureWrapper.CreateNew(hero, feature, level, liveFeatureGuids)
         if cacheFeature then
             local guid = cacheFeature:GetGuid()
             keyed[guid] = cacheFeature
@@ -262,8 +285,9 @@ end
 --- @param hero character
 --- @param feature CharacterChoice
 --- @param level integer
+--- @param liveFeatureGuids table|nil set of feature guids live in this build, used to scope uniqueness checks against stale levelChoices entries
 --- @return CBFeatureWrapper|nil
-function CBFeatureWrapper.CreateNew(hero, feature, level)
+function CBFeatureWrapper.CreateNew(hero, feature, level, liveFeatureGuids)
     if not feature.IsDerivedFrom("CharacterChoice") then return nil end
 
     local category = CBFeatureWrapper._deriveCategory(feature)
@@ -276,6 +300,7 @@ function CBFeatureWrapper.CreateNew(hero, feature, level)
         categoryOrder = categoryOrder,
         currentOptionId = nil,
         level = level,
+        liveFeatureGuids = liveFeatureGuids,
     }
 
     newObj:Update(hero)
@@ -748,12 +773,17 @@ function CBFeatureWrapper:_excludeChoice(hero, choice)
     local fn = validators[self.feature.typeName]
     if fn then return fn(hero, choice) end
 
-    -- Look for it in any level choice
+    -- Look for it in any level choice that's still backed by a live feature.
+    -- A dead key (see liveFeatureGuids above) can hold a leftover guid that
+    -- happens to match a different, current unique choice and wrongly hide it.
     local choiceId = choice:GetGuid()
     local levelChoices = hero:GetLevelChoices() or {}
-    for _,featureChoices in pairs(levelChoices) do
-        for _,id in ipairs(featureChoices) do
-            if id == choiceId then return true end
+    local liveFeatureGuids = self:try_get("liveFeatureGuids")
+    for featureId,featureChoices in pairs(levelChoices) do
+        if liveFeatureGuids == nil or liveFeatureGuids[featureId] then
+            for _,id in ipairs(featureChoices) do
+                if id == choiceId then return true end
+            end
         end
     end
     -- local featureChoices = levelChoices[self:GetGuid()] or {}


### PR DESCRIPTION
## Bug report
Feedback report `9NPY3KWM` (Discord thread [1542038302297686068](https://discord.com/channels/@me/1542038302297686068), signature `charbuilder-orphaned-levelchoices-entry-hides-unique-perk-option`):

> Missing Monster Whisperer perk. Doesn't affect newly created characters, but does affect "Moria" both in the campaign and the character sheet in the main Player menu.

## Root cause
`CBFeatureWrapper:_excludeChoice` (`Draw Steel Character Builder/FeatureCache.lua`) enforces "unique" choices (perks, etc.) can't be picked twice by sweeping *every* key in `hero:GetLevelChoices()`. A hero's `levelChoices` table can accumulate orphaned entries under a guid that no longer resolves to any current feature — e.g. homebrew content whose guid changed, or content that was removed. On the reporting user's hero, one such dead entry happened to contain the Monster Whisperer perk's guid, so the perk was reported as "already taken" and hidden from her perk picker. Fresh heroes have no stale entries, so they were unaffected — matching the reported symptom exactly.

Confirmed via read-only inspection of the affected hero's saved data: the guid `786cac63-676f-48b9-abb8-21b0cb9ffcf9` (Monster Whisperer) appears exactly once in her record, sitting under an unrelated dead `levelChoices` key (`fbd3aa38-f8e6-46e0-a885-2c49410a3ebd`) that resolves to no known feature in the current content or the data repo's history.

## Fix
Instead of pruning the stale hero data directly (fragile — the dead key could reappear from any other drifted content, and a module being temporarily disabled could make a *valid* key look orphaned), this scopes the sweep itself:

- `CBFeatureCache._processFeatures` now pre-scans the hero's current feature list to build a `liveFeatureGuids` set (feature guids that pass their prerequisites in this build).
- That set is threaded through `CBFeatureWrapper.CreateNew` and stored on the wrapper.
- `_excludeChoice`'s generic uniqueness sweep now only checks `levelChoices` slots whose key is in `liveFeatureGuids`, ignoring orphaned/dead keys.

Genuine cross-slot uniqueness enforcement (the actual purpose of the sweep — stopping the same unique perk being granted twice via two different features) is preserved, since it still checks every *live* slot.

`CBFeatureWrapper.CreateNew` has exactly one call site (inside `_processFeatures`), so no other callers needed updating.

## Test plan
- [ ] Deploy to a dev client, open the affected hero (or reproduce an orphaned `levelChoices` entry on a test hero) in the Builder, confirm Monster Whisperer (or any previously-hidden unique perk) now appears in the picker
- [ ] Confirm a genuinely-already-taken unique perk/choice (via a live slot) is still correctly excluded from the picker, on both a class-granted and a template/feat-granted slot
- [ ] Confirm a freshly created hero is unaffected