### PR TITLE
Fix floor-alignment opacity slider having no effect (report HVRN7PRY)

### DIFF
--- a/DMHub Core Panels/CreateMapDialog.lua
+++ b/DMHub Core Panels/CreateMapDialog.lua
@@ -1979,7 +1979,7 @@ mod.shared.ShowFloorAlignmentDialog = function(info)
                 movingImagePanel.y = ny
                 movingImagePanel.selfStyle.width = nw
                 movingImagePanel.selfStyle.height = nh
-                movingImagePanel.opacity = newFloorOpacity
+                movingImagePanel.selfStyle.opacity = newFloorOpacity
                 children[#children+1] = movingImagePanel
             end
 


### PR DESCRIPTION
**Symptom:** When importing a new floor image onto an existing map, the alignment dialog's "Opacity:" slider does nothing -- the incoming floor is stuck at its initial 60% blend, so the two maps can never be faded to line them up.

**Root cause:** In `mod.shared.ShowFloorAlignmentDialog`'s `updatePreview` handler, `DMHub Core Panels/CreateMapDialog.lua` assigned `movingImagePanel.opacity = newFloorOpacity`. `opacity` is a Style property (declared in `Definitions/Style.lua`), not a Panel property -- `Definitions/Panel.lua` has no `opacity` field. Style keys passed to the `gui.Panel{}` constructor are applied to the panel's `selfStyle`, which is why the initial 0.6 takes effect, but the later bare runtime assignment writes a field the Panel object does not own and is silently discarded. The two lines immediately above already correctly go through `selfStyle` (`.selfStyle.width` / `.selfStyle.height`), and this was the only runtime `panel.opacity = ...` assignment in the repo; every other site uses `element.selfStyle.opacity`.

**Fix:** One line -- route the slider's value through `movingImagePanel.selfStyle.opacity`. The constructor-time `opacity = newFloorOpacity` is left alone (passing it there is correct).

**Verify:** Open a map that already has a floor image, import another image as a new floor, and confirm the alignment preview's "Opacity:" slider now fades the incoming floor from 0% to 100% over the existing one.

Report `HVRN7PRY`. Originated from automated feedback triage.