### PR TITLE
fix(rules): honour stacking config for casterTracking="multiple" ongoing effects

### DIFF
--- a/DMHub Game Rules/Creature.lua
+++ b/DMHub Game Rules/Creature.lua
@@ -7014,10 +7014,14 @@ function creature:ApplyOngoingEffect(ongoingEffectid, duration, casterInfo, opti
 						cond._tmp_endAbility = ongoingEffect:GetEndAbility()
 						cond.casterInfo = casterInfo
 						cond.seq = highestSeq + 1
-						if options.stacks == nil then
-							cond.stacks = 1
+						--per-caster tracking decides WHICH instance we land on; once we have it,
+						--the effect's own stacking config still governs what happens to its stacks.
+						if ongoingEffect.stackable and not ongoingEffect.clearStacksWhenApplying then
+							cond.stacks = (cond.stacks or 1) + (options.stacks or 1)
+						elseif ongoingEffect.stackable then
+							cond.stacks = math.max((cond.stacks or 1), (options.stacks or 1))
 						else
-							cond.stacks = options.stacks
+							cond.stacks = options.stacks or 1
 						end
 						cond:Refresh(duration)
 						result = cond


### PR DESCRIPTION
## Problem

`creature:ApplyOngoingEffect` dispatches on an `if / elseif not stackable / else` chain, and `casterTracking == "multiple"` is tested **first**. A stackable effect that also uses per-caster tracking therefore never reaches the stacking branch below it.

Inside the `"multiple"` branch, when the same caster re-applies to a target that already carries their instance:

```lua
if options.stacks == nil then
    cond.stacks = 1
else
    cond.stacks = options.stacks
end
```

That is an assignment, not an accumulation, so the effect is silently pinned to the incoming value no matter how many times it is applied. The effect's own `stackable` and `clearStacksWhenApplying` settings are ignored entirely.

## Change

Per-caster tracking should only decide *which* instance we land on; once we have it, the effect's own stacking config still governs what happens to its stacks. This applies the same three-way rule the stackable branch already uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
