### PR TITLE
Fix floor visibility toggle also switching the current floor (report NMAT9PH6)

### DIFF
--- a/DMHub Core Panels/Floors.lua
+++ b/DMHub Core Panels/Floors.lua
@@ -1716,6 +1716,7 @@ CreateLayersPanel = function()
 
 							gui.Panel{
 								classes = {'floorPanelIconPanel'},
+								swallowPress = true,
 								press = function(element)
 									floor.floorInvisible = not floor.floorInvisible
 									element:FireEventTree("refreshGame")


### PR DESCRIPTION
**Symptom:** In the Floors & Layers panel, clicking a floor's eye (visibility) icon also switches the current floor to that one, instead of only toggling its visibility.

**Root cause:** The eye icon panel handles `press` but does not set `swallowPress`, so the press propagates up to the enclosing floor row panel. Releasing over the row completes a click on the row, whose `click` handler calls `game.ChangeMap(game.currentMap, floor)`. The handler was changed from `click` to `press` in 940eee7d without adding `swallowPress`. This matches the reporter's workaround exactly: press the eye, drag off the panel, then release, so the row's click never completes.

**Fix:** Add `swallowPress = true` to the eye icon's panel in `CreateLayersPanel` (`DMHub Core Panels/Floors.lua`). The icon now consumes the press and the row never receives it. One-line change; the sibling lock icon and the layer-level icons (which already use `click`) are untouched. The only behavioural side effect is that drag-to-reorder can no longer be started from directly on top of the eye icon, which is the desired behaviour for a button.

Report id: NMAT9PH6

Originated from automated feedback triage.