### PR TITLE
Fix Jump leaking the free-movement flag, disabling move tracking (report D5SUHE3Y)

### DIFF
--- a/Draw Steel Ability Behaviors/AbilityJump.lua
+++ b/Draw Steel Ability Behaviors/AbilityJump.lua
@@ -488,6 +488,9 @@ function ActivatedAbilityJumpBehavior:ExecuteJump(ability, casterToken, targetLo
 
     local landLoc = ActivatedAbilityJumpBehavior.ShortLandingLoc(casterToken.loc, targetLoc, dists[tier])
 
+    --Saved and restored rather than cleared outright so this never stomps a value an
+    --enclosing flow (e.g. a relocate cast) is relying on.
+    local previousFreeMovement = casterToken.properties:try_get("_tmp_freeMovement", false)
     casterToken.properties._tmp_freeMovement = true
 
     local path = casterToken:Move(landLoc, {
@@ -499,6 +502,8 @@ function ActivatedAbilityJumpBehavior:ExecuteJump(ability, casterToken, targetLo
         movementType = "jump",
         jumpHeight = heights[tier],
     })
+
+    casterToken.properties._tmp_freeMovement = previousFreeMovement
 
     if path ~= nil and path.numSteps ~= 0 then
         options.symbols.cast.spacesMoved = options.symbols.cast.spacesMoved + path.numSteps


### PR DESCRIPTION
**Symptom:** After a hero uses a Jump ability, movement stops being tracked for the rest of the session -- movement becomes effectively unlimited, and the Sniper kit's Patient Shot (activation condition "Moved This Turn = 0") fires even after the hero has already moved, applying its speed-0 "cannot move this turn" ongoing effect.

**Root cause:** `ActivatedAbilityJumpBehavior:ExecuteJump` in `Draw Steel Ability Behaviors/AbilityJump.lua` sets `casterToken.properties._tmp_freeMovement = true` just before the jump's `casterToken:Move(...)` call, and nothing ever sets it back. `_tmp_freeMovement` is a client-local (`_tmp_`-prefixed, non-uploaded) property, so it stays true for the remainder of the session. `creature:Moved` in `DMHub Game Rules/Creature.lua` gates its entire "Move Cost" `token:ModifyProperties{...}` block on `if not self:try_get("_tmp_freeMovement") then`, so from the first jump onward `moveDistance` and `moveDistanceRoundId` are never written again and `creature:DistanceMovedThisTurn()` permanently returns 0.

**The fix:** Save the flag's previous value before the jump's `Move` and restore it immediately after, mirroring the existing pattern in `Draw Steel Ability Behaviors/AbilityRelocateAura.lua`. `creature:Moved` is invoked synchronously from inside `casterToken:Move`, so the flag is still true while the generic move-cost accounting is correctly suppressed, and is restored before any later movement. Restoring the saved value rather than hard-setting `false` preserves correct behavior when a jump runs nested inside a relocate cast that legitimately set the flag (`AbilityRelocateCreature.lua` sets it in `Cast` and clears it at the end).

The jump's own "Jump Move Cost" `ModifyProperties` block is unchanged -- that is what charges the jump's distance, and is why suppressing the generic accounting during the jump is correct in the first place.

Report id: `D5SUHE3Y`

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
