### PR TITLE
Fix /objectcommand keyword form broken by duplicate macro registration (report 97KQQURQ)

### DIFF
--- a/DMHub Core Panels/ObjectPropertiesDialog.lua
+++ b/DMHub Core Panels/ObjectPropertiesDialog.lua
@@ -6,6 +6,14 @@ mod.shared.objectDragAcceptors = {}
 --addressed by floor id + object id. This is the executable form recorded by
 --the command builder's lightning icons on the property dialog's command
 --buttons, so journal macro buttons can drive specific objects.
+--
+--Codex Macros/Macros.lua already registers an 'objectcommand' with the older
+--keyword form, /objectcommand <keyword[.component]> <command>, and this file
+--loads after it, so registering the same name here replaces it. Capture the
+--previous implementation and fall back to it for the two-argument keyword
+--form, so journal buttons written against the old syntax keep working.
+local legacyObjectCommand = Commands.objectcommand
+
 Commands.RegisterMacro{
     name = "objectcommand",
     summary = "execute a command on a map object",
@@ -13,6 +21,11 @@ Commands.RegisterMacro{
     command = function(str)
         local floorid, objid, cmdName = string.match(str or "", "^%s*(%S+)%s+(%S+)%s+(.-)%s*$")
         if floorid == nil or cmdName == nil or cmdName == "" then
+            --not the three-field form; hand it to the older keyword form.
+            if legacyObjectCommand ~= nil then
+                return legacyObjectCommand(str)
+            end
+
             dmhub.Log("objectcommand: usage: /objectcommand <floorid> <objectid> <command>")
             return
         end


### PR DESCRIPTION
**Symptom:** Journal command buttons that run `/objectcommand <keyword> <command>` (e.g. the Delian Tomb's "Open Door" button, `/objectcommand d14_door.Door opendoor`) do nothing when pressed.

**Root cause:** Two different macros are registered under the name `objectcommand`. `Codex Macros/Macros.lua` (required at `main.lua:42`) registers the original keyword form, `/objectcommand <keyword[.component]> <command>`. `DMHub Core Panels/ObjectPropertiesDialog.lua` (required at `main.lua:52`, added in befc2f4a) later registers the same name with the identity form `/objectcommand <floorid> <objectid> <command>`. `Commands.RegisterMacro` simply assigns `Commands[name] = fn`, so the later registration silently replaces the earlier one. The new parser requires three whitespace-separated fields, so a two-token keyword invocation matches nothing and falls straight into the `dmhub.Log("objectcommand: usage: ...")` branch. The reporter's log shows 20+ presses, each `ExecuteCommand: Executing = objectcommand with ARGS d14_door.Door opendoor` followed immediately by the usage message; the legacy implementation's own trace never appears. Both the shipped `data/objectTables/documents/d3-hall-of-the-brave.yaml` and `useful-macros.yaml` documents use the keyword form.

**Fix:** In `DMHub Core Panels/ObjectPropertiesDialog.lua` only, capture the previously registered implementation into a file-scope local before re-registering the name, and delegate to it when the three-field match fails. The two forms are unambiguous by argument count: the keyword form is always exactly two tokens (its implementation only ever reads `args[1]`/`args[2]`), the identity form always three. `RegisterMacro` builds a fresh closure per registration, so the captured value is always a distinct prior closure and the delegation chain terminates. If no previous registration exists, the original usage message is still logged. Syntax checked with `luac -p`; no other file changes.

Report id: 97KQQURQ. This PR originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
