### PR TITLE
Fix folder arrow in "Add to the run" picker toggling twice per click (report 49G5YPDX)

### DIFF
--- a/DocumentSystem/CampaignTrackerPanel.lua
+++ b/DocumentSystem/CampaignTrackerPanel.lua
@@ -1417,7 +1417,7 @@ local function CreateAddPopup(element)
             bodyPanel:SetClass("collapsed", not arrow:HasClass("expanded"))
         end
         arrow = gui.ExpandoArrow {
-            press = Toggle,
+            interactable = false,
         }
 
         local headerRow = gui.Panel {


### PR DESCRIPTION
**Symptom:** In the Run panel's "+ Add to the run" picker, clicking a folder's expand/collapse triangle opens and instantly closes the folder; clicking anywhere else on the folder row works.

**Root cause:** In `BuildFolderPanel` (`DocumentSystem/CampaignTrackerPanel.lua`), both the `gui.ExpandoArrow` and its parent `headerRow` registered the same `Toggle` closure on `press`. `SheetPanel.OnPointerDown` re-dispatches the pointer-down event up the hierarchy (`ExecuteEvents.ExecuteHierarchy(transform.parent...)`) whenever `swallowPress` is false, so a press that landed on the triangle fired `Toggle` once for the arrow and then again for the header row -- a net no-op.

**Fix:** One line. The arrow becomes `interactable = false` and drops its own `press` handler, so clicks over the triangle fall through to `headerRow` (full-width raycast target) and fire `Toggle` exactly once. `Toggle` already drives the arrow's `expanded` class, so the triangle still animates. `headerRow`'s `press = Toggle` is unchanged. This mirrors the established idiom at `DMHub Core Panels/MapImport.lua:2442`.

No new fields are passed to `gui.ExpandoArrow` beyond `interactable`, so the `triangle` theme class and 12x12 sizing survive `gui.CombineFields`.

Report id: 49G5YPDX

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
