### PR TITLE
fix(targeting): Guise forced-friend hook + summon placement hover guard

### DIFF
--- a/DMHub Game Rules/Creature.lua
+++ b/DMHub Game Rules/Creature.lua
@@ -7467,10 +7467,21 @@ end
 
 -- Returns whether casterToken treats targetToken as a friend for TARGETING purposes.
 -- Mirrors casterToken:IsFriend, except a creature with the "Count Allies as Enemies"
--- attribute treats allies within N squares (N = attribute value) as enemies.
+-- attribute treats allies within N squares (N = attribute value) as enemies, and a
+-- creature with the "Count As Ally To Enemies" attribute forces everyone (even actual
+-- enemies) to treat it as a friend. The target-side "cannot be treated as enemy" check
+-- runs first and wins over both the base relationship and the caster-side attribute,
+-- since it represents an effect the target is actively using to protect itself.
 function IsFriendForTargeting(casterToken, targetToken)
     if casterToken == nil or targetToken == nil then
         return false
+    end
+
+    if targetToken.properties ~= nil then
+        local forcedFriend = targetToken.properties:CalculateNamedCustomAttribute("Count As Ally To Enemies")
+        if forcedFriend ~= nil and forcedFriend > 0 then
+            return true
+        end
     end
 
     local isFriend = casterToken:IsFriend(targetToken)

--- a/DrawSteelActionBar/DrawSteelActionBar.lua
+++ b/DrawSteelActionBar/DrawSteelActionBar.lua
@@ -11371,9 +11371,14 @@ CreateAbilityController = function()
                                 --The ability moves nobody -- it PLACES something in the hovered
                                 --square (a summon). The default "Movement: 3 squares" reads as the
                                 --caster walking there and quotes a movement cost that is never
-                                --spent, so name what actually arrives. GetPlacementName is nil for
-                                --any other nil-movement ability, which keeps the old wording.
-                                local placementName = g_currentAbility:GetPlacementName(g_token, g_currentSymbols)
+                                --spent, so name what actually arrives. GetPlacementName's definition
+                                --lives in a not-yet-merged PR (removed from main in e9a9ac38), and a
+                                --missing method on a game type raises rather than reading nil, so
+                                --pcall-guard: without the definition we keep the old wording.
+                                local placementName = nil
+                                pcall(function()
+                                    placementName = g_currentAbility:GetPlacementName(g_token, g_currentSymbols)
+                                end)
                                 if placementName ~= nil then
                                     diagramLabel = placementName
                                     diagramTextOverride = string.format(tr("%s appears here"), placementName)


### PR DESCRIPTION
## Summary
Two targeting-layer fixes from the Voiceless Talker Archivist (Condemned) implementation: a new target-side hook in IsFriendForTargeting powering the Guise malice feature, and a pcall guard on the summon-placement hover that has been raising on main since Aug 25.

## Changes
- `Creature.lua` — IsFriendForTargeting now checks the target for the "Count As Ally To Enemies" custom attribute first; when set, everyone (including real enemies) treats that creature as a friend for targeting. The attribute definition lives in the data repo (`objectTables/customattributes/count-as-ally-to-enemies.yaml`). The target-side check wins over the caster-side "Count Allies as Enemies" attribute since it represents an effect the target is actively using to protect itself.
- `DrawSteelActionBar.lua` — pcall guard around `ability:GetPlacementName` in the summon-placement hover. Commit e9a9ac38 split the GetPlacementName definitions out to a not-yet-merged PR but left this call site, so every summon-placement hover raises. @rickdog heads-up: when your PR restoring the definitions lands, this guard becomes a harmless no-op, but the guard lets main work in the meantime.

## Testing
Live-tested in-game: Guise applied to the Archivist prevents heroes from targeting him with hostile abilities for the duration; summon-placement hover no longer errors. James verified both during Archivist playtesting.

## Notes for reviewer
The Guise hook requires a Codex reload (not hot-load) since it changes core Lua.

🤖 Generated with [Claude Code](https://claude.com/claude-code)