### PR TITLE
Fix missing RAMPAGE box on the classic character panel (report TG6UGB5X)

### DIFF
--- a/Draw Steel Beastheart/DSCompanion.lua
+++ b/Draw Steel Beastheart/DSCompanion.lua
@@ -1159,5 +1159,6 @@ if TacPanel ~= nil and TacPanel.RegisterHeroicResourceDisplay ~= nil then
         id = "rampage",
         create = CreateRampageBox,
         ord = 2,
+        classic = true,
     }
 end


### PR DESCRIPTION
**Symptom:** The numeric RAMPAGE box no longer appears in the HEROIC RESOURCES section of the Beastheart's or the companion's character panel (Rampage itself is still tracked correctly - only the readout/editor is missing).

**Root cause:** The character panel rework (`00308a01`, "feat(character panel): put the hero rework behind dev:testcharpanel") split the resource-box list in two. `TacPanel.HeroicResourcesClassic()` renders only registered displays whose entry has `classic` set:

```lua
for id, entry in pairs(g_heroicResourceDisplays) do
    if entry.classic then
```

Only the built-in `victories` and `heroic` entries were flagged. The `rampage` display registered at the bottom of `Draw Steel Beastheart/DSCompanion.lua` was not, so it was filtered out. Because the reworked panel is gated behind `dev:testcharpanel`, which defaults to `false`, everyone gets the classic panel and nobody sees the box. (The classic section's own `refreshCharacter` already tests `GetRampageDisplayToken()` to decide whether to show HEROIC RESOURCES at all, which is why the section still appears - just empty of its Rampage box.)

**The fix:** Add `classic = true` to the `rampage` display registration - one table field, restoring exactly the pre-rework rendering path. It does not affect the reworked panel, which selects boxes via `BuildResourceDisplays(where)` on `entry.where` and ignores `classic`. `CreateRampageBox` already collapses itself when `GetRampageDisplayToken()` returns nil, so non-Beastheart creatures are unaffected. `ord = 2` places it after VICTORIES (0) and the heroic resource (1).

Verified with `luac -p` on the edited file.

Report id: **TG6UGB5X**

Not changed here, but worth a look separately: `Draw Steel Acolyte/Acolyte.lua` registers `patronsgaze` with the same omission and would be invisible on the classic panel for the same reason. Only the screenshot-confirmed Rampage defect is in scope for this PR.

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
