### PR TITLE
Fix project rolls losing the characteristic and all modifiers

### DIFF
--- a/Downtime Projects/DTProjectRollDialog.lua
+++ b/Downtime Projects/DTProjectRollDialog.lua
@@ -7,6 +7,101 @@
 --- It extends creature rather than living in this file's own namespace, which
 --- is exactly why deleting the dialog took it out by accident once already.
 
+--- The player-facing project roll. Without this registration RollCheck falls
+--- through to its unknown-skill fallback, and the roll goes out as a bare 2d10
+--- with no characteristic and no modifiers to tick. `rollType` picks the dialog,
+--- while GetModifiers passes "project_roll", the modifier pipeline's own scope
+--- for Skilled, the language banes and the class/title project edges.
+RollCheck.RegisterCustom{
+    id = "project_power_roll",
+    rollType = "power_roll_custom",
+
+    Describe = function(check, isplayer)
+        return check.info.explanation
+    end,
+
+    GetRoll = function(check, creature)
+        return "2d10 + " .. creature:AttributeMod(check.info.attrid)
+    end,
+
+    GetModifiers = function(check, creature)
+        local roll = check:GetRoll(creature)
+        local options = {
+            attribute = check.info.attrid,
+            skills = check.skills,
+        }
+
+        local result = creature:GetModifiersForPowerRoll(roll, "project_roll", options)
+
+        --Skilled is offered rather than applied: the pipeline cannot know the
+        --skill was chosen for this project, so proficiency is confirmed here.
+        local skillsTable = GetTableCached("Skills")
+        for _, skillid in ipairs(check.skills or {}) do
+            local skill = skillsTable[skillid]
+            if skill ~= nil and creature:ProficientInSkill(skill) then
+                for _, entry in ipairs(result) do
+                    if entry.modifier.name == "Skilled" then
+                        entry.hint.result = true
+                    end
+                end
+            end
+        end
+
+        --A project source in a language the hero does not know costs them the
+        --Unknown Language penalty, softened to Related Language if they know a
+        --language related to it.
+        local langs = creature:LanguagesKnown()
+        local relatedLanguages = GetTableCached("languageRelations")
+
+        local languageKnown = false
+        local languageRelated = false
+
+        for _, lang in ipairs(check.languages or {}) do
+            if langs[lang] then
+                languageKnown = true
+                break
+            elseif relatedLanguages[lang] then
+                for related, _ in pairs(relatedLanguages[lang].related) do
+                    if langs[related] then
+                        languageRelated = true
+                        break
+                    end
+                end
+            end
+        end
+
+        for _, entry in ipairs(result) do
+            if not languageKnown and not languageRelated then
+                if entry.modifier.name == "Unknown Language" then
+                    entry.hint.result = true
+                    entry.hint.justification = {"<color=#FF0000>You do not know the language(s) of the project source.</color>"}
+                end
+            elseif not languageKnown and languageRelated then
+                if entry.modifier.name == "Related Language" then
+                    entry.hint.result = true
+                    entry.hint.justification = {"<color=#FF0000>You do not know the project source language(s), but you know a related language.</color>"}
+                end
+            end
+        end
+
+        --Modifiers the caller put on the check itself, such as a complication's.
+        for _, entry in pairs(check:try_get("modifiers", {})) do
+            result[#result + 1] = entry
+        end
+
+        return result
+    end,
+
+    ShowDialog = function(check, dialogOptions)
+        --Presentation axis: the chat card reads this type to suppress the tier
+        --badges a project roll does not have.
+        dialogOptions.rollProperties = RollProperties.new{
+            type = "project_power_roll",
+        }
+        return GameHud.instance.rollDialog.data.ShowDialog(dialogOptions)
+    end,
+}
+
 -- @param casterToken - The token making the roll
 -- @param options - Table with:
 --   attrid: attribute ID (default "mgt")


### PR DESCRIPTION
**Symptom:** Respite/downtime project rolls come out as a flat `2d10` - the hero's characteristic is never added, Skilled cannot be ticked, and no project banes/edges are offered.

**Root cause:** `creature:RequestProjectRoll` builds a `RollCheck` with `id = "project_power_roll"`, but the matching `RollCheck.RegisterCustom{ id = "project_power_roll", ... }` block was deleted along with the old bespoke project roll dialog in e75114cf; the follow-up e332cb91 restored only `RequestProjectRoll` from that file. With no custom entry, `RollCheck:GetRoll` and `RollCheck:GetModifiers` (`Draw Steel UI/DSRequestRollsDialog.lua`) fall through every type branch into the unknown-skill fallback: `Skill.SkillsById["project_power_roll"]` is nil, so they warn and return bare `GameSystem.BaseSkillRoll` ("2d10") and `{}`. Confirmed by the reporter's log, which has six `DTRoll` records all with `rollString "2d10"` and `amount == naturalRoll`. The modifiers themselves were never missing - `data/objectTables/globalrulemods/tests.yaml` still defines Skilled, Related Language and Unknown Language at `rollType: project_roll` - they were simply never queried.

**The fix:** Re-adds the registration to `Downtime Projects/DTProjectRollDialog.lua`, modelled on the shipping twin in `Downtime Projects/FSHCast.lua` (id `fsh_cast`):
- `GetRoll` returns `"2d10 + " .. creature:AttributeMod(check.info.attrid)`.
- `GetModifiers` queries `creature:GetModifiersForPowerRoll(roll, "project_roll", ...)`, ticks Skilled when the roller is proficient in one of the check's skills (nil-guarded, which the pre-deletion code was not), ticks Unknown/Related Language from `check.languages`, and appends the modifiers the caller put on the check.
- `ShowDialog` sets `rollProperties = RollProperties.new{ type = "project_power_roll" }`, which is what keeps `ChatPanel/ActionLogPanel.lua` suppressing the tier badges a project roll does not have.

Purely additive: one file, one top-level registration, no other id collides. Syntax-checked with `luac -p` and ASCII-clean.

Report: `GXY35K5R`. Originated from automated feedback triage.