### PR TITLE
Fix Add to the run folder arrow toggling twice (report 49G5YPDX)

### DIFF
--- a/DocumentSystem/CampaignTrackerPanel.lua
+++ b/DocumentSystem/CampaignTrackerPanel.lua
@@ -1417,6 +1417,10 @@ local function CreateAddPopup(element)
             bodyPanel:SetClass("collapsed", not arrow:HasClass("expanded"))
         end
         arrow = gui.ExpandoArrow {
+            --swallowPress: headerRow below also has press = Toggle, and the
+            --engine propagates press to ancestors, so without this a click on
+            --the arrow would toggle the folder twice and appear to do nothing.
+            swallowPress = true,
             press = Toggle,
         }
 


### PR DESCRIPTION
**Symptom:** In the Run panel's "+ Add to the run" picker, clicking a journal folder's expand/collapse arrow does nothing; clicking elsewhere on the same folder row works.

**Root cause:** In `DocumentSystem/CampaignTrackerPanel.lua`, `CreateAddPopup` -> `BuildFolderPanel` gives the `gui.ExpandoArrow` `press = Toggle`, and the `headerRow` panel that contains that arrow also has `press = Toggle`. The engine propagates pointer-down to ancestors -- `SheetPanel.OnPointerDown` ends with `ExecuteEvents.ExecuteHierarchy(transform.parent.gameObject, ...)` and only returns early when `swallowPress` is set. So a click on the arrow fired the arrow's `Toggle` and then the header row's `Toggle`: expand, then immediately collapse. A click off the arrow only hits the header row, so it toggled once and behaved correctly.

**Fix:** Add `swallowPress = true` to that `ExpandoArrow` so the press stops at the arrow. `swallowPress` only suppresses parent propagation (nothing else follows it in `OnPointerDown`), and this is the same idiom already used for an identical arrow-inside-clickable-header layout in `DMHub Import Framework/ImportDialog.lua`. Nothing else is changed: the `Toggle` closure, `headerRow`, and `bodyPanel` are untouched, and the other `ExpandoArrow` in this file (the run-row accordion) is unaffected -- it uses `click`, not `press`, and its header row has no press/click toggle.

Report id: 49G5YPDX

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
