### PR TITLE
Add /heroeffect macro to apply an ongoing effect to all heroes

### DIFF
--- a/Codex Macros/Macros.lua
+++ b/Codex Macros/Macros.lua
@@ -246,7 +246,30 @@ Commands.RegisterMacro{
 --  "endnextround"     -- ends when the next round ends
 --  "until_rest"       -- ends on a respite or a long rest
 --  "until_long_rest"  -- ends on a long rest only
-local g_heroEffectDuration = "save_ends"
+local g_heroEffectDuration = nil
+
+--Duration keywords /heroeffect accepts as an argument, mapped to the values
+--above. "indefinite" is the odd one out: it means nil, so it needs a name here
+--rather than being passed straight through like the rest.
+local g_heroEffectDurationKeywords = {
+    indefinite = true,
+    eoe = true,
+    eoe_or_dying = true,
+    save_ends = true,
+    end_of_next_turn = true,
+    endround = true,
+    endnextround = true,
+    until_rest = true,
+    until_long_rest = true,
+}
+
+--Turn a duration keyword into the value ApplyOngoingEffect wants.
+local function durationFromKeyword(keyword)
+    if keyword == "indefinite" then
+        return nil
+    end
+    return keyword
+end
 
 --Look up an ongoing effect by its display name (case-insensitive). Returns the
 --effect's table id, or nil if nothing matches.
@@ -262,7 +285,7 @@ end
 Commands.RegisterMacro{
     name = "heroeffect",
     summary = "apply an ongoing effect to every hero",
-    doc = "Usage: /heroeffect <effect name> [map|party]\nApplies the given ongoing effect to every hero. Defaults to 'party': all heroes in the player party, whether or not they are on the current map. Pass 'map' to limit it to heroes on the current map.",
+    doc = "Usage: /heroeffect <effect name> [map|party] [duration]\nApplies the given ongoing effect to every hero. Scope defaults to 'party': all heroes in the player party, whether or not they are on the current map; pass 'map' to limit it to heroes on the current map. Duration defaults to 'indefinite'; the others are eoe, eoe_or_dying, save_ends, end_of_next_turn, endround, endnextround, until_rest and until_long_rest. Scope and duration may be given in either order.",
     completions = function(args, argIndex)
         if argIndex == 1 then
             return ongoingEffectCompletions(args, argIndex)
@@ -270,6 +293,15 @@ Commands.RegisterMacro{
         return {
             {text = "party", summary = "every hero in the player party (default)"},
             {text = "map", summary = "only heroes on the current map"},
+            {text = "indefinite", summary = "never expires on its own (default)"},
+            {text = "eoe", summary = "ends when the encounter ends"},
+            {text = "eoe_or_dying", summary = "ends at end of encounter, or when the target starts dying"},
+            {text = "save_ends", summary = "target rolls to shake it off at the end of each of its turns"},
+            {text = "end_of_next_turn", summary = "ends at the end of the target's next turn"},
+            {text = "endround", summary = "ends when the current round ends"},
+            {text = "endnextround", summary = "ends when the next round ends"},
+            {text = "until_rest", summary = "ends on a respite or a long rest"},
+            {text = "until_long_rest", summary = "ends on a long rest only"},
         }
     end,
     command = function(str)
@@ -280,24 +312,42 @@ Commands.RegisterMacro{
 
         local text = trim(str or "")
         local scope = "party"
+        local duration = g_heroEffectDuration
+        local durationLabel = "indefinite"
 
         --Match the whole argument as an effect name first, so an effect that
-        --genuinely ends in "map" or "party" still resolves. Only when that fails
-        --do we treat a trailing keyword as the scope.
+        --genuinely ends in a keyword still resolves. Only when that fails do we
+        --peel recognised trailing keywords off the end, one at a time, so scope
+        --and duration can be given in either order. An unrecognised trailing
+        --word stops the peeling and is reported as part of the bad name.
         local effectid = findOngoingEffectByName(string.lower(text))
-        if effectid == nil then
-            local head, tail = string.match(text, "^(.-)%s+(%S+)$")
-            if head ~= nil then
-                local keyword = string.lower(tail)
-                if keyword == "map" or keyword == "party" then
-                    scope = keyword
-                    effectid = findOngoingEffectByName(string.lower(trim(head)))
-                end
+        local remainder = text
+        local haveScope = false
+        local haveDuration = false
+        while effectid == nil do
+            local head, tail = string.match(remainder, "^(.-)%s+(%S+)$")
+            if head == nil then
+                break
             end
+
+            local keyword = string.lower(tail)
+            if (keyword == "map" or keyword == "party") and not haveScope then
+                scope = keyword
+                haveScope = true
+            elseif g_heroEffectDurationKeywords[keyword] and not haveDuration then
+                duration = durationFromKeyword(keyword)
+                durationLabel = keyword
+                haveDuration = true
+            else
+                break
+            end
+
+            remainder = trim(head)
+            effectid = findOngoingEffectByName(string.lower(remainder))
         end
 
         if effectid == nil then
-            dmhub.Log(string.format("/heroeffect: no ongoing effect named '%s'. Usage: /heroeffect <effect name> [map|party]", text))
+            dmhub.Log(string.format("/heroeffect: no ongoing effect named '%s'. Usage: /heroeffect <effect name> [map|party] [duration]", text))
             return
         end
 
@@ -326,14 +376,14 @@ Commands.RegisterMacro{
                 description = "Apply Ongoing Effect",
                 combine = true,
                 execute = function()
-                    token.properties:ApplyOngoingEffect(effectid, g_heroEffectDuration)
+                    token.properties:ApplyOngoingEffect(effectid, duration)
                 end,
             }
         end
 
         local effectName = dmhub.GetTable("characterOngoingEffects")[effectid].name
-        dmhub.Log(string.format("/heroeffect: applied %s to %d hero%s (%s).",
-            effectName, #targets, cond(#targets == 1, "", "es"), scope))
+        dmhub.Log(string.format("/heroeffect: applied %s to %d hero%s (%s, %s).",
+            effectName, #targets, cond(#targets == 1, "", "es"), scope, durationLabel))
     end,
 }
 

--- a/Codex Macros/Macros.lua
+++ b/Codex Macros/Macros.lua
@@ -236,6 +236,107 @@ Commands.RegisterMacro{
     end,
 }
 
+--Durations that creature:ApplyOngoingEffect accepts:
+--  nil                -- indefinite; only removed by hand or by an end-effect
+--  "eoe"              -- ends when the encounter ends
+--  "eoe_or_dying"     -- ends when the encounter ends, or when the target starts dying
+--  "save_ends"        -- target rolls to shake it off at the end of each of its turns
+--  "end_of_next_turn" -- ends at the end of the target's next turn
+--  "endround"         -- ends when the current round ends
+--  "endnextround"     -- ends when the next round ends
+--  "until_rest"       -- ends on a respite or a long rest
+--  "until_long_rest"  -- ends on a long rest only
+local g_heroEffectDuration = "save_ends"
+
+--Look up an ongoing effect by its display name (case-insensitive). Returns the
+--effect's table id, or nil if nothing matches.
+local function findOngoingEffectByName(name)
+    for k, v in unhidden_pairs(dmhub.GetTable("characterOngoingEffects")) do
+        if string.lower(v.name) == name then
+            return k
+        end
+    end
+    return nil
+end
+
+Commands.RegisterMacro{
+    name = "heroeffect",
+    summary = "apply an ongoing effect to every hero",
+    doc = "Usage: /heroeffect <effect name> [map|party]\nApplies the given ongoing effect to every hero. Defaults to 'party': all heroes in the player party, whether or not they are on the current map. Pass 'map' to limit it to heroes on the current map.",
+    completions = function(args, argIndex)
+        if argIndex == 1 then
+            return ongoingEffectCompletions(args, argIndex)
+        end
+        return {
+            {text = "party", summary = "every hero in the player party (default)"},
+            {text = "map", summary = "only heroes on the current map"},
+        }
+    end,
+    command = function(str)
+        if not dmhub.isDM then
+            dmhub.Log("/heroeffect: GM only.")
+            return
+        end
+
+        local text = trim(str or "")
+        local scope = "party"
+
+        --Match the whole argument as an effect name first, so an effect that
+        --genuinely ends in "map" or "party" still resolves. Only when that fails
+        --do we treat a trailing keyword as the scope.
+        local effectid = findOngoingEffectByName(string.lower(text))
+        if effectid == nil then
+            local head, tail = string.match(text, "^(.-)%s+(%S+)$")
+            if head ~= nil then
+                local keyword = string.lower(tail)
+                if keyword == "map" or keyword == "party" then
+                    scope = keyword
+                    effectid = findOngoingEffectByName(string.lower(trim(head)))
+                end
+            end
+        end
+
+        if effectid == nil then
+            dmhub.Log(string.format("/heroeffect: no ongoing effect named '%s'. Usage: /heroeffect <effect name> [map|party]", text))
+            return
+        end
+
+        local targets = {}
+        if scope == "map" then
+            for _, token in ipairs(dmhub.allTokens) do
+                if token.properties ~= nil and token.properties:IsHero() then
+                    targets[#targets + 1] = token
+                end
+            end
+        else
+            --GetCharacterById rather than GetTokenById: the latter only sees tokens
+            --spawned on the map that is currently loaded, and the party scope is
+            --meant to reach heroes wherever they are. Despawned characters (dead,
+            --turned into a corpse) are skipped.
+            for _, charid in ipairs(dmhub.GetCharacterIdsInParty(GetDefaultPartyID()) or {}) do
+                local token = dmhub.GetCharacterById(charid)
+                if token ~= nil and token.properties ~= nil and not token.despawned and token.properties:IsHero() then
+                    targets[#targets + 1] = token
+                end
+            end
+        end
+
+        for _, token in ipairs(targets) do
+            token:ModifyProperties{
+                description = "Apply Ongoing Effect",
+                combine = true,
+                execute = function()
+                    token.properties:ApplyOngoingEffect(effectid, g_heroEffectDuration)
+                end,
+            }
+        end
+
+        local effectName = dmhub.GetTable("characterOngoingEffects")[effectid].name
+        dmhub.Log(string.format("/heroeffect: applied %s to %d hero%s (%s).",
+            effectName, #targets, cond(#targets == 1, "", "es"), scope))
+    end,
+}
+
 Commands.RegisterMacro{
     name = "dramaticbanner",
     summary = "show a dramatic banner",


### PR DESCRIPTION
## Summary
Adds `/heroeffect <effect name> [map|party] [duration]`, a GM-only chat macro that applies an ongoing effect -- a plain buff/debuff or a condition-bearing one -- to every hero at once.

The existing `/applyongoingeffect` sprays every token on the map, monsters included, and hardcodes an end-of-encounter duration. This is the hero-scoped equivalent, with the duration exposed.

**Scope** (optional, defaults to `party`)
- `party` -- every hero in the player party, resolved via `GetCharacterIdsInParty` + `GetCharacterById`, so heroes not currently spawned on the loaded map are still reached.
- `map` -- only heroes on the current map (`dmhub.allTokens` filtered by `IsHero()`).
- Despawned heroes are skipped under both, matching the party-folder filter in `DMHub Core Panels/CharacterPanel.lua` ("dead, converted to a corpse").

**Duration** (optional, defaults to `indefinite`)
- Accepts `indefinite`, `eoe`, `eoe_or_dying`, `save_ends`, `end_of_next_turn`, `endround`, `endnextround`, `until_rest`, `until_long_rest` -- the values `creature:ApplyOngoingEffect` actually normalises into `remove*` flags. `indefinite` maps to `nil`.
- Defaults to indefinite on the assumption that a broad, GM-driven application is meant to persist until the GM clears it.

**Parsing** -- the full argument is matched as an effect name first, so an effect genuinely ending in a keyword still resolves; only then are recognised trailing keywords peeled off one at a time. Scope and duration may therefore be given in either order, and an unrecognised trailing word stops the peel and is reported as part of the bad name. Effect lookup is case-insensitive by display name, reusing the completion helper from `/applyongoingeffect`. Tab-completion offers the scopes and all nine durations.

## Test plan
Verified live against a running DMHub instance over the MCP bridge. Every case was cleared and re-checked as empty before the next, and distinct effects were used throughout, so no result is a carryover.

**Scope** -- set up three heroes in three states: one on the map, one in the party but never placed on the map, one despawned.

| Hero state | `map` scope | `party` scope |
|---|---|---|
| On map | applied | applied |
| In party, never placed on this map | not applied | **applied** |
| Despawned | not applied | not applied (skipped by design) |

- [x] Both heroes on map, default scope, Frightened -- both received it.
- [x] `map` scope, Grabbed -- only the on-map hero; the off-map and despawned heroes untouched.
- [x] `party` scope, Taunted -- the on-map hero **and the off-map hero** received it; the despawned hero was skipped.
- [x] A later run against a loaded encounter (3 heroes + 3 gnolls on the map) applied to all 3 heroes and no monsters.

**Duration** -- confirmed each keyword produces the correct instance flag, and that none report `Expired()`:

| Command | Resulting flag |
|---|---|
| `Slowed map` (no duration) | no flags = indefinite |
| `Slowed map save_ends` | `removeOnSave` |
| `Restrained save_ends map` (reversed order) | `removeOnSave` |
| `Frightened map eoe` | `removeOnEoE` |
| `Grabbed map end_of_next_turn` | `removeAtNextTurnEnd` |
| `Taunted map until_long_rest` | `removeOnLongRest` |
| `Bleeding map indefinite` | no flags |
| `Weakened map endnextround` | `removeAtRoundEnd = 2` |
| `Weakened map notaduration` | rejected, nothing applied |

**Other**
- [x] Condition-bearing effect verified to register on the creature itself (`HasCondition` / `HasNamedCondition`), not merely to sit in `ongoingEffects`.
- [x] Plain non-condition effect (`condition = "none"`) stacks alongside a condition effect without interference.
- [x] GM-only gating, unknown effect names (with and without a trailing keyword), empty argument, `help`, and case-insensitive input (`"sLoWeD MAP"`).
- [x] Syntax checked with `load()` and hot-reloaded before each round of testing.
- [x] All test-applied effects removed afterward; tokens verified back at their original state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)