### PR TITLE
Guard Create Aura behaviors that ship without an aura payload

### DIFF
--- a/DMHub Game Rules/Aura.lua
+++ b/DMHub Game Rules/Aura.lua
@@ -2024,6 +2024,17 @@ end
 --- @param targets table
 --- @param options table
 function ActivatedAbilityAuraBehavior:Cast(ability, casterToken, targets, options)
+    --The aura payload is only created when the author opens "Edit Aura" in the
+    --behavior editor, so content that sets only the duration ships with no aura
+    --field at all. Reading it would raise ("Attempt to read unknown field aura
+    --in type ActivatedAbilityBehavior") and kill the cast coroutine, taking
+    --every later behavior of the ability down with it. There is nothing to
+    --place, so log it for the author and let the rest of the cast resolve.
+    if not self:has_key("aura") then
+        print(string.format("AURA:: '%s' has a Create Aura behavior with no aura configured; skipping it.", tostring(ability.name)))
+        return
+    end
+
     --Purge before placing anything. This lives here rather than in CastOnArea
     --because one cast can cover several areas (targetAreaList), and purging
     --per-area would make a multi-area cast delete its own earlier areas.
@@ -2146,9 +2157,12 @@ function ActivatedAbilityAuraBehavior:CastOnArea(ability, casterToken, targets, 
             end
         end
 
+        --"none" is the Aura default meaning "no object" (see Aura.objectid);
+        --passing it through to SpawnObjectLocal just logs a spawn failure.
         local obj = nil
-        if self.aura.objectid ~= nil then
-            obj = targetFloor:SpawnObjectLocal(self.aura.objectid)
+        local auraObjectId = self.aura:try_get("objectid", "none")
+        if auraObjectId ~= nil and auraObjectId ~= "none" then
+            obj = targetFloor:SpawnObjectLocal(auraObjectId)
             if obj ~= nil then
                 auraInstance.object = {
                     floorid = obj.floorid,


### PR DESCRIPTION
Cherry-picked from the `Aura.lua` hunks of #270. That PR is still open and now conflicts with `main`; this half is self-contained, applies cleanly to current `main`, and fixes a live content bug, so it is worth landing on its own.

## The bug

The aura payload is only created when the author opens **Edit Aura** in the behavior editor, so content that sets only a duration ships with no `aura` field at all. `ActivatedAbilityAuraBehavior:Cast` reads `self.aura` unguarded, and a missing field on a registered game type **raises** rather than reading nil:

```
Attempt to read unknown field aura in type ActivatedAbilityBehavior
```

That kills the cast coroutine, which takes **every later behavior of the ability** down with it.

This is the same unknown-field-raises failure mode as the `GetPlacementName` regression fixed in #296.

## Shipped content hits this today

I scanned all 166 `ActivatedAbilityAuraBehavior` instances in the data repo. One lacks an `aura` field, and it is reachable — `monsters/high-elf-ordinator.yaml`, inside the invoked `And the Sun Forsook Her Children Presence Test`:

```yaml
- __typeName: ActivatedAbilityPowerRollBehavior   # tiers: "12 corruption damage; pull 5"
- __typeName: ActivatedAbilityAuraBehavior
  duration: eoe                                   # <-- no aura: field, raises here
- __typeName: ActivatedAbilityForcedMovementLocBehavior
  type: aura                                      # <-- the pull, never runs
```

So the Ordinator's power roll resolves and reports its tier, and then the pull the tiers promise silently never happens.

## The change

- `Cast`: if the behavior has no `aura` key, log it for the author and return, letting the rest of the cast resolve.
- `CastOnArea`: stop passing the Aura default `objectid: "none"` through to `SpawnObjectLocal`, which only logged a spawn failure.

16 insertions, 2 deletions, one file.

## Testing notes

Worth confirming on the High Elf Ordinator that the presence test now resolves through to the forced movement, and that a normal Create Aura ability (one with a configured payload) is unaffected — the guard only fires when the key is absent.

## Not included

The rest of #270 is still unmerged: summon placement naming (`GetPlacementName` / `SummonedCreatureName`), the persistent-cast dead-target guard, the invoke chooser caption, the villain-action prompt text, and two `GameHud.instance` nil-guards in DocumentSystem. Those touch files that have churned since Aug 25 and need a rebase; this one did not.
