### PR TITLE
Fix character panel dropping point-bought ancestry traits (reports ZJDJ8XCF, HBVSGVEM)

### DIFF
--- a/Draw Steel Character Builder/FeatureCache.lua
+++ b/Draw Steel Character Builder/FeatureCache.lua
@@ -1886,7 +1886,25 @@ local function categoriserHasUnmadeChoice(creature, feature)
         local num = feature:NumChoices(creature)
         if num == nil or num <= 0 then return end
         local made = creature:GetLevelChoices()[feature.guid] or {}
-        if #made < num then unmade = true end
+        if feature:try_get("costsPoints") then
+            --For a point-buy slot NumChoices is the POINTS BUDGET, not a pick
+            --count: two picks costing 2+1 complete a 3-point slot. Judge
+            --completeness by points spent (mirrors FeatureUnspentChoices in
+            --Draw Steel V/DrawSteelChararcterSheet.lua).
+            local options = feature:GetOptions(creature:GetLevelChoices()) or {}
+            local spent = 0
+            for _,choiceid in ipairs(made) do
+                for _,opt in ipairs(options) do
+                    if opt.guid == choiceid then
+                        spent = spent + (rawget(opt, "pointsCost") or 1)
+                        break
+                    end
+                end
+            end
+            if spent < num then unmade = true end
+        else
+            if #made < num then unmade = true end
+        end
     end)
     return unmade
 end


### PR DESCRIPTION
**Symptom:** The character panel's FEATURES section shows an ancestry's signature trait but none of the point-bought ancestry traits (for some ancestries, no Ancestry group appears at all) -- the full character sheet shows them correctly.

**Root cause:** `categoriserHasUnmadeChoice` in `Draw Steel Character Builder/FeatureCache.lua` decided a choice slot was still unfinished with `#made < num`, i.e. it counted *picks* against `NumChoices`. For a `costsPoints` slot, `NumChoices` is the **points budget**, not a pick count (`CharacterFeatureChoice:Choices` in `DMHub Game Rules/Class.lua` reads it as `pointsAvailable`). Every ancestry's "Purchased X Traits" is a 3-point (Memonek/Polder 4) point-buy slot whose options cost 1 or 2 points, so a hero who fully spent the budget with fewer picks than 3 was flagged as having an unmade choice. `FeatureCategoriser.IsTacPanelEntry` then discarded the entire slot entry -- and because `categoriserAddBuildFeatures` suppresses each chosen option's own pipeline entry in favour of the slot row, dropping the slot dropped every purchased trait with it.

**Fix:** Make that one local predicate point-buy aware: when `costsPoints` is set, sum the `pointsCost` of the made choices and compare *points spent* against the budget. The logic is copied from the already-shipped, points-aware `FeatureUnspentChoices` helper in `Draw Steel V/DrawSteelChararcterSheet.lua`, which is why the full character sheet gets this right today.

Scope is deliberately narrow: non-point-buy choices keep byte-for-byte the previous behaviour, a genuinely under-spent point-buy slot still reports an unmade choice, and everything stays inside the existing `pcall` so a feature type lacking `GetOptions`/`try_get` still degrades to "no unmade choice" as before. No signature change; the predicate is used only by the tac-panel curation.

Verified: `luac -p` parses clean, file remains ASCII-only and CRLF.

Reports: **ZJDJ8XCF** ("The character panel does not have the ancestry features under the features section. The full character sheet does.") and **HBVSGVEM** ("Features section on the Character Pop-out sheet ONLY displays Signature Traits, but does not display purchased traits").

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
