### PR TITLE
fix(tools-menu): give Body Banks its own dna icon

### DIFF
--- a/Draw Steel V/MonsterBuilderTool.lua
+++ b/Draw Steel V/MonsterBuilderTool.lua
@@ -13,7 +13,7 @@ local mod = dmhub.GetModLoading()
 
 DockablePanel.Register{
     name = "Body Banks",
-    icon = "phosphor/hammer.png",
+    icon = "phosphor/dna-bold.png",
     menu = "tools",
     dmonly = true,
     launch = function()


### PR DESCRIPTION
## Summary
The Body Banks entry in the Tools menu (and its icon-rail button) shipped with the placeholder phosphor hammer icon. This swaps it to phosphor/dna-bold.png so the entry has an icon that reflects what it is.

## Changes
- `Draw Steel V/MonsterBuilderTool.lua`: DockablePanel registration icon changed from `phosphor/hammer.png` to `phosphor/dna-bold.png`.

## Testing
Verified in-game in the Tools dropdown. Bold weight chosen deliberately: context-menu icons render at 16x16 with an @fg tint, and the thin/light phosphor weights anti-alias into partial alpha there and read grey/faint next to the solid legacy glyphs (Undo/Redo/Zoom).

## Notes for reviewer
One-line change; no behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)