### PR TITLE
Fix Campaign Tracker sections lingering after their mod unloads (report J79QSAGW)

### DIFF
--- a/DocumentSystem/CampaignTrackerPanel.lua
+++ b/DocumentSystem/CampaignTrackerPanel.lua
@@ -523,10 +523,16 @@ function CampaignTracker.RegisterSection(args)
         error("CampaignTracker.RegisterSection: requires { id = string, create = function }")
     end
 
+    --remember which mod registered this so the section can be dropped once
+    --that mod unloads (the Lua state outlives a game, so a module's section
+    --would otherwise linger into the next campaign). nil when not loading a mod.
+    local ownerMod = dmhub.GetModLoading()
+
     CampaignTracker._sections[args.id] = {
         id = args.id,
         ord = args.ord or 100,
         create = args.create,
+        mod = ownerMod,
     }
 
     dmhub.FireGlobalEvent(SECTIONS_CHANGED_EVENT)
@@ -544,7 +550,10 @@ end
 local function GetSortedSections()
     local result = {}
     for _, section in pairs(CampaignTracker._sections) do
-        result[#result + 1] = section
+        --skip sections whose owning mod has been unloaded.
+        if section.mod == nil or section.mod.unloaded ~= true then
+            result[#result + 1] = section
+        end
     end
     table.sort(result, function(a, b)
         if a.ord ~= b.ord then


### PR DESCRIPTION
**Symptom:** After visiting a campaign that uses the Crows (Crowdex) module, that module's "Dungeon Turn" Campaign Tracker section keeps showing in the Campaign Tracker of every other campaign entered afterwards, and restarting the app does not clear it.

**Root cause:** `CampaignTracker._sections` is deliberately kept on a Lua global so registrations survive a reload of `DocumentSystem/CampaignTrackerPanel.lua`. But the Lua VM is shared across games -- switching campaigns only reloads code mods, it does not recreate the VM. `CampaignTracker.RegisterSection` recorded nothing about which mod registered a section, and nothing removed sections when a mod was unloaded on leaving the game, so a module-supplied section stayed in the table and `rebuildSections()` called its orphaned `create` closure in the next campaign.

**Fix:** `RegisterSection` now records `dmhub.GetModLoading()` as the section's owner (nil when the registration was not made during a mod load, which preserves today's behavior), and `GetSortedSections()` skips any section whose owning mod has `unloaded == true`. The registry table itself is not mutated during iteration, and re-registering the same id after a mod reload overwrites the stale entry exactly as before.

Report: J79QSAGW

This PR originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
