### PR TITLE
Fix Ability Duration Effect leaking a copy on every trigger fire

### DIFF
--- a/DMHub Game Rules/Creature.lua
+++ b/DMHub Game Rules/Creature.lua
@@ -7332,6 +7332,35 @@ function creature:ApplyTemporaryEffect(effect)
     return result
 end
 
+--Removes EVERY copy of a temporary effect, unlike the single-slot cancel that
+--ApplyTemporaryEffect hands back. Use this when the owner of an effect wants it
+--gone regardless of how many times it was applied -- an ability whose cast ran
+--more than once can leave a copy behind whose cancel nobody holds any more, and
+--_tmp_ state is invisible to the character sheet, so a stray copy is otherwise
+--unreachable for the rest of the session.
+--- @param effect any the effect object that was passed to ApplyTemporaryEffect
+--- @return number how many copies were removed
+function creature:PurgeTemporaryEffect(effect)
+    local list = self:try_get("_tmp_temporaryEffects")
+    if list == nil then
+        return 0
+    end
+
+    local removed = 0
+    for i = #list, 1, -1 do
+        if list[i] == effect then
+            table.remove(list, i)
+            removed = removed + 1
+        end
+    end
+
+    if removed > 0 then
+        self:Invalidate()
+    end
+
+    return removed
+end
+
 function creature:ApplyMomentaryEffect(effect)
 	local momentaryEffects = self:get_or_add("_tmp_momentaryEffects", {})
 	momentaryEffects[#momentaryEffects+1] = effect

--- a/Draw Steel Ability Behaviors/AbilityTemporaryEffects.lua
+++ b/Draw Steel Ability Behaviors/AbilityTemporaryEffects.lua
@@ -88,30 +88,43 @@ function ActivatedAbilityApplyAbilityDurationEffect:Cast(ability, casterToken, t
 
         print("ApplyTo:: Applying effect to", #targets)
     local tokenids = {}
+    local targetCreatures = {}
 	for i,target in ipairs(targets) do
 		local targetCreature = target.token.properties
         tokenids[target.token.charid] = true
+        targetCreatures[#targetCreatures+1] = targetCreature
 		self.momentaryEffect.iconid = ability.iconid
 		self.momentaryEffect.display = ability.display
-		local result = targetCreature:ApplyTemporaryEffect(self.momentaryEffect)
-
-        --when the ability ends we remove the temporary effect.
-        options.OnFinishCastHandlers = options.OnFinishCastHandlers or {}
-        options.OnFinishCastHandlers[#options.OnFinishCastHandlers+1] = function()
-            if self.lingerTime > 0 then
-                dmhub.Schedule(math.min(self.lingerTime,10), function()
-                    print("ApplyTo:: Cancel")
-                    result.cancel()
-                    game.Refresh{
-                        tokens = tokenids,
-                    }
-                end)
-                return
-            end
-                    print("ApplyTo:: Cancel")
-            result.cancel()
-        end
+		targetCreature:ApplyTemporaryEffect(self.momentaryEffect)
 	end
+
+    --When the ability ends we purge EVERY copy of the effect from these targets,
+    --rather than cancelling just the one slot this call added. A triggered
+    --ability whose behaviors mix instant and non-instant runs this Cast twice per
+    --fire, and the first run's options table -- which holds that run's cancel --
+    --is thrown away, so a single-slot cancel leaves a copy applied permanently.
+    --Purging by effect cleans up after both runs from whichever handler survives.
+    local effect = self.momentaryEffect
+    local lingerTime = self.lingerTime
+    options.OnFinishCastHandlers = options.OnFinishCastHandlers or {}
+    options.OnFinishCastHandlers[#options.OnFinishCastHandlers+1] = function()
+        local function purge()
+            print("ApplyTo:: Cancel")
+            for _,targetCreature in ipairs(targetCreatures) do
+                targetCreature:PurgeTemporaryEffect(effect)
+            end
+            game.Refresh{
+                tokens = tokenids,
+            }
+        end
+
+        if lingerTime > 0 then
+            dmhub.Schedule(math.min(lingerTime,10), purge)
+            return
+        end
+
+        purge()
+    end
 
     game.Refresh{
         tokens = tokenids,


### PR DESCRIPTION
Fixes the leak behind issue `25KUGPFC` (reports `25KUGPFC`, `ZKS2C7V7`).

## The bug

A triggered ability whose behaviors mix an **instant** behavior with a **non-instant** one runs its instant half **twice** per fire, but only ever cleans up **once**. For `Ability Duration Effect` that strands one copy of the effect on the creature every single time the trigger fires, permanently, for the rest of the session.

1. `TriggeredAbility:ExecuteTriggerCast` calls `CastInstantPortion` to find out whether the cast needs a coroutine. That call is side-effecting — it runs every instant behavior, so the duration effect applies (**application #1**) and registers its cancel on the local `options` table.
2. Because a non-instant behavior is present, the branch that would run `options.OnFinishCastHandlers` is skipped and the whole table is discarded. **Application #1's cancel is orphaned.**
3. `TriggerCo` builds a fresh options table and calls `Cast`, which runs the instant portion again — **application #2**. Only that cancel ever runs.

Net: **+2 applications, −1 cancellation, one stranded copy per fire.**

The copies live in `_tmp_temporaryEffects`, which `GetActiveModifiers` folds in and which serialization skips entirely. So they keep supplying modifiers and triggered abilities while being invisible to the character sheet and absent from all saved data — disabling or deleting the source ability does nothing. Restarting the client clears them, which made it look intermittent.

Reported three times from three abilities that looked unrelated: Bloodfire Burn (minions never die), Provoking Nettles on Yddraed (damage on move-through after the trigger was disabled), and Gone Cold on the Stranger (a custom attribute stuck at 1 with no icon).

## The fix

**Fix the cleanup, not the execution.** Instant behaviors still run twice. The duration-effect behavior now registers one finish handler per cast that purges *every* copy of its effect from the targets it touched, instead of one handler per target each cancelling a single slot — so whichever of the two runs survives cleans up after both.

- `Creature.lua` — new `creature:PurgeTemporaryEffect(effect)` alongside the existing single-slot cancel. Reverse iteration, `Invalidate` once after mutation. List shape unchanged, so the reader in `GetActiveModifiers` is untouched.
- `AbilityTemporaryEffects.lua` — one handler per cast rather than per target.

`ActivatedAbility`, `TriggeredAbility` and `MCDMModifyTriggers` are **not touched**. The `MCDMModifyTriggers` variation-ability coroutine path is fixed for free, because the fix lives in the behavior rather than the call site.

## Why not fix the double-execution

**Please read this before suggesting the deeper fix** — it is the obvious one, and it breaks a shipped monster.

Replacing the side-effecting probe with a non-executing predicate was implemented and tested against 5,731 abilities with zero behavioral mismatches. It was then rejected: `ExecuteTriggerCast` defers its coroutine through `RunWhenCastsComplete`, so the probe ran instant behaviors *before* that deferral and moving execution into `Cast` puts them *after* it.

For a trigger that fires **mid-cast**, the effect then lands only once the triggering cast has resolved. Lightbender's **Stalker's AfterImage** triggers on taking damage from a strike and applies an effect reading *"the lightbender ignores any nondamaging effects from the triggering ability"* — it exists solely to be live **during** that ability. Deferred past it, the ability silently stops working. Flying Sawblade (`forcemove`) is exposed the same way.

No test caught it, because no *value* was wrong — only the moment of application moved. It was found by reading content.

**Constraint for any future fix:** instant behaviors must keep running before the `RunWhenCastsComplete` deferral. Thread the pre-coroutine `options` through `TriggerCo` into `Cast` with a flag suppressing the second run.

## Verification

Live, against Flying Sawblade (Bugbear Roughneck) — instant `ApplyAbilityDurationEffect` + non-instant `InvokeAbility`. The control row restores the old single-slot semantics in memory; everything else identical.

| Cleanup | Fires | Applications | Net stranded |
|---|---|---|---|
| **Purge all copies** (this PR) | 4 | 2 per fire | **0** |
| Single-slot cancel (before) | 3 | 2 per fire | **3** |

Applications stayed at two per fire in both rows — the double-execution is untouched and the leak is gone anyway. The control reproduces the reported bug exactly.

Unit checks on `PurgeTemporaryEffect`: three stacked copies removed in one call; second call returns 0; call against a creature that never had the field returns 0 without raising; removing one effect leaves others intact. Both files parse under Lua 5.4; ASCII-only; no line-ending churn.

### Repro for a test dummy

A Triggered Ability with trigger `End Turn`, behavior 1 = **Ability Duration Effect** ("Apply Instantly at Start" checked, Linger Time 0, momentary effect containing an *additive* modifier), behavior 2 = **Damage** (non-instant). Pre-fix the bonus compounds by one per turn and survives deleting the ability. Or watch `#(token.properties:try_get("_tmp_temporaryEffects") or {})`.

Note the console still prints two `ApplyTo:: Applying effect` to one `ApplyTo:: Cancel` **after** this fix — that is expected; the count is what changed.

## Known limitations

- **Two casters sharing one effect object can collide.** Compendium table entries are shared, so if two creatures carrying the same ongoing effect apply it to one target, the first finish handler purges both. Measured: `removed=2`. Exposure is **exactly one ability** — `Aura of Souls` (`applyto=targets`, `lingerTime=1`) — because monster abilities are deep-copied per token (verified: no live token shares a properties object with any asset). Symptom is self-limiting since the aura re-triggers, versus the permanent leak it replaces. Exact fix if wanted: tag applications with their caster, roughly fifteen lines.
- **The double-execution remains** and warrants its own ticket. Trigger-variation abilities still dispatch `useability` and `targetwithability` twice per cast, which can cascade into other triggers firing twice. Ordinary triggered abilities are unaffected — `CountsAsRegularAbilityCast()` returns false for them.
- **Instant-only trigger variations still leak** — that branch never reaches a `Cast`. Zero content exposure; the one variation in content is mixed.
- **The purge also removes the action-bar preview copy**, which the action bar re-derives on its next refresh.

## Unrelated findings worth their own tickets

**Five abilities throw on cast.** Four behavior `__typeName`s appear in YAML with no Lua implementation anywhere in the repo. The engine auto-creates the type on deserialization but *bare*, with no parent, so it never inherits `ActivatedAbilityBehavior.instant = false` and reading `behavior.instant` raises:

| Type name (YAML only) | Content |
|---|---|
| `ActivatedAbilityLeechTempStaminaBehavior` | Shambling Mound — "Leech" |
| `ActivatedAbilityHarvestCorpseBehavior` | Shambling Mound — "Alchemical Ingredients" |
| `ActivatedAbilityLeechDamageBehavior` | Wraith — "Stolen Vitality (1 Malice)"; "Leeching Wilds" |
| `ActivatedAbilityRepositionIntoEngulferBehavior` | "Impaled: Carried by the Ashen Hoarder" |

Broken independently of this PR — old and new code raise at the identical point with the identical message.

**Stale UI after removing a duration effect.** The pre-fix non-linger path called `cancel()` with no `game.Refresh`, while the linger path did. Incidentally fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
