### PR TITLE
Fix appearance preview ignoring saved token scale (report BBHB6GFU)

### DIFF
--- a/DMHub CharacterSheet Base/CharacterSheetAppearance.lua
+++ b/DMHub CharacterSheet Base/CharacterSheetAppearance.lua
@@ -653,7 +653,7 @@ function CharSheet.FramePreviewPanel()
 
                                     local fields = { "portraitFrame", "portrait", "portraitBackground", "portraitRibbon",
                                         "portraitFrameHueShift", "name", "ownerId", "portraitZoom", "portraitOffset",
-                                        "saddles", "saddleSize", "saddlePositions", "popoutScale" }
+                                        "saddles", "saddleSize", "saddlePositions", "popoutScale", "tokenScale" }
                                     for i, field in ipairs(fields) do
                                         if g_previewToken[field] ~= info.token[field] then
                                             g_previewToken[field] = info.token[field]


### PR DESCRIPTION
**Symptom:** On the character sheet's Appearance tab, the "what your token looks like in-game" preview always renders at 100% scale, ignoring the token's saved Scale (e.g. a token set to 64% previews at 100%); it only corrects once the Scale slider is dragged, and resets on reopen. The token on the map is unaffected.

**Root cause:** `CharSheet.FramePreviewPanel()` builds the preview from a throwaway token created by `previewFloor:CreateToken(...)`, which the engine initializes with a token scaling of 1.0. The `refreshAppearance` handler then copies an explicit list of appearance fields from the real token onto the preview token. `tokenScale` was missing from that list, so the preview kept the engine default of 1.0. The Scale slider's `change` handler writes `g_previewToken.tokenScale` directly, which is why dragging the slider appeared to "fix" it.

**Fix:** Add `"tokenScale"` to the `fields` list in that handler (one line). The existing copy loop compares and assigns it like any other field, and bumps `diffs` so the preview re-renders - the same shape as the neighbouring `popoutScale` entry. Slider handlers are unchanged.

Report: BBHB6GFU

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
