### PR TITLE
Fix missing Rampage counter on the Beastheart character panel (report TG6UGB5X)

### DIFF
--- a/Draw Steel Beastheart/DSCompanion.lua
+++ b/Draw Steel Beastheart/DSCompanion.lua
@@ -1159,5 +1159,6 @@ if TacPanel ~= nil and TacPanel.RegisterHeroicResourceDisplay ~= nil then
         id = "rampage",
         create = CreateRampageBox,
         ord = 2,
+        classic = true,
     }
 end


### PR DESCRIPTION
**Symptom:** The Rampage counter disappeared from the Beastheart / companion character panel, even though Rampage is still tracked (Rampage 8 triggers still fire).

**Root cause:** `DSCompanion.lua` registers its Rampage box with `TacPanel.RegisterHeroicResourceDisplay`, but without the `classic` flag. Commit 00308a01 put the reworked hero panel behind the `dev:testcharpanel` preference (default `false`) and made `TacPanel.HeroicResourcesClassic()` filter registered displays with `if entry.classic then`. `victories` and `heroic` were marked `classic = true`; `rampage`, registered from another module, was not. So on the panel essentially everyone sees, the Rampage box is never built. It cannot fall back to OTHER RESOURCES either, because `TacPanel.OtherResources` lists `CharacterResource.rampageId` in its `excludedIds`. The classic section header already anticipates Rampage -- its `refreshCharacter` expands the section when `GetRampageDisplayToken()` is non-nil -- it just had no display to show.

**Fix:** Add `classic = true` to the Rampage registration in `Draw Steel Beastheart/DSCompanion.lua`. One line; it only puts the box back into the classic section's list. No resource math changes, and the reworked panel is unaffected (it selects displays by `where`, not `classic`). `CreateRampageBox` already collapses itself when `GetRampageDisplayToken()` returns nil, so non-Beastheart characters show nothing, and its panel structure matches `TacPanel.VictoriesBox`, so it lays out alongside VICTORIES / the heroic resource at ord 2 with no styling work.

**Report:** TG6UGB5X

Unconfirmed follow-up, deliberately not included here: the Acolyte "Patron's Gaze" box (`Draw Steel Acolyte/Acolyte.lua` ~line 1141) registers the same way without `classic` and may have the same problem. Out of scope for this report.

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
