### PR TITLE
Fix mode-gated purge deleting the effect its own ability just applied (report 64XYJBPE)

### DIFF
--- a/DMHub Game Rules/ActivatedAbility.lua
+++ b/DMHub Game Rules/ActivatedAbility.lua
@@ -4734,11 +4734,35 @@ function ActivatedAbilityApplyOngoingEffectBehavior:Cast(ability, casterToken, t
 		end
 	end
 
+	--MODE GATING ALSO MATTERS: a purge gated to a different mode than this apply
+	--can never run in the same cast (ActivatedAbilityBehavior:IsFiltered drops a
+	--behavior whose modesSelected does not contain options.symbols.mode), so it is
+	--not a pairing and must not install the FinishCast leak protection -- doing so
+	--deletes the effect the cast just applied. The Shieldscale Drangolin's
+	--"Size 2 or 3" applies its size effect on one mode and purges it on the other
+	--(report 64XYJBPE). Only treat the modes as exclusive when the engine actually
+	--honors them: multipleModes with a non-empty list on both sides.
+	local myModes = self:try_get("modesSelected", {})
+
 	local hasPurgePair = false
 	for i,b in ipairs(ability.behaviors) do
 		if (myIndex == nil or i > myIndex) and b.typeName == "ActivatedAbilityPurgeEffectsBehavior" and b.mode == "effect" and b.ongoingEffect == self.ongoingEffect then
-			hasPurgePair = true
-			break
+			local purgeModes = b:try_get("modesSelected", {})
+			local modeExclusive = false
+			if ability.multipleModes and #myModes > 0 and #purgeModes > 0 then
+				modeExclusive = true
+				for _,m in ipairs(myModes) do
+					if table.contains(purgeModes, m) then
+						modeExclusive = false
+						break
+					end
+				end
+			end
+
+			if not modeExclusive then
+				hasPurgePair = true
+				break
+			end
 		end
 	end
 	local pairedApplications = nil


### PR DESCRIPTION
**Symptom:** Using a multi-mode ability whose modes apply and remove the same ongoing effect (e.g. the Shieldscale Drangolin's "Size 2 or 3") appears to do nothing -- the effect is applied and then immediately removed as the cast finishes.

**Root cause:** `ActivatedAbilityApplyOngoingEffectBehavior:Cast` scans the ability's later behaviors for a matching `ActivatedAbilityPurgeEffectsBehavior` to detect an apply/purge "pairing", and when it finds one it installs a `FinishCast` handler that deletes anything the purge never got to (leak protection for casts canceled between the apply and the purge). That scan ignored mode gating. In an ability with `multipleModes`, a purge whose `modesSelected` is disjoint from the apply's `modesSelected` can never run in the same cast -- `ActivatedAbilityBehavior:IsFiltered` filters it out -- so it is not a pairing at all. Treating it as one made the `FinishCast` handler remove the effect the cast had just applied. This is the same failure shape as the earlier ordering bug (report NA3SCFH5), on a different axis.

**Fix:** Only count a purge as a pairing when it could actually run alongside this apply. The check mirrors the gate that really decides it (`IsFiltered`): the modes are considered exclusive only when `ability.multipleModes` is set and both behaviors have a non-empty `modesSelected` with no mode in common. When either side is un-gated, or the two share any mode, behavior is unchanged -- so the Dread March cancel-leak protection and the Stormwight ordering fix are preserved. The change only ever narrows when `hasPurgePair` is set.

Report id: 64XYJBPE

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
