### PR TITLE
Restore summon placement naming, and drop the pcall that stood in for it

### DIFF
--- a/DMHub Game Rules/AbilitySummon.lua
+++ b/DMHub Game Rules/AbilitySummon.lua
@@ -337,6 +337,90 @@ function ActivatedAbilitySummonBehavior:SummarizeBehavior(ability, creatureLooku
 	return "Summon Creatures"
 end
 
+--Memo for SummonedCreatureName below. The bestiary sweep is a full
+--assets.monsters scan with a GoblinScript evaluation per monster, and the
+--callers (the targeting prompt, the hovered-square label) run on every
+--targeting refresh. Keyed by monster type + filter + caster, since a filter may
+--reference the caster. Only invalidated by a reload; the value is display text
+--on a targeting prompt, so a bestiary edit mid-session going unnoticed is
+--acceptable.
+local g_summonNameCache = {}
+
+--- The name of the creature this behavior will summon, when that is knowable
+--- before the cast: nil when the filter matches several creatures (the caster
+--- picks one during the cast, so no single name is right yet) or when this is a
+--- duplicate-token behavior.
+--- @param casterToken CharacterToken
+--- @param symbols nil|table
+--- @return nil|string
+function ActivatedAbilitySummonBehavior:SummonedCreatureName(casterToken, symbols)
+    if self.duplicateMode or casterToken == nil then
+        return nil
+    end
+
+    if self.monsterType ~= "custom" then
+        local monster = assets.monsters[self.monsterType]
+        if monster == nil then
+            return nil
+        end
+        return monster.properties:try_get("monster_type")
+    end
+
+    local key = string.format("%s|%s|%s", tostring(self.monsterType), tostring(self.bestiaryFilter), tostring(casterToken.id))
+    local cached = g_summonNameCache[key]
+    if cached ~= nil then
+        return cached.name
+    end
+
+    --Mirror the candidate sweep in Cast (same filter, same beast symbol), but
+    --stop at the second match: we only care whether exactly one creature can be
+    --summoned. A malformed filter must not take the targeting UI down with it.
+    local name = nil
+    pcall(function()
+        local extra = {}
+        if symbols ~= nil then
+            for k,v in pairs(symbols) do
+                extra[k] = v
+            end
+        end
+
+        local found = nil
+        for k,monster in pairs(assets.monsters) do
+            if not assets:GetMonsterNode(k).hidden then
+                extra.beast = GenerateSymbols(monster.properties)
+                if monster.properties:has_key("monster_type") and ExecuteGoblinScript(self.bestiaryFilter, GenerateSymbols(casterToken.properties, extra), 0, string.format("Bestiary filter naming summons for filter %s", self.bestiaryFilter)) ~= 0 then
+                    if found ~= nil then
+                        --more than one candidate; the caster chooses at cast time.
+                        found = nil
+                        break
+                    end
+                    found = monster.properties:try_get("monster_type")
+                end
+            end
+        end
+
+        name = found
+    end)
+
+    g_summonNameCache[key] = { name = name }
+    return name
+end
+
+--- @param casterToken CharacterToken
+--- @param symbols nil|table
+--- @return nil|string
+function ActivatedAbilitySummonBehavior:BehaviorPlacementName(casterToken, symbols)
+    --Only the squares the ability itself targets are named here. When
+    --choosePlacement is set the behavior runs its own "Place creature N of M"
+    --prompt during the cast instead, and the ability's own target is something
+    --else entirely (often the caster).
+    if self.choosePlacement or self.replaceCaster then
+        return nil
+    end
+
+    return self:SummonedCreatureName(casterToken, symbols)
+end
+
 --Returns the live encounter squad data used when a non-Summoner ability opts
 --into squad choice. Rules-level Summoners keep using their private roster.
 local function GetEncounterMinionSquads(monsterType)

--- a/DMHub Game Rules/ActivatedAbility.lua
+++ b/DMHub Game Rules/ActivatedAbility.lua
@@ -3170,6 +3170,36 @@ function ActivatedAbility:GetMovementType(token, symbols)
     return nil
 end
 
+--- The display name of what this behavior PLACES in the ability's targeted
+--- square -- a summoned creature, a conjured object -- or nil when the behavior
+--- places nothing. Square-targeted abilities preview as a movement by default
+--- ("Movement: 3 squares"), which is wrong for an ability that moves nobody, so
+--- behaviors that put something new on the map name it here and the targeting
+--- prompt and hovered-square label speak about placement instead.
+--- @param casterToken CharacterToken
+--- @param symbols nil|table
+--- @return nil|string
+function ActivatedAbilityBehavior:BehaviorPlacementName(casterToken, symbols)
+    return nil
+end
+
+--- The name of the creature/object this ability places in its targeted square,
+--- or nil if it places nothing (or places something whose identity is not known
+--- until the caster picks during the cast).
+--- @param casterToken CharacterToken
+--- @param symbols nil|table
+--- @return nil|string
+function ActivatedAbility:GetPlacementName(casterToken, symbols)
+    for _,behavior in ipairs(self:try_get("behaviors", {})) do
+        local name = behavior:BehaviorPlacementName(casterToken, symbols)
+        if name ~= nil then
+            return name
+        end
+    end
+
+    return nil
+end
+
 --- Per-tier targeting rings drawn while this behavior's ability is being
 --- targeted, or nil for ordinary single-ring targeting. Each entry:
 --- {tier: integer, tiles: integer, height: integer, radius: number,

--- a/Draw Steel Core Rules/MCDMActivatedAbility.lua
+++ b/Draw Steel Core Rules/MCDMActivatedAbility.lua
@@ -3911,6 +3911,27 @@ function ActivatedAbility:PromptText(casterToken, targets, symbols, synthesizedS
         return ""
     end
 
+    --Square-targeted abilities that PLACE something (a summon) rather than move
+    --a creature: "Choose Target 1/2" says nothing about what is being placed, so
+    --name it -- "Choose where Goblin Runner 2 appears". GetPlacementName is nil
+    --for every other ability, and for a summon whose creature the caster has yet
+    --to pick, so the generic wording below still covers those.
+    if self.targetType == "emptyspace" or self.targetType == "anyspace" then
+        local placementName = self:GetPlacementName(casterToken, symbols)
+        if placementName ~= nil then
+            local index = #targets + 1
+            if self.sequentialTargeting and symbols ~= nil and symbols.targetnumber ~= nil then
+                index = symbols.targetnumber
+            end
+
+            if numTargets == 1 then
+                return string.format("Choose where %s appears", placementName)
+            end
+
+            return string.format("Choose where %s %d appears", placementName, index)
+        end
+    end
+
     if numTargets == 1 and #targets == 0 then
         return nil
     end

--- a/DrawSteelActionBar/DrawSteelActionBar.lua
+++ b/DrawSteelActionBar/DrawSteelActionBar.lua
@@ -11371,14 +11371,9 @@ CreateAbilityController = function()
                                 --The ability moves nobody -- it PLACES something in the hovered
                                 --square (a summon). The default "Movement: 3 squares" reads as the
                                 --caster walking there and quotes a movement cost that is never
-                                --spent, so name what actually arrives. GetPlacementName's definition
-                                --lives in a not-yet-merged PR (removed from main in e9a9ac38), and a
-                                --missing method on a game type raises rather than reading nil, so
-                                --pcall-guard: without the definition we keep the old wording.
-                                local placementName = nil
-                                pcall(function()
-                                    placementName = g_currentAbility:GetPlacementName(g_token, g_currentSymbols)
-                                end)
+                                --spent, so name what actually arrives. GetPlacementName is nil for
+                                --any other nil-movement ability, which keeps the old wording.
+                                local placementName = g_currentAbility:GetPlacementName(g_token, g_currentSymbols)
                                 if placementName ~= nil then
                                     diagramLabel = placementName
                                     diagramTextOverride = string.format(tr("%s appears here"), placementName)


### PR DESCRIPTION
Cherry-picked from the `AbilitySummon.lua`, `ActivatedAbility.lua` and `MCDMActivatedAbility.lua` hunks of #270, which is still open and now conflicts with `main`. Third and last of the salvage series after #299 (aura payload guard) and #300 (persistent-cast dead targets).

Closes the loop on the `GetPlacementName` regression: #296 stopped the crash with a `pcall`, and this restores the definitions it was standing in for.

## What it does

Square-targeted abilities preview as a movement by default — "Movement: 3 squares" — which is wrong for an ability that moves nobody and places something instead. It reads as the caster walking there, and quotes a movement cost that is never spent.

- `ActivatedAbilityBehavior:BehaviorPlacementName` is the opt-in hook, nil by default, so every other behavior is unaffected.
- `ActivatedAbility:GetPlacementName` walks the behaviors and returns the first name.
- The summon behavior answers with the creature it will summon — **only when that is knowable before the cast**. A filter matching several creatures returns nil, because the caster has yet to pick; so do `choosePlacement` and `replaceCaster`, where the ability's own target is something else and the behavior runs its own placement prompt.

The targeting prompt then reads "Choose where Goblin Runner 2 appears" rather than "Choose Target 1/2", and the hovered-square label names what arrives instead of quoting a movement cost.

The bestiary sweep behind the name is a full `assets.monsters` scan with a GoblinScript evaluation per monster, and the callers run on every targeting refresh — so it is memoized per monster type + filter + caster, and wrapped in a `pcall` so a malformed filter cannot take the targeting UI down.

## Removing #296's pcall

#296 added a `pcall` around the `GetPlacementName` call because the method had no definition on `main`. With the definition restored it is dead weight: it would swallow genuine errors raised *inside* the call, and its comment pointing at "a not-yet-merged PR" is now stale and would mislead the next reader. This restores the call site to its pre-`e9a9ac38` form.

**Reviewers: this is the one hunk to drop if you disagree** — the rest of the PR works with or without it, since a successful `pcall` returns the name either way.

## Review notes

- `AbilitySummon.lua` needed a hand-merge. `main` added `GetEncounterMinionSquads` at #270's insertion point, so the block goes after `SummarizeBehavior` as before, ahead of the new code. The other two applied with offsets only.
- I checked every direct field read the new code adds against its type's declared defaults, since unknown-field reads raise rather than returning nil (the failure mode behind #296, #299, and a bug I fixed in #300). All are declared: `bestiaryFilter`, `monsterType`, `replaceCaster`, `choosePlacement`, `duplicateMode` on the summon behavior, and `targetType`, `sequentialTargeting` on the ability. No `try_get` changes were needed here.
- The new prompt strings are bare, not `tr()`-wrapped. That matches `PromptText`, which does not localise any of its returns.

## Testing

`luac -p` passes on `MCDMActivatedAbility.lua`. `AbilitySummon.lua` and `ActivatedAbility.lua` fail under Lua 5.1 — but they fail identically on unmodified `main`, at line numbers shifted by exactly my insertion sizes (+84 and +30), on `goto` and attribute syntax 5.1 cannot parse. Since `luac` stops at the first error and both insertions sit above those lines, the added code parses. `DrawSteelActionBar.lua` cannot be checked at all under 5.1 (`more than 60 upvalues`, an implementation limit).

Not exercised in-app. Worth confirming: a single-candidate summon names the creature in both the prompt and the hover label; a multi-candidate filter still shows the generic wording; and a `choosePlacement` summon is unchanged.

## #270 after this

Only the invoke chooser caption (`AbilityInvokeAbility.lua`) and two `GameHud.instance` nil-guards in `DocumentSystem.lua` remain unsalvaged.
