### PR TITLE
fix(roll dialog): offer the defender's own after-roll modifiers

### DIFF
--- a/Timeline/EmbeddedRollDialog.lua
+++ b/Timeline/EmbeddedRollDialog.lua
@@ -4311,6 +4311,67 @@ function GameHud.CreateEmbeddedRollDialog()
         resultPanel:FireEventTree("dispatchTriggerUpdates")
     end
 
+    --Cached per-defender modifier copies, keyed "<modifier guid>/<defender charid>".
+    local m_defenderAfterRollCopies = {}
+
+    --Pass 3 of the after-roll modifier collection: the defender's own "Enemy
+    --Ability Rolls vs Us" modifiers, e.g. "an enemy who scores a tier 1 against
+    --you becomes frightened of you". Passes 1 and 2 only ever ask the roller.
+    --Scans every target, not just the one on display: the list is dialog-wide but
+    --gets rebuilt inside the per-target cycle in RecalculateMultiTargets.
+    local CollectDefenderAfterRollModifiers = function(result)
+        --"Enemy Ability Rolls vs Us" only pairs with an ability power roll; the
+        --gate keeps these out of the damage and test dialogs that share this code.
+        if rollType ~= "ability_power_roll" then
+            return
+        end
+
+        local defenderTokens = {}
+        if m_multitargets ~= nil then
+            for _, t in ipairs(m_multitargets) do
+                defenderTokens[#defenderTokens + 1] = t.token
+            end
+        elseif targetCreature ~= nil then
+            defenderTokens[1] = dmhub.LookupToken(targetCreature)
+        end
+
+        for _, defenderToken in ipairs(defenderTokens) do
+            if defenderToken ~= nil and defenderToken.valid and defenderToken.properties ~= creature then
+                local defenderMods = defenderToken.properties:GetAfterRollModifiersForPowerRoll(
+                    "enemy_ability_power_roll", {
+                        ability = m_options.ability,
+                        target  = defenderToken.properties,
+                        caster  = creature,
+                        title   = m_options.title or "",
+                        symbols = m_symbols,
+                    })
+
+                for _, mod in ipairs(defenderMods) do
+                    --casterCharid names the defender as the acting creature, which
+                    --the dialog otherwise defaults to the roller. Copied so the
+                    --shared class-feature modifier is left alone, and cached so the
+                    --entry merge keeps the player's checkbox state across passes.
+                    local key = tostring(mod.modifier:try_get("guid", "")) .. "/" .. defenderToken.charid
+                    local modifier = m_defenderAfterRollCopies[key]
+                    if modifier == nil then
+                        modifier = DeepCopy(mod.modifier)
+                        modifier.casterCharid = defenderToken.charid
+                        m_defenderAfterRollCopies[key] = modifier
+                    end
+
+                    --Not modFromTarget: that flag prefixes the row with "Target
+                    --is", which reads wrong for the defender's own feature.
+                    result[#result + 1] = {
+                        modifier    = modifier,
+                        context     = { mod = modifier },
+                        hint        = mod.hint,
+                        isAfterRoll = true,
+                    }
+                end
+            end
+        end
+    end
+
     RecalculateMultiTargets = function()
         if m_multitargets == nil or rollProperties == nil then
             return
@@ -4549,6 +4610,9 @@ function GameHud.CreateEmbeddedRollDialog()
                         end
                     end
                 end
+
+                -- Pass 3: the targets' own "Enemy Ability Rolls vs Us" after-roll modifiers.
+                CollectDefenderAfterRollModifiers(recollected)
 
                 -- Merge with existing entries to preserve any user override values.
                 local existingByModifier = {}
@@ -6330,6 +6394,9 @@ function GameHud.CreateEmbeddedRollDialog()
                                 end
                             end
 
+                            -- Pass 3: the targets' own "Enemy Ability Rolls vs Us" after-roll modifiers.
+                            CollectDefenderAfterRollModifiers(m_afterRollModifierEntries)
+
                             if #m_afterRollModifierEntries > 0 then
                                 m_options.modifiers = m_options.modifiers or {}
                                 for _, entry in ipairs(m_afterRollModifierEntries) do
@@ -6337,6 +6404,13 @@ function GameHud.CreateEmbeddedRollDialog()
                                 end
                                 resultPanel:FireEventTree('prepare', m_options)
                                 CalculateRollText{}
+
+                                --Acceptance consumes each target's modifiersUsed
+                                --snapshot, taken before the dice landed, so the
+                                --entries just added need a fresh pass to be seen.
+                                if m_multitargets ~= nil then
+                                    RecalculateMultiTargets()
+                                end
                             end
 
                             -- Auto-resolve for game systems with no manual Accept /


### PR DESCRIPTION
## Problem

A defender's **"Enemy Ability Rolls vs Us"** modifier that activates *after* the roll is currently offered by nobody, so it can never fire. The canonical case is a reactive feature like *"an enemy who scores a tier 1 against you becomes frightened of you"*.

Two things have to line up for such a modifier to reach the roll dialog, and neither does:

- The roll dialog's two existing after-roll collection passes only ever ask the **roller** (`creature`), never the targets.
- The before-roll defender pass in `MCDMAbilityRollBehavior` deliberately skips it, because `shouldShowInPowerRollDialog` rejects any modifier whose `activationAfterRoll` is a string.

## Change

Adds a third collection pass, `CollectDefenderAfterRollModifiers`, called from both places that build the after-roll entry list (the multi-target recalculation in `RecalculateMultiTargets`, and the roll-landed path).

It scans **every** target of the roll rather than just the one on display: the list is dialog-wide but gets rebuilt inside the per-target cycle in `RecalculateMultiTargets`, so collecting only the current target would let the last target cycled wipe out every other defender's entries.

The pass is gated to `rollType == "ability_power_roll"`. `"Enemy Ability Rolls vs Us"` only pairs with an attacker's ability power roll, and without the gate the defender's power modifiers would also surface in damage and test dialogs, which run this same collection.

### Per-defender modifier copies

Each entry uses a **cached copy** of the modifier rather than the modifier itself, for three reasons:

1. **Caster identity.** The roll dialog's resource/trigger loop defaults the acting creature to the roller, so the copy carries `casterCharid` to name the defender instead. Without it a custom trigger fires with the *attacker* as its caster — which, for a frighten effect, leaves the attacker frightened of itself.
2. **No shared mutation.** `GetActiveModifiers` hands out the class-feature modifier by reference; copying keeps `casterCharid` off the shared object.
3. **Checkbox stability.** The merge in `RecalculateMultiTargets` matches entries by modifier identity to preserve the player's checkbox state, so a fresh copy each pass would reset the checkbox every time. The cache is keyed `"<modifier guid>/<defender charid>"`.

Entries are deliberately *not* flagged `modFromTarget`: that flag means "a property of the target" and prefixes the row with "Target is", which reads wrong for a defender's own reactive feature. `casterCharid` already records ownership.

### Multi-target acceptance fix

On the multi-target path the roll-landed handler now calls `RecalculateMultiTargets()` after collecting. Acceptance consumes each target's `modifiersUsed` snapshot, which is taken *before* the dice land and so predates every after-roll entry just added. Only the single-target path re-snapshots at acceptance, so without this the modifier showed and read as active but its trigger never fired — until the player toggled it, which forced the same recalculation by hand.

## Testing

Syntax-checked with `load()` inside a running Codex instance (this machine has no standalone `luac`); ASCII-clean. Exercised in-game against a defender with a tier-based reactive frighten feature, on both the single-target and multi-target paths.
