### PR TITLE
Fix titlescreen crash reading uninitialized gamehud global (report 7DX8B39H)

### DIFF
--- a/DMHub Core UI/DockablePanel.lua
+++ b/DMHub Core UI/DockablePanel.lua
@@ -65,7 +65,7 @@ setting{
     onchange = function()
         --Apply the new scale live to any docks that already exist. Docks are
         --only created once a game is active; bail out otherwise.
-        if gamehud == nil or rawget(gamehud, "leftDock") == nil then
+        if rawget(_G, "gamehud") == nil or rawget(gamehud, "leftDock") == nil then
             return
         end
         for _,dock in ipairs(gamehud:Docks()) do
@@ -2368,7 +2368,7 @@ DockablePanel = {
 	--Views feature to capture the working layout.
 	GetDockPanels = function(side)
 		local result = {}
-		if gamehud == nil or rawget(gamehud, "leftDock") == nil then
+		if rawget(_G, "gamehud") == nil or rawget(gamehud, "leftDock") == nil then
 			return result
 		end
 		local dock = cond(side == "right", gamehud.rightDock, gamehud.leftDock)
@@ -2391,7 +2391,7 @@ DockablePanel = {
 	--mechanics as Deserialize. Used by the icon rail so a dock opened from
 	--the rail carries that rail side's panels.
 	SetDockPanels = function(side, names)
-		if gamehud == nil or rawget(gamehud, "leftDock") == nil then
+		if rawget(_G, "gamehud") == nil or rawget(gamehud, "leftDock") == nil then
 			return
 		end
 		local dock = cond(side == "right", gamehud.rightDock, gamehud.leftDock)
@@ -2513,7 +2513,7 @@ DockablePanel = {
 					click = function(operation)
 						-- Docks are only created once a game is active. Bail out
 						-- silently when invoked from the lobby.
-						if gamehud == nil or rawget(gamehud, "leftDock") == nil then
+						if rawget(_G, "gamehud") == nil or rawget(gamehud, "leftDock") == nil then
 							return
 						end
 
@@ -2637,7 +2637,7 @@ DockablePanel = {
 
 
 	FindInstance = function(identifier)
-        if gamehud == nil or rawget(gamehud,"leftDock") == nil then
+        if rawget(_G, "gamehud") == nil or rawget(gamehud,"leftDock") == nil then
             return nil
         end
 		for _,dock in ipairs({gamehud.leftDock, gamehud.rightDock, gamehud.floatingDock}) do
@@ -2987,7 +2987,7 @@ end
 --with layout and the scaled dock drifts off its edge. See the setScale dock
 --event and the note in CreateSingleDock.
 local function ApplyDockScale()
-	if gamehud == nil or rawget(gamehud, "leftDock") == nil then
+	if rawget(_G, "gamehud") == nil or rawget(gamehud, "leftDock") == nil then
 		return
 	end
 	for _,dock in ipairs(gamehud:Docks()) do


### PR DESCRIPTION
**Symptom:** On the titlescreen, opening the dev-only Developer menu throws `Attempt to read uninitialized variable gamehud` and the menu fails to build.

**Root cause:** Six guards in `DMHub Core UI/DockablePanel.lua` test the `gamehud` global with a bare read (`if gamehud == nil or rawget(gamehud, "leftDock") == nil then`). DMHub's Lua runs with strict globals -- `lua-core` installs a `_G.__index` that raises `error("Attempt to read uninitialized variable "..n)` -- and the engine only publishes `gamehud` once the in-game hud is built. Before any game is entered the global has never been assigned, so the guard's own first term raises instead of evaluating to true. The reported traceback is `DockablePanel:2640 in field 'FindInstance'` <- `:2471 GetMenuItems` <- `CodexTitleBar:6747`. The `rawget(gamehud, ...)` second term was already the safe form; only the first term was wrong.

**The fix:** In each of those six conditions, change only the first term to `rawget(_G, "gamehud") == nil`. `rawget` on `_G` bypasses the strict-global `__index` and yields nil instead of raising when the global is absent; when the global is set it returns exactly the value the bare read returned, so in-game behaviour is unchanged. The short-circuit means the later `gamehud` reads only run when the global exists. This is the same idiom already used in `Codex Titlescreen/CodexTitleBar.lua`. No other lines, files, or bodies were touched.

Report id: `7DX8B39H`

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
