### PR TITLE
Fix Character panel FEATURES omitting ancestry traits (report ZJDJ8XCF)

### DIFF
--- a/Draw Steel Character Builder/FeatureCache.lua
+++ b/Draw Steel Character Builder/FeatureCache.lua
@@ -1886,7 +1886,25 @@ local function categoriserHasUnmadeChoice(creature, feature)
         local num = feature:NumChoices(creature)
         if num == nil or num <= 0 then return end
         local made = creature:GetLevelChoices()[feature.guid] or {}
-        if #made < num then unmade = true end
+        if feature:try_get("costsPoints") then
+            --A point-buy slot's NumChoices is the POINTS BUDGET, not a pick
+            --count -- two picks costing 3 points complete a 3-point slot --
+            --so completeness is judged by points spent, as the character
+            --sheet's FeatureUnspentChoices does.
+            local options = feature:GetOptions(creature:GetLevelChoices()) or {}
+            local spent = 0
+            for _,choiceid in ipairs(made) do
+                for _,opt in ipairs(options) do
+                    if opt.guid == choiceid then
+                        spent = spent + (rawget(opt, "pointsCost") or 1)
+                        break
+                    end
+                end
+            end
+            if spent < num then unmade = true end
+        elseif #made < num then
+            unmade = true
+        end
     end)
     return unmade
 end
@@ -1905,8 +1923,12 @@ local function categoriserFeatureGrantsSkillOrLanguage(feature)
         for _,m in ipairs(feature:try_get("modifiers", {})) do
             local subtype = m:try_get("subtype")
             local skills = m:try_get("skills")
+            --A "power" modifier's skills list SCOPES an edge or bane to those
+            --skill tests, it does not grant the skills, so it is not a grant.
+            local grantsSkillList = m:try_get("behavior") ~= "power"
+                and type(skills) == "table" and #skills > 0
             if subtype == "skill" or subtype == "language"
-                or (type(skills) == "table" and #skills > 0) then
+                or grantsSkillList then
                 found = true
                 return
             end


### PR DESCRIPTION
**Symptom:** The Character panel's FEATURES section shows no Ancestry group -- purchased ancestry traits (and on some ancestries the signature trait) appear only on the full character sheet's Features tab.

**Root cause:** Two helpers in the tac-panel curation of `Draw Steel Character Builder/FeatureCache.lua`:

1. `categoriserHasUnmadeChoice` compared the number of picks made against `NumChoices`. For a point-buy choice (`costsPoints: true`) `NumChoices` is the POINTS BUDGET, not a pick count. Draw Steel ancestries model purchased traits as one `CharacterFeatureChoice` with `costsPoints: true` and `numChoices: 3` (4 for Polder) whose options carry `pointsCost` 1 or 2, so a hero who spent 2+1 has only 2 picks against a budget of 3 and the slot was judged "unmade". `IsTacPanelEntry` then dropped the whole ancestry entry -- and because the categoriser carries the picks on the parent slot as `entry.chosen`, every purchased trait vanished with it.
2. `categoriserFeatureGrantsSkillOrLanguage` treated any modifier carrying a `skills` list as a skill grant. An edge/bane modifier (`behavior: power`, `modtype: edge`) uses `skills` to SCOPE which skill tests get the edge; it grants nothing. E.g. `data/objectTables/races/elf-high.yaml` "Signature Trait: High Elf Glamor" and "High Senses" were both misclassified as skill grants and curated out.

**The fix:**

1. When `feature:try_get("costsPoints")` is true, judge completeness by points spent -- resolve the options via `feature:GetOptions(creature:GetLevelChoices())`, sum `pointsCost` (default 1) over the chosen guids, and report unmade only when `spent < num`. This mirrors the character sheet's own `FeatureUnspentChoices` (`Draw Steel V/DrawSteelChararcterSheet.lua`). Non-`costsPoints` choices keep the existing `#made < num` comparison.
2. The bare-`skills`-list branch no longer fires for `behavior == "power"` modifiers. Real grants are written as `behavior: proficiency` + `subtype: "skill"` / `"language"` and still match through the untouched subtype branches.

Both helpers are file-local and feed only the Character-panel curation predicates (`IsPassiveFeature` / `IsTacPanelEntry`), so the blast radius is the Character panel's FEATURES list; the full character sheet is unaffected. Edit 1 stays inside the existing `pcall`.

**Reports:** ZJDJ8XCF (primary) and HBVSGVEM -- same defect, two reporters. Originated from automated feedback triage; please review before merge.
