### PR TITLE
Name what the invoke chooser is picking a target for

### DIFF
--- a/DMHub Game Rules/AbilityInvokeAbility.lua
+++ b/DMHub Game Rules/AbilityInvokeAbility.lua
@@ -406,10 +406,26 @@ function ActivatedAbilityInvokeAbilityBehavior:Cast(ability, casterToken, target
 
             print("INVOKE:: ChooseTarget:: prompting...")
             targets = nil
+
+            --The chooser's caption. An explicit Prompt When Resolving text wins;
+            --otherwise borrow the invoke's own prompt text (what the chosen
+            --target will be offered, e.g. "Move Speed or Make Free Strike") so
+            --the Director sees what they are picking a target FOR rather than a
+            --bare "Choose Target".
+            local chooserPrompt = self:try_get("promptWhenResolvingText", "")
+            if chooserPrompt == "" then
+                local promptText = self:try_get("promptText", "")
+                if promptText ~= "" then
+                    chooserPrompt = "Choose the next target: " .. StringInterpolateGoblinScript(promptText, casterToken.properties:LookupSymbol{})
+                else
+                    chooserPrompt = "Choose Target"
+                end
+            end
+
             GameHud.instance.actionBarPanel:FireEventTree("chooseTargetToken", {
                 sourceToken = casterToken,
                 targets = table.shallow_copy(targetChoices),
-                prompt = self:try_get("promptWhenResolvingText", "Choose Target"),
+                prompt = chooserPrompt,
                 choose = function(targetToken)
                     print("ChooseTarget:: chosen")
                     targets = {


### PR DESCRIPTION
Cherry-picked from the `AbilityInvokeAbility.lua` hunk of #270, which is still open and now conflicts with `main`. Fourth of the salvage series after #299, #300 and #301.

## What it does

When an Invoke Ability behavior prompts the Director to choose the next target, the chooser was captioned `"Choose Target"` unless the behavior carried an explicit **Prompt When Resolving** text. That says nothing about what the chosen target is about to be offered.

This falls back to the invoke's own prompt text when no resolving text is set:

> Choose the next target: Move Speed or Make Free Strike

An explicit Prompt When Resolving text still wins, and a behavior with neither keeps the old `"Choose Target"`.

## Review notes

- The interpolation mirrors the two existing uses of `promptText` in this same file (lines 550 and 717), which run it through `StringInterpolateGoblinScript` against `casterToken.properties:LookupSymbol{}` identically.
- Both fields are read through `try_get`, and `promptText` is a declared default (`ActivatedAbilityInvokeAbilityBehavior.promptText = ''`), so there is no unknown-field read here — the failure mode behind #296, #299, and a bug I fixed in #300.
- The new strings are bare rather than `tr()`-wrapped, matching this file, which has no `tr()` calls at all.

## Testing

`luac -p` PASSes, and PASSes on the unmodified file too, so the check is meaningful for this file.

Not exercised in-app. Worth confirming an invoke with a prompt text shows the interpolated caption, one with an explicit Prompt When Resolving text is unchanged, and one with neither still reads "Choose Target".

## #270 after this

Only the two `GameHud.instance` guards in `DocumentSystem.lua` remain — and those have history worth checking before re-landing: the same change went in as c722cc81 on 30 Aug and was reverted the same day by dc705e04, apparently as part of a two-commit batch back-out rather than on its merits. Raising that separately rather than folding it in here.
