### PR TITLE
fix(triggers): clear resourceNumber when a trigger's cost is removed

### DIFF
--- a/Draw Steel Ability Editor/NewTriggeredAbilityEditor.lua
+++ b/Draw Steel Ability Editor/NewTriggeredAbilityEditor.lua
@@ -1346,6 +1346,7 @@ local function buildSetupSection(ability, refreshSection, fireChange, editorOpti
                         ability.resourceNumber = tonumber(text)
                     else
                         ability.resourceCost = "none"
+                        ability.resourceNumber = nil
                     end
                     element.text = cond(ability.resourceCost == "none", "", ability.resourceNumber)
                 end,


### PR DESCRIPTION
### Problem

Clearing the **Resource Cost** box on a triggered ability sets `resourceCost = "none"` but leaves the old `resourceNumber` behind on the ability.

Nothing in `TriggeredAbility.lua` reads `resourceCost` -- the runtime prompt title reads `resourceNumber` on its own:

```lua
local cost = self:try_get("resourceNumber")
if type(cost) == "number" then
    text = string.format("%s (%d %s)", text, cost, casterToken.properties:GetHeroicResourceName())
end
```

So the orphaned value keeps annotating the prompt. A trigger that had it's 2 cost removed rendered as:

> **Trigger Name (2 HR) (0 HR)**

### Why it only affects edited abilities

A trigger that never had a cost stores no `resourceNumber` at all, so `try_get` returns `nil` and the `type(cost) == "number"` guard skips the annotation. Surveying one game's compendium: 174 triggers stored nothing, 11 stored a genuine cost, and **3 were in the stale state** -- two carrying a leftover `0` (rendering `(0 Nerve)`) and one carrying a leftover `1`, rendering a cost the ability did not have.

### Fix

Drop the field alongside the flag, so a cleared cost leaves the ability in the same shape as one that never had a cost:

```lua
else
    ability.resourceCost = "none"
    ability.resourceNumber = nil
end
```

### Safety of the following line

The next line is `element.text = cond(ability.resourceCost == "none", "", ability.resourceNumber)`. Since `cond` is a function and evaluates all three arguments, it reads `ability.resourceNumber` even on the `"none"` path. That read is safe with the field removed -- `TriggeredAbility` extends `ActivatedAbility`, which defines `ActivatedAbility.resourceNumber = 1`, so it falls back to the type default rather than raising an unknown-field error. Verified live:

```
stored (rawget): nil
plain read ok? true   value: 1
cond(...) as at line 1350 ok? true -> []
trigger prompt title: Double Down (2 Nerve)
```

### Notes

- Editor-side only; no change to `TriggeredAbility.lua`. Zero-cost triggers now simply never reach the annotation branch.
- Existing content already saved with a stale `resourceNumber` keeps its wrong title until the ability is re-edited (or the field is cleared in the data); this change stops new ones from being created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
