### PR TITLE
IconRail size helpers: guard GameHud.instance's false default

### DIFF
--- a/DocumentSystem/DocumentSystem.lua
+++ b/DocumentSystem/DocumentSystem.lua
@@ -7353,7 +7353,11 @@ end
 --windows past the right rail. Falls back to the aspect formula before
 --the first layout pass.
 local function IconRailUIWidth()
-    if GameHud.instance ~= nil and GameHud.instance.documentsPanel ~= nil and GameHud.instance.documentsPanel.valid then
+    --Truthiness, not a nil check: with no hud - at the home screen, say -
+    --GameHud.instance is its `false` default, which passes ~= nil and then
+    --raises on the index. RightHostMargin polls this from a think, so getting
+    --it wrong floods the log rather than erroring once.
+    if GameHud.instance and GameHud.instance.documentsPanel ~= nil and GameHud.instance.documentsPanel.valid then
         local w = GameHud.instance.documentsPanel.renderedWidth
         if type(w) == "number" and w > 100 then
             return w
@@ -7365,7 +7369,7 @@ end
 --the height of the rail's coordinate space, measured the same way (the
 --layer is ~1048 units tall, not 1080; see IconRailUIWidth).
 local function IconRailUIHeight()
-    if GameHud.instance ~= nil and GameHud.instance.documentsPanel ~= nil and GameHud.instance.documentsPanel.valid then
+    if GameHud.instance and GameHud.instance.documentsPanel ~= nil and GameHud.instance.documentsPanel.valid then
         local h = GameHud.instance.documentsPanel.renderedHeight
         if type(h) == "number" and h > 100 then
             return h
@@ -16553,7 +16557,7 @@ RailShowAddPicker = function(element, side)
     --left edge. Anchoring to the full-screen documents layer makes
     --center mean the middle of the screen -- the library is a
     --destination surface, not a flyout of the + button.
-    if GameHud.instance ~= nil and GameHud.instance.documentsPanel ~= nil then
+    if GameHud.instance and GameHud.instance.documentsPanel ~= nil then
         element.popupPositioning = GameHud.instance.documentsPanel
     end
     element.popup = gui.Panel{


### PR DESCRIPTION
> **Please confirm before merging.** This exact change was landed as c722cc81 on 30 Aug and reverted the same day by dc705e04 (@timclark3). I am re-raising it because the revert looks operational rather than a judgement on the fix — but you are the one who reverted it, so please say if it was deliberate and I will close this.
>
> What makes it look operational: the same session's other commit, abb40530 ("Title screen: skip unhydrated compendium entries"), was reverted alongside it by 89987903, back to back. Neither revert message gives a reason.

Last of the salvage series off #270, after #299, #300, #301 and #302.

## The defect, still live on `main`

```lua
local function IconRailUIWidth()
    if GameHud.instance ~= nil and GameHud.instance.documentsPanel ~= nil and ...
```

`GameHud.instance` defaults to **`false`**, not nil. So `~= nil` passes and the next index raises on a boolean.

`IconRailUIWidth` is reached from `RightHostMargin`, which is polled from a think at 0.25s — so with no hud, at the home screen, this **floods the log** rather than erroring once. That also makes it a plausible contributor to noisy `recentErrors` in bug reports filed from the title screen.

(The rationale above is c722cc81's own, which I verified against current `main` rather than taking on trust.)

## The change

Three one-line edits: a truthiness check, which catches both the `false` default and nil. `IconRailUIHeight` and `RailShowAddPicker`'s positioning guard have the same shape, so all three go together — that is #270's version of the fix, which is broader than c722cc81's single site.

I also restored c722cc81's explanatory comment at the first site. Without it the guard reads like a sloppy nil check and is liable to be "corrected" back.

## Testing

`luac -p` cannot fully check this file under Lua 5.1 — it hits `more than 60 upvalues`, an implementation limit, on both the modified and unmodified file, at line numbers differing by exactly the 4 lines of comment I added. So the change parses up to that point, but the file is not fully verified by tooling.

Not exercised in-app. The natural check is to sit at the home screen with no hud and confirm the log stays quiet.
