### PR TITLE
Add "leash" movement restriction so Hooked can be enforced

### DIFF
--- a/DMHub Game Rules/Creature.lua
+++ b/DMHub Game Rules/Creature.lua
@@ -6874,6 +6874,19 @@ function creature:ApplyOngoingEffect(ongoingEffectid, duration, casterInfo, opti
 	--use this as an opportunity to clean up any ongoingEffects that are no longer active.
 	self.ongoingEffects = self:ActiveOngoingEffects(true)
 
+	--Record where the caster stood when this effect landed. Effects that leash a target
+	--to "the caster's position when this ability is used" (Hooked) measure from this
+	--point, so it has to be captured now -- the caster is free to walk away afterwards.
+	if casterInfo ~= nil and casterInfo.tokenid ~= nil and casterInfo.loc == nil then
+		local casterLocToken = dmhub.GetTokenById(casterInfo.tokenid)
+		if casterLocToken ~= nil and casterLocToken.valid then
+			local casterLoc = casterLocToken.loc
+			if casterLoc ~= nil and casterLoc.valid then
+				casterInfo.loc = { x = casterLoc.x, y = casterLoc.y, floor = casterLoc.floor }
+			end
+		end
+	end
+
 	options = options or {}
 
 	if options.transformid ~= nil then

--- a/DMHub Game Rules/ModifierMovementText.lua
+++ b/DMHub Game Rules/ModifierMovementText.lua
@@ -183,42 +183,109 @@ CharacterModifier.TypeInfo.movementtext = {
 
 CharacterModifier.RegisterType('movementrestriction', "Movement Restriction")
 
+--The two shapes a movement restriction can take. "approach" stops a creature closing
+--on something (frightened); "leash" stops it straying too far from something (hooked).
+local g_restrictionTypes = {
+    {
+        id = "approach",
+        text = "Cannot Approach Target",
+    },
+    {
+        id = "leash",
+        text = "Cannot Stray From Target",
+    },
+}
+
+--Resolves the modifier's Target formula to a token id. Drawing one movement overlay
+--tests hundreds of tiles, so the answer is cached on the creature for the frame -- it
+--cannot be cached on the modifier, which is shared by every creature carrying the effect.
+local function ResolveRestrictionTarget(modifier, creature)
+    local formula = modifier:try_get("targetFormula", "")
+    if formula == "" then return nil end
+
+    local currentFrame = dmhub.FrameCount()
+    local cache = creature:try_get("_tmp_movementRestrictionTargets")
+    if cache == nil or cache.frame ~= currentFrame then
+        cache = { frame = currentFrame, targets = {} }
+        creature._tmp_movementRestrictionTargets = cache
+    end
+
+    local cacheKey = modifier:try_get("guid", formula)
+    local cached = cache.targets[cacheKey]
+    if cached ~= nil then
+        return cached.charid
+    end
+
+    local targetCharid = nil
+    local result = dmhub.EvalGoblinScriptToObject(formula, creature:LookupSymbol(), "Movement restriction target")
+    if type(result) == "string" and result ~= "" then
+        targetCharid = result
+    elseif type(result) == "number" then
+        targetCharid = tostring(math.floor(result))
+    elseif result ~= nil and type(result) == "table" then
+        local tid = dmhub.LookupTokenId(result)
+        if tid ~= nil and tid ~= "" then
+            targetCharid = tid
+        end
+    end
+
+    cache.targets[cacheKey] = { charid = targetCharid }
+
+    return targetCharid
+end
+
+--The fixed point a leash is measured from. Draw Steel leashes read "can't move more
+--than N squares away from the caster's position when this ability is used", so they
+--anchor on where the caster stood when the effect landed -- creature:ApplyOngoingEffect
+--records that in casterInfo.loc. Anything without a recorded position (a condition, an
+--aura, an effect applied before this was recorded) falls back to where the anchor
+--creature is standing right now.
+local function GetLeashAnchorLoc(modContext, targetToken, targetCharid)
+    local ongoingEffect = modContext ~= nil and modContext.ongoingEffect or nil
+    if ongoingEffect ~= nil then
+        local casterInfo = ongoingEffect:try_get("casterInfo")
+        if casterInfo ~= nil and casterInfo.tokenid == targetCharid and type(casterInfo.loc) == "table" then
+            local recorded = casterInfo.loc
+            if type(recorded.x) == "number" and type(recorded.y) == "number" then
+                return core.Loc{x = recorded.x, y = recorded.y, floorIndex = recorded.floor}
+            end
+        end
+    end
+
+    return targetToken.loc
+end
+
 CharacterModifier.TypeInfo.movementrestriction = {
     init = function(modifier)
         modifier.targetFormula = ""
+        modifier.restrictionType = "approach"
+        modifier.distance = 3
     end,
 
-    -- Returns false if stepping onto loc would bring the creature closer to the
-    -- target than its starting position.
+    -- Returns false if stepping onto loc would break the restriction: for "approach",
+    -- getting closer to the target than the creature's starting position; for "leash",
+    -- ending up more than 'distance' squares from the anchor point.
     MoveToLocPermitted = function(modifier, modContext, creature, startLoc, loc)
-        local formula = modifier:try_get("targetFormula", "")
-        if formula == "" then return true end
-
-        -- Cache the resolved charid per frame so EvalGoblinScriptToObject only runs
-        -- once across all tile checks in a single movement overlay calculation.
-        local currentFrame = dmhub.FrameCount()
-        local targetCharid = modifier:try_get("_tmp_targetCharid")
-        if modifier:try_get("_tmp_targetFrame") ~= currentFrame then
-            targetCharid = nil
-            local result = dmhub.EvalGoblinScriptToObject(formula, creature:LookupSymbol(), "Movement restriction target")
-            if type(result) == "string" and result ~= "" then
-                targetCharid = result
-            elseif type(result) == "number" then
-                targetCharid = tostring(math.floor(result))
-            elseif result ~= nil and type(result) == "table" then
-                local tid = dmhub.LookupTokenId(result)
-                if tid ~= nil and tid ~= "" then
-                    targetCharid = tid
-                end
-            end
-            modifier._tmp_targetFrame = currentFrame
-            modifier._tmp_targetCharid = targetCharid
-        end
-
+        local targetCharid = ResolveRestrictionTarget(modifier, creature)
         if targetCharid == nil or targetCharid == "" then return true end
 
         local targetToken = dmhub.GetTokenById(targetCharid)
         if targetToken == nil or (not targetToken.valid) then return true end
+
+        if modifier:try_get("restrictionType", "approach") == "leash" then
+            local anchorLoc = GetLeashAnchorLoc(modContext, targetToken, targetCharid)
+            if anchorLoc == nil then return true end
+
+            local locDist = loc:DistanceInTiles(anchorLoc)
+            if locDist <= modifier:try_get("distance", 3) then
+                return true
+            end
+
+            -- Already outside the leash -- forced movement can push a creature out, and
+            -- the rules give no answer for that. Rather than freezing them in place,
+            -- allow any step that does not take them further away still.
+            return locDist <= startLoc:DistanceInTiles(anchorLoc)
+        end
 
         local targetLocs = targetToken.locsOccupying
         if targetLocs == nil or #targetLocs == 0 then return true end
@@ -249,8 +316,32 @@ CharacterModifier.TypeInfo.movementrestriction = {
                 element:FireEvent("refreshModifier")
             end
 
+            local restrictionType = modifier:try_get("restrictionType", "approach")
+
+            local targetHelp = "A GoblinScript expression that evaluates to the creature the restricted creature cannot approach. Can be a raw token ID number, or a GoblinScript expression such as ConditionCaster(\"Frightened\")."
+            if restrictionType == "leash" then
+                targetHelp = "A GoblinScript expression that evaluates to the creature the restricted creature must stay near. Distance is measured from where that creature stood when the effect was applied, falling back to where it is now. Can be a raw token ID number, or a GoblinScript expression such as ConditionCaster(\"Hooked\")."
+            end
+
             local children = {}
             children[#children+1] = modifier:FilterConditionEditor()
+
+            children[#children+1] = gui.Panel{
+                classes = {"formPanel"},
+                gui.Label{
+                    classes = {"formLabel"},
+                    text = "Restriction:",
+                },
+                gui.Dropdown{
+                    classes = {"formDropdown"},
+                    options = g_restrictionTypes,
+                    idChosen = restrictionType,
+                    change = function(self)
+                        modifier.restrictionType = self.idChosen
+                        Refresh()
+                    end,
+                },
+            }
 
             children[#children+1] = gui.Panel{
                 classes = {"formPanel"},
@@ -270,17 +361,38 @@ CharacterModifier.TypeInfo.movementrestriction = {
                         Refresh()
                     end,
                     documentation = {
-                        help = "A GoblinScript expression that evaluates to the creature the restricted creature cannot approach. Can be a raw token ID number, or a GoblinScript expression such as ConditionCaster(\"Frightened\").",
+                        help = targetHelp,
                         output = "creature",
                         examples = {
                             {
                                 script = "ConditionCaster(\"Frightened\")",
                                 text = "Cannot approach the creature that inflicted Frightened on this creature.",
                             },
+                            {
+                                script = "ConditionCaster(\"Hooked\")",
+                                text = "Cannot stray from the creature that inflicted Hooked on this creature.",
+                            },
                         },
                     },
                 },
             }
+
+            if restrictionType == "leash" then
+                children[#children+1] = gui.Panel{
+                    classes = {"formPanel"},
+                    gui.Label{
+                        classes = {"formLabel"},
+                        text = "Squares:",
+                    },
+                    gui.Input{
+                        text = tostring(modifier:try_get("distance", 3)),
+                        change = function(self)
+                            modifier.distance = math.max(0, math.floor(tonumber(self.text) or 3))
+                            Refresh()
+                        end,
+                    },
+                }
+            end
 
             element.children = children
         end

--- a/Draw Steel Ability Editor/AbilityEditorModifierPicker.lua
+++ b/Draw Steel Ability Editor/AbilityEditorModifierPicker.lua
@@ -212,6 +212,11 @@ local MODIFIER_METADATA = {
         tags = {"cast", "origin", "position", "source"},
         group = "movement",
     },
+    movementrestriction = {
+        description = "Stop the bearer approaching a creature, or straying more than a set number of squares from one.",
+        tags = {"restrict", "leash", "approach", "frightened", "hooked", "move"},
+        group = "movement",
+    },
     forcedmovement = {
         description = "Enable forced movement on the bearer.",
         tags = {"push", "pull", "slide", "forced", "move"},


### PR DESCRIPTION
## What

`movementrestriction` could only express one shape: stop a creature from **approaching** a target (Frightened). Draw Steel needs the opposite too -- Hooked reads *"a hooked target can't move more than 3 squares away from the caster's position when this ability is used"*.

This adds a `restrictionType` of `approach` (existing behaviour, still the default) or `leash`, with a configurable square count.

## The anchor point

A leash can't measure from the caster's *live* position -- the Orc Chainlock is free to walk away after hooking someone, and the rules text pins the distance to where it stood when the ability was used.

So `creature:ApplyOngoingEffect` now records the caster's position into `casterInfo.loc` as the effect lands, and the leash measures from that. Effects with no recorded position (auras, conditions, anything applied before this change) fall back to the anchor creature's current location, so nothing regresses.

## Edge case: already outside the leash

Forced movement can push a hooked creature past its own leash, and the rules give no answer for what happens next. Freezing them in place felt worse than the alternative, so any step that doesn't increase the distance is allowed -- they can always move back toward the anchor.

## Bug fixed along the way

The per-frame cache for the resolved target token was stored on the **modifier**, which is shared by every creature carrying the effect. Two hooked creatures in one frame would read each other's anchor. The cache now lives on the creature (`_tmp_movementRestrictionTargets`), keyed by modifier guid.

## Data side

The matching content change is already on `draw-steel-data` main (`4d6da10`): the Hooked ongoing effect gains a leash modifier at 3 squares targeting `ConditionCaster("Hooked")`. **The `data` submodule pointer is deliberately not bumped in this PR** -- happy to add that commit if you'd rather they land together.

## Testing

Not exercised in a running client -- the local DMHub MCP bridge was down and this checkout has no Lua interpreter, so neither a live test nor a `luac -p` syntax check was possible. Worth a hands-on pass on both restriction types before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
