### PR TITLE
Fix jump leaking free-movement flag and zeroing move accounting (report D5SUHE3Y)

### DIFF
--- a/Draw Steel Ability Behaviors/AbilityJump.lua
+++ b/Draw Steel Ability Behaviors/AbilityJump.lua
@@ -488,6 +488,9 @@ function ActivatedAbilityJumpBehavior:ExecuteJump(ability, casterToken, targetLo
 
     local landLoc = ActivatedAbilityJumpBehavior.ShortLandingLoc(casterToken.loc, targetLoc, dists[tier])
 
+    --Saved and restored rather than cleared outright so this never stomps a
+    --value an enclosing flow (e.g. a relocate) is relying on.
+    local previousFreeMovement = casterToken.properties:try_get("_tmp_freeMovement", false)
     casterToken.properties._tmp_freeMovement = true
 
     local path = casterToken:Move(landLoc, {
@@ -499,6 +502,8 @@ function ActivatedAbilityJumpBehavior:ExecuteJump(ability, casterToken, targetLo
         movementType = "jump",
         jumpHeight = heights[tier],
     })
+
+    casterToken.properties._tmp_freeMovement = previousFreeMovement
 
     if path ~= nil and path.numSteps ~= 0 then
         options.symbols.cast.spacesMoved = options.symbols.cast.spacesMoved + path.numSteps


### PR DESCRIPTION
**Symptom:** After using a Jump ability, a hero's ordinary movement stopped counting, so Patient Shot's "if you don't take a move action this turn" bonus fired even after moving 7 squares -- and its speed-0 effect then locked the hero out of the rest of their movement.

**Root cause:** `ActivatedAbilityJumpBehavior:ExecuteJump` set `casterToken.properties._tmp_freeMovement = true` before `casterToken:Move(...)` to exempt the jump itself from the movement budget, but never restored it. `_tmp_*` properties are client-local and persist on the creature for the remainder of the session, so from that point on every ordinary move by that creature skipped its move-cost accounting: `creature:Moved` (`DMHub Game Rules/Creature.lua`) only runs `token:ModifyProperties{description = "Move Cost", ...}` inside `if not self:try_get("_tmp_freeMovement") then`. `moveDistance` stayed 0, and anything gated on `Moved This Turn` -- Patient Shot's `activationCondition` among them -- read the creature as not having moved.

**Fix:** Save `_tmp_freeMovement` before setting it and restore it immediately after the `Move` call returns, before the jump's own "Jump Move Cost" accounting block. The `Moved` event is dispatched synchronously from inside `Move`, so the jump's own movement is still exempted exactly as before; only the leak past the end of the jump is closed. Saved/restored rather than cleared outright so an enclosing flow (e.g. a relocate) that set the flag is not stomped -- the same idiom already used in `Draw Steel Ability Behaviors/AbilityRelocateAura.lua`, and `DMHub Game Rules/AbilityRelocateCreature.lua` likewise clears the flag at the end of its Cast. This restores parity rather than introducing a new pattern.

`AbilityJump.lua` contains exactly one `:Move(` call, so nothing later in the jump flow depends on the flag remaining set. Verified with `luac -p`; file remains pure ASCII.

Report: `D5SUHE3Y`

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
