### PR TITLE
End persistent recasts whose targets are all dead, before charging essence

### DIFF
--- a/Draw Steel Ability Behaviors/AbilityPersistentCast.lua
+++ b/Draw Steel Ability Behaviors/AbilityPersistentCast.lua
@@ -65,6 +65,26 @@ function ActivatedAbilityPersistenceControlBehavior:Cast(ability, casterToken, t
     local finished = false
     local canceled = false
 
+    --Persistent recasts whose every target is already dead or gone have nothing
+    --left to maintain; end them now, before the persistence cost is settled, so
+    --the caster is not charged essence for them. Multi-target entries survive
+    --while any target still lives (see creature:PersistentAbilityTargetsAllDead).
+    local autoEnded = casterToken.properties:AutoEndPersistentAbilitiesWithDeadTargets()
+    if #autoEnded > 0 then
+        casterToken:ModifyProperties{
+            description = "Persistent Ability Ended",
+            undoable = false,
+            execute = function()
+                casterToken.properties:FloatLabel(string.format(tr("%s ended: target dead"), table.concat(autoEnded, ", ")), "#C49A5A")
+            end,
+        }
+    end
+
+    --Nothing left to decide: behave as if the trigger had never fired.
+    if #(casterToken.properties:try_get("persistentAbilities") or {}) == 0 then
+        return
+    end
+
     local caster = casterToken:GetCreature()
     local casterClasses = caster:GetClassesAndSubClasses()
     local startOfTurnHeroicResource = 0

--- a/Draw Steel Core Rules/MCDMCreature.lua
+++ b/Draw Steel Core Rules/MCDMCreature.lua
@@ -6693,26 +6693,41 @@ function creature:PersistentAbilities()
 
             local targets = nil
 
+            --Set when a recast_target persistence has nobody left to recast on
+            --(every original target is dead, removed from the map, or -- with the
+            --"Target Must Be In Range" option -- out of range). The trigger is
+            --not offered at all in that case: previously it still prompted and
+            --opened a targeting flow whose filter matched no token, leaving the
+            --player with nothing to do but Skip.
+            local noValidTargets = false
+
             local filterstr = ""
             if persistenceMode == "recast_target" then
                 targeting = "inherit"
                 targets = {}
-                for i, targetid in ipairs(a.targets or {}) do
-                    if i == #a.targets then
-                        filterstr = string.format("%s %s", filterstr,
-                            string.format("self.id = %s", Utils.HashGuidToNumber(targetid)))
-                    else
-                        filterstr = string.format("%s or %s", filterstr,
-                            string.format("self.id = %s", Utils.HashGuidToNumber(targetid)))
-                    end
-                end
+                local selfToken = dmhub.LookupToken(self)
+                local filterParts = {}
                 for _, targetid in ipairs(a.targets or {}) do
                     local targetToken = dmhub.GetTokenById(targetid)
-                    if targetToken ~= nil then
+                    local usable = targetToken ~= nil and targetToken.valid and targetToken.properties ~= nil
+                        and (not targetToken.properties:IsDead())
+                    if usable and persistence:try_get("inrange") == true and selfToken ~= nil then
+                        local range = ability:GetRange(self)
+                        if type(range) == "number" and selfToken:Distance(targetToken) > range then
+                            usable = false
+                        end
+                    end
+                    if usable then
                         targets[#targets + 1] = {
                             token = targetToken,
                         }
+                        filterParts[#filterParts + 1] = string.format("self.id = %s", Utils.HashGuidToNumber(targetid))
                     end
+                end
+                if #filterParts == 0 then
+                    noValidTargets = true
+                else
+                    filterstr = table.concat(filterParts, " or ")
                 end
                 ability.targetFilter = filterstr
             elseif persistenceMode == "recast_with_one_target" then
@@ -6740,9 +6755,24 @@ function creature:PersistentAbilities()
                 end
             end
 
+            --Prompt shown at the bottom of the screen while the recast is being
+            --targeted. An ability can supply its own wording through
+            --persistence.promptText (authored in the ability data); it is
+            --appended after the ability name so the player sees what the recast
+            --lets them do. Conditions the engine has already checked before
+            --offering the trigger (start of turn, target alive) should not be
+            --restated there.
+            local promptText
+            local customPrompt = persistence:try_get("promptText")
+            if type(customPrompt) == "string" and trim(customPrompt) ~= "" then
+                promptText = string.format("%s: %s; %s", tr("Persistence"), ability.name, customPrompt)
+            else
+                promptText = string.format(tr("Persistence: Recast %s"), ability.name)
+            end
+
             local invoke = ActivatedAbilityInvokeAbilityBehavior.new {
                 customAbility = ability,
-                promptText = string.format(tr("Persistence: Recast %s"), ability.name),
+                promptText = promptText,
                 targeting = "prompt",
                 --targetingFormula = filterstr,
                 --targets = targets,
@@ -6767,7 +6797,9 @@ function creature:PersistentAbilities()
                 domains = {},
             }
 
-            result[#result + 1] = mod
+            if not noValidTargets then
+                result[#result + 1] = mod
+            end
         end
     end
 
@@ -6865,6 +6897,100 @@ function creature:EndPersistentAbilityById(guid)
     }
 
     return false
+end
+
+--- True when this persistent entry exists only to recast on specific targets
+--- (mode recast_target) and EVERY one of those targets is dead or gone from
+--- the map, so there is nothing left to maintain it for. Conservative on
+--- purpose:
+---  * one surviving target out of several keeps the entry alive;
+---  * an out-of-range target is not "gone" (it can come back into range);
+---  * an entry that is also keeping something else alive -- a linked aura or
+---    object, or a behavior with a "persistence" duration (e.g. the area of
+---    Web of All That's Come Before) -- is never reported, since ending it
+---    would drop that effect too;
+---  * an entry with no recorded targets is never reported.
+--- @param entry Persistence
+--- @return boolean
+function creature:PersistentAbilityTargetsAllDead(entry)
+    if type(entry) ~= "table" then
+        return false
+    end
+
+    --Entries are normally Persistence instances, but tolerate a plain table
+    --(older/partial data) rather than raising on a missing field.
+    local function field(key)
+        if entry.try_get ~= nil then
+            return entry:try_get(key)
+        end
+        return rawget(entry, key)
+    end
+
+    local ability = field("ability")
+    if ability == nil or type(ability) ~= "table" or getmetatable(ability) == nil then
+        return false
+    end
+
+    local persistence = ability:Persistence()
+    if persistence == nil or persistence.mode ~= "recast_target" then
+        return false
+    end
+
+    local targets = field("targets") or {}
+    if #targets == 0 then
+        return false
+    end
+
+    if #(field("objects") or {}) > 0 then
+        return false
+    end
+
+    for _, aura in ipairs(self:try_get("auras", {})) do
+        if aura:try_get("persistenceId") == entry.guid then
+            return false
+        end
+    end
+
+    for _, behavior in ipairs(ability:try_get("behaviors") or {}) do
+        if type(behavior) == "table" and behavior:try_get("duration") == "persistence" then
+            return false
+        end
+    end
+
+    for _, targetid in ipairs(targets) do
+        local targetToken = dmhub.GetTokenById(targetid)
+        if targetToken ~= nil and targetToken.valid and targetToken.properties ~= nil
+            and (not targetToken.properties:IsDead()) then
+            return false
+        end
+    end
+
+    return true
+end
+
+--- Ends every persistent ability whose recast targets are all dead or gone
+--- (see PersistentAbilityTargetsAllDead), so the caster is no longer charged
+--- for maintaining it. Returns the names of the abilities that were ended.
+--- Intended to run at the start of the caster's turn, before the persistence
+--- cost is settled.
+--- @return string[]
+function creature:AutoEndPersistentAbilitiesWithDeadTargets()
+    local ended = {}
+    local persistentAbilities = self:try_get("persistentAbilities", {})
+    for i = #persistentAbilities, 1, -1 do
+        local entry = persistentAbilities[i]
+        if self:PersistentAbilityTargetsAllDead(entry) then
+            local name = nil
+            if entry.try_get ~= nil then
+                name = entry:try_get("abilityName")
+            else
+                name = rawget(entry, "abilityName")
+            end
+            ended[#ended + 1] = name or "Persistent Ability"
+            self:EndPersistentAbilityById(entry.guid)
+        end
+    end
+    return ended
 end
 
 creature.RegisterSymbol {


### PR DESCRIPTION
Cherry-picked from the `AbilityPersistentCast.lua` and `MCDMCreature.lua` hunks of #270. That PR is still open and now conflicts with `main`; these two files apply cleanly to current `main` (one-line offset) and are the rules-correctness half of it. Follows #299, which took the `Aura.lua` half.

## The bug

A `recast_target` persistence whose targets are all dead has nothing left to maintain, but it was still offered and still billed. At the start of the caster's turn the trigger prompted, opened a targeting flow whose filter matched no token, and left the player with nothing to do but **Skip** — after the persistence cost had already been settled. The caster pays essence to maintain an ability on a corpse.

## The change

`creature:PersistentAbilityTargetsAllDead(entry)` reports an entry whose every recorded target is dead or gone. Deliberately conservative — it does **not** report:

- an entry where any one target still lives;
- an out-of-range target (it can come back into range);
- an entry with no recorded targets;
- an entry also keeping a linked aura, a spawned object, or a `duration: persistence` behavior alive (e.g. the area of Web of All That's Come Before), since ending it would drop that effect too.

`creature:AutoEndPersistentAbilitiesWithDeadTargets()` ends those entries and returns their names. `ActivatedAbilityPersistenceControlBehavior:Cast` now runs it **before** the persistence cost is settled, floats `"<ability> ended: target dead"`, and returns early when nothing is left to decide.

The recast target list itself also now filters dead, invalid, and — under **Target Must Be In Range** — out-of-range tokens, so the trigger is not offered at all when no valid target remains, instead of opening an unsatisfiable targeting flow.

## Two deliberate changes from #270's version

`persistence.promptText` and `persistence.inrange` now go through `try_get`.

`Persistence` is a registered game type that declares only `name`, and `RegisterGameType`'s `__index` calls `error("Attempt to read unknown field ...")` rather than returning nil unless the type opted into `allowUnsafeReads`. `promptText` is a new field that no shipped ability data sets, so the original direct read would have thrown from inside `creature:PersistentAbilities()` — a hot path — the first time any persistent ability built its trigger list. This is the same unknown-field failure mode as the `GetPlacementName` regression (#296) and the missing aura payload (#299).

`inrange` is read directly elsewhere in shipping code, so it is likely always set, but it is an optional editor toggle and older persistence data may predate it; `try_get` costs nothing there.

## Testing notes

I could not run a Lua syntax check — no interpreter on this machine — so the diff is the reviewed #270 hunks plus those two identifier-level edits, unvalidated by tooling.

Worth exercising in-app: a `recast_target` persistence whose sole target dies (should auto-end at the start of the caster's turn, float the label, and not charge); one with two targets where only one dies (should survive and still offer the recast); and a persistence keeping an aura alive whose target dies (should **not** auto-end).

## Still not included from #270

Summon placement naming (`GetPlacementName` / `SummonedCreatureName`, `AbilitySummon.lua` + `ActivatedAbility.lua`), the invoke chooser caption (`AbilityInvokeAbility.lua`), the villain-action prompt text (`MCDMActivatedAbility.lua`), and two `GameHud.instance` nil-guards in `DocumentSystem.lua`.
