### PR TITLE
fix(invoke): forward the trigger Subject on the local invoke path

### DIFF
--- a/DMHub Game Rules/AbilityInvokeAbility.lua
+++ b/DMHub Game Rules/AbilityInvokeAbility.lua
@@ -566,6 +566,10 @@ function ActivatedAbilityInvokeAbilityBehavior:Cast(ability, casterToken, target
 
                 else
 
+                    if options.symbols.subject ~= nil then
+                        symbols.subject = options.symbols.subject
+                    end
+
                     local abilityTemplate = nil
                     if self.abilityType == "named" then
                         local abilities = target.token.properties:GetActivatedAbilities{allLoadouts = true, bindCaster = true}


### PR DESCRIPTION
## Problem

`ActivatedAbilityInvokeAbilityBehavior:Cast` builds a deliberately minimal symbol table at `AbilityInvokeAbility.lua:475`, under the comment *"be careful not to put anything in here we don't want to transmit to the database."* That minimality exists for the **remote** path, which serializes the table and ships the trigger's `Subject` separately as `subjectid`, rebuilding it in `AbilityInvocation:Invoke` (`:1617`).

The **local** path has no equivalent rebuild. It passes that same bare table straight to `ExecuteInvoke` (`:803`), so an invoke that resolves on this machine hands the invoked ability no `Subject` at all.

Consequences on the local path:

- any behavior with `applyto: subject` resolves to an empty target list and silently does nothing (`ActivatedAbility.lua:3845`)
- any GoblinScript referencing `Subject` inside the invoked ability evaluates as empty

Which path you get is decided by `target.token.activeControllerId ~= nil`, so the same content works for a player-controlled token and silently no-ops for a Director-controlled one.

## Fix

Forward `Subject` on the local branch. It is forwarded on its own rather than unioning all of `options.symbols`: the other trigger-only symbols are opt-in for the reason documented at `attacker` (`:477-485`), and blanket-forwarding `compeltoward` would silently constrain unrelated invokes.

## How it was found

A Tactician's Mark move-trigger ("when the marked creature is reduced to 0 Stamina, you can move the mark to a new target") never cleared the mark from the old holder. The move is implemented as an invoked standard ability whose purge behavior uses `applyto: subject` to reach the old holder. Every piece checked out individually against a live instance — the correct trigger branch fired, `applyto: subject` resolved to the right creature, the caster filter matched, and the effect passed `AppliesToEffect` — but the purge never ran, because the invoked cast had no `Subject` to resolve.

## Regression review

- **Shipped content is unaffected.** Parsed every YAML in `objectTables` and `monsters`: 38 `applyto: subject` behaviors, **zero** nested under a `customAbility` (i.e. none reached through an invoke). All sit directly in triggered abilities, where `Subject` was already present. Exactly one string mentioning "Subject" appears inside a `customAbility` and it is a display name, not an expression.
- **Trigger gating is untouched.** `TriggeredAbility:Trigger` takes its symbols from the event `info` table (`CharacterModifier.lua:3953`), never from cast `options.symbols`, so the `symbols.subject == nil` fallbacks at `TriggeredAbility.lua:997/1150` cannot be reached by this.
- **Nothing new is serialized.** No path DeepCopies or serializes cast symbols into the database; the remote invoke already converts `Subject` to an id rather than shipping the object.
- **Scope.** Local branch only; the remote branch is unchanged. `symbols` is declared inside the per-target loop (`:451`), so the mutation cannot bleed between targets.
- **No new nil-deref.** `options.symbols` is already dereferenced unconditionally at `:475`, before the guarded read added here.

One pre-existing condition worth naming: `ActivatedAbilityForcedMovementBehavior:Cast` does `DeepCopy(options.symbols)` (`ActivatedAbility.lua:5360`), and `Subject` is a `GenerateSymbols` closure when restored by the remote path. That table already contains a closure on every invoke path — `ExecuteInvoke` sets `symbols.invoker = GenerateSymbols(...)` at `:883` — so this adds one more entry to a situation that already exists rather than a new failure mode.

## Testing

Syntax-checked against the engine's Lua. Symbol resolution and the `applyto: subject` redirect were verified live via the MCP bridge; `activeControllerId` was confirmed `nil` on the affected token, putting it on the local path. Not yet exercised through a full in-game repro of the Tactician trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
