### PR TITLE
Limit retarget picker to the strike's distance and line of effect (report KTD5PFR3)

### DIFF
--- a/Draw Steel Core Rules/DSRuleUtils.lua
+++ b/Draw Steel Core Rules/DSRuleUtils.lua
@@ -23,4 +23,62 @@ RuleUtils = {
         local coverInfo = dmhub.GetCoverInfo(toka, tokb, pierceWalls)
         return coverInfo == nil or coverInfo.coverModifier < 1
     end,
+
+    --Retarget pickers (Goaded, Meat Shield, ...) redirect a strike from the
+    --creature casting it to a new target. The new target still has to be one
+    --the caster could actually strike: inside the ability's distance and in the
+    --caster's line of effect. This adds a reason for each candidate in
+    --`targets` that fails either check, keyed by charid, in the same shape as
+    --changeTargetReasonedFilters so the picker shows the token greyed out with
+    --that tooltip. Candidates that already carry a reason are left alone.
+    --`range` is in squares (what ActivatedAbility:GetRange returns).
+    --One-line prompt for the retarget picker's cast message, replacing the
+    --generic "Choose a target". Names the striker and the strike's reach when
+    --the picker is limited to the original ability's range (rangeType ==
+    --"ability"), so the player knows why some tokens are greyed out.
+    RetargetPromptText = function(sourceToken, range, rangeType)
+        if rangeType ~= "ability" or sourceToken == nil or not sourceToken.valid then
+            return "Choose a new target for the strike"
+        end
+        local sourceName = "the attacker"
+        if sourceToken.canLocalPlayerSeeName and sourceToken.name ~= nil and sourceToken.name ~= "" then
+            sourceName = sourceToken.name
+        end
+        range = tonumber(range)
+        if range == nil or range <= 0 then
+            return string.format("Choose a new target within %s's line of effect", sourceName)
+        end
+        local rangeText = tostring(range)
+        if range == math.floor(range) then
+            rangeText = tostring(math.floor(range))
+        end
+        local unit = "squares"
+        if range == 1 then unit = "square" end
+        return string.format("Choose a new target within %s %s and line of effect of %s", rangeText, unit, sourceName)
+    end,
+
+    AddRetargetRangeReasons = function(targets, reasons, sourceToken, range)
+        if sourceToken == nil or not sourceToken.valid then
+            return
+        end
+        local sourceName = "The attacker"
+        if sourceToken.canLocalPlayerSeeName and sourceToken.name ~= nil and sourceToken.name ~= "" then
+            sourceName = sourceToken.name
+        end
+        range = tonumber(range)
+        --whole-number ranges print as "5", not "5.0".
+        local rangeText = tostring(range)
+        if range ~= nil and range == math.floor(range) then
+            rangeText = tostring(math.floor(range))
+        end
+        for _, tok in ipairs(targets) do
+            if reasons[tok.charid] == nil and tok.valid and tok.charid ~= sourceToken.charid then
+                if range ~= nil and range > 0 and sourceToken:Distance(tok) > range then
+                    reasons[tok.charid] = string.format("%s's strike can only reach targets within %s squares.", sourceName, rangeText)
+                elseif not RuleUtils.HasLineOfEffect(sourceToken, tok) then
+                    reasons[tok.charid] = string.format("%s has no line of effect to this creature.", sourceName)
+                end
+            end
+        end
+    end,
 }

--- a/Draw Steel Core Rules/DSRuleUtils.lua
+++ b/Draw Steel Core Rules/DSRuleUtils.lua
@@ -24,18 +24,9 @@ RuleUtils = {
         return coverInfo == nil or coverInfo.coverModifier < 1
     end,
 
-    --Retarget pickers (Goaded, Meat Shield, ...) redirect a strike from the
-    --creature casting it to a new target. The new target still has to be one
-    --the caster could actually strike: inside the ability's distance and in the
-    --caster's line of effect. This adds a reason for each candidate in
-    --`targets` that fails either check, keyed by charid, in the same shape as
-    --changeTargetReasonedFilters so the picker shows the token greyed out with
-    --that tooltip. Candidates that already carry a reason are left alone.
-    --`range` is in squares (what ActivatedAbility:GetRange returns).
-    --One-line prompt for the retarget picker's cast message, replacing the
-    --generic "Choose a target". Names the striker and the strike's reach when
-    --the picker is limited to the original ability's range (rangeType ==
-    --"ability"), so the player knows why some tokens are greyed out.
+    --Prompt shown when a retarget picker (Goaded, Meat Shield) is limited to the
+    --original strike's range. Names the striker and its reach so the player can
+    --see why some tokens are greyed out.
     RetargetPromptText = function(sourceToken, range, rangeType)
         if rangeType ~= "ability" or sourceToken == nil or not sourceToken.valid then
             return "Choose a new target for the strike"
@@ -57,6 +48,9 @@ RuleUtils = {
         return string.format("Choose a new target within %s %s and line of effect of %s", rangeText, unit, sourceName)
     end,
 
+    --Greys out retarget candidates the striker could not actually hit. Adds a
+    --tooltip to `reasons` (charid -> text, the shape changeTargetReasonedFilters
+    --uses) for any target beyond `range` squares or with no line of effect.
     AddRetargetRangeReasons = function(targets, reasons, sourceToken, range)
         if sourceToken == nil or not sourceToken.valid then
             return

--- a/Draw Steel UI/DSActionBar.lua
+++ b/Draw Steel UI/DSActionBar.lua
@@ -4786,6 +4786,7 @@ function GameHud.CreateActionBar(self, dialog, tokenInfo)
                                         }
                                         local filterFormula = trigger.powerRollModifier.powerRollModifier:try_get("changeTargetFilter")
                                         local targets = {}
+                                        local retargetReasons = {}
                                         for _,potential in ipairs(dmhub.allTokens) do
                                             symbols.target = potential.properties:LookupSymbol{}
                                             if trim(filterFormula) == "" or GoblinScriptTrue(ExecuteGoblinScript(filterFormula, potential.properties:LookupSymbol(symbols), 1)) then
@@ -4802,12 +4803,19 @@ function GameHud.CreateActionBar(self, dialog, tokenInfo)
                                         elseif rangeType == "distance" then
                                             range = trigger.powerRollModifier.powerRollModifier:try_get("changeTargetDistance", 10)
                                         end
+                                        --the new target must be one the striking creature could actually
+                                        --hit: inside the strike's distance and in its line of effect.
+                                        if rangeType == "ability" then
+                                            RuleUtils.AddRetargetRangeReasons(targets, retargetReasons, sourceToken, range)
+                                        end
 
                                         print("ChooseTarget:: A")
                                         gamehud.actionBarPanel:FireEventTree("chooseTarget", {
                                             sourceToken = sourceToken,
                                             radius = range,
                                             targets = targets,
+                                            reasons = retargetReasons,
+                                            prompt = RuleUtils.RetargetPromptText(sourceToken, range, rangeType),
                                             choose = function(newTargetToken)
                                                 if token == nil then
                                                     return
@@ -4974,6 +4982,7 @@ function GameHud.CreateActionBar(self, dialog, tokenInfo)
                                             }
                                             local filterFormula = trigger.powerRollModifier.powerRollModifier:try_get("changeTargetFilter")
                                             local targets = {}
+                                            local retargetReasons = {}
                                             for _,potential in ipairs(dmhub.allTokens) do
                                                 symbols.target = potential.properties:LookupSymbol{}
                                                 if trim(filterFormula) == "" or GoblinScriptTrue(ExecuteGoblinScript(filterFormula, potential.properties:LookupSymbol(symbols), 1)) then
@@ -4990,12 +4999,19 @@ function GameHud.CreateActionBar(self, dialog, tokenInfo)
                                             elseif rangeType == "distance" then
                                                 range = trigger.powerRollModifier.powerRollModifier:try_get("changeTargetDistance", 10)
                                             end
+                                            --the new target must be one the striking creature could actually
+                                            --hit: inside the strike's distance and in its line of effect.
+                                            if rangeType == "ability" then
+                                                RuleUtils.AddRetargetRangeReasons(targets, retargetReasons, sourceToken, range)
+                                            end
 
                                         print("ChooseTarget:: B")
                                             gamehud.actionBarPanel:FireEventTree("chooseTarget", {
                                                 sourceToken = sourceToken,
                                                 radius = range,
                                                 targets = targets,
+                                                reasons = retargetReasons,
+                                                prompt = RuleUtils.RetargetPromptText(sourceToken, range, rangeType),
                                                 choose = function(newTargetToken)
                                                     if token == nil then
                                                         return

--- a/DrawSteelActionBar/DrawSteelTriggerPanel.lua
+++ b/DrawSteelActionBar/DrawSteelTriggerPanel.lua
@@ -96,6 +96,11 @@ local function RunTriggerRetargetChoice(element, triggerToken, trigger)
     elseif rangeType == "distance" then
         range = powerMod:try_get("changeTargetDistance", 10)
     end
+    --the new target must be one the striking creature could actually
+    --hit: inside the strike's distance and in its line of effect.
+    if rangeType == "ability" then
+        RuleUtils.AddRetargetRangeReasons(targets, retargetReasons, sourceToken, range)
+    end
 
     local controller = element:Get("abilityController")
     if controller == nil then
@@ -108,6 +113,7 @@ local function RunTriggerRetargetChoice(element, triggerToken, trigger)
         radius = range,
         targets = targets,
         reasons = retargetReasons,
+        prompt = RuleUtils.RetargetPromptText(sourceToken, range, rangeType),
         choose = function(newTargetToken)
             if triggerToken == nil or not triggerToken.valid then
                 return
@@ -683,12 +689,18 @@ mod.shared.CreateTriggerPanel = function()
                                         elseif rangeType == "distance" then
                                             range = trigger.powerRollModifier.powerRollModifier:try_get("changeTargetDistance", 10)
                                         end
+                                        --the new target must be one the striking creature could actually
+                                        --hit: inside the strike's distance and in its line of effect.
+                                        if rangeType == "ability" then
+                                            RuleUtils.AddRetargetRangeReasons(targets, retargetReasons, sourceToken, range)
+                                        end
 
                                         element:Get("abilityController"):FireEventTree("chooseTarget", {
                                             sourceToken = sourceToken,
                                             radius = range,
                                             targets = targets,
                                             reasons = retargetReasons,
+                                            prompt = RuleUtils.RetargetPromptText(sourceToken, range, rangeType),
                                             choose = function(newTargetToken)
                                                 if g_token == nil then
                                                     return
@@ -905,12 +917,18 @@ mod.shared.CreateTriggerPanel = function()
                                             elseif rangeType == "distance" then
                                                 range = trigger.powerRollModifier.powerRollModifier:try_get("changeTargetDistance", 10)
                                             end
+                                            --the new target must be one the striking creature could actually
+                                            --hit: inside the strike's distance and in its line of effect.
+                                            if rangeType == "ability" then
+                                                RuleUtils.AddRetargetRangeReasons(targets, retargetReasons, sourceToken, range)
+                                            end
 
                                             element:Get("abilityController"):FireEventTree("chooseTarget", {
                                                 sourceToken = sourceToken,
                                                 radius = range,
                                                 targets = targets,
                                                 reasons = retargetReasons,
+                                                prompt = RuleUtils.RetargetPromptText(sourceToken, range, rangeType),
                                                 choose = function(newTargetToken)
                                                     if g_token == nil then
                                                         return
@@ -1125,12 +1143,18 @@ mod.shared.CreateTriggerPanel = function()
                                         elseif rangeType == "distance" then
                                             range = trigger.powerRollModifier.powerRollModifier:try_get("changeTargetDistance", 10)
                                         end
+                                        --the new target must be one the striking creature could actually
+                                        --hit: inside the strike's distance and in its line of effect.
+                                        if rangeType == "ability" then
+                                            RuleUtils.AddRetargetRangeReasons(targets, retargetReasons, sourceToken, range)
+                                        end
 
                                         element:Get("abilityController"):FireEventTree("chooseTarget", {
                                             sourceToken = sourceToken,
                                             radius = range,
                                             targets = targets,
                                             reasons = retargetReasons,
+                                            prompt = RuleUtils.RetargetPromptText(sourceToken, range, rangeType),
                                             choose = function(newTargetToken)
                                                 if g_token == nil then
                                                     return
@@ -1630,12 +1654,18 @@ mod.shared.CreateTriggerPanel = function()
                                             elseif rangeType == "distance" then
                                                 range = trigger.powerRollModifier.powerRollModifier:try_get("changeTargetDistance", 10)
                                             end
+                                            --the new target must be one the striking creature could actually
+                                            --hit: inside the strike's distance and in its line of effect.
+                                            if rangeType == "ability" then
+                                                RuleUtils.AddRetargetRangeReasons(targets, retargetReasons, sourceToken, range)
+                                            end
 
                                             element:Get("abilityController"):FireEventTree("chooseTarget", {
                                                 sourceToken = sourceToken,
                                                 radius = range,
                                                 targets = targets,
                                                 reasons = retargetReasons,
+                                                prompt = RuleUtils.RetargetPromptText(sourceToken, range, rangeType),
                                                 choose = function(newTargetToken)
                                                     if g_token == nil then
                                                         return


### PR DESCRIPTION
**Symptom:** When the Mastermind uses Goaded to redirect a marked creature's strike, the picker offers every ally on the map -- including ones the striker could never reach -- and prompts with a bare "Choose a target". The card text also said "Line of Sight" / "Choose yourself or an ally", overstating the legal choices (reporter: the display should say the new target must be within the strike's distance and line of effect).

**Root cause:** The retarget flow (`changeTargetRange: ability`) already draws the strike's radius from the striking creature, but the candidate list is built only from `changeTargetFilter` (`Friends(target, triggerer)` for Goaded). Nothing checked distance or line of effect from the striker, and no retarget site passed a `prompt` to the picker, so it fell back to the default string.

**Fix:**
- `Draw Steel Core Rules/DSRuleUtils.lua`: two helpers. `RuleUtils.AddRetargetRangeReasons` adds a tooltip reason (same shape as `changeTargetReasonedFilters`) for every candidate outside the original ability's distance or without line of effect from the striker, so the picker shows them greyed out and blocks players from choosing them under strict targeting (Directors can still override). `RuleUtils.RetargetPromptText` builds a one-line prompt naming the striker and the reach, e.g. "Choose a new target within 5 squares and line of effect of Arixx".
- `DrawSteelActionBar/DrawSteelTriggerPanel.lua` (five retarget sites, including the deferred trigger-before path) and `Draw Steel UI/DSActionBar.lua` (both legacy sites, which now also pass `reasons`): call the helpers after the range block and pass the prompt. Both only kick in when the trigger's change-target range is `ability`, so other retarget triggers are unchanged.
- Data (already pushed to `draw-steel-data` main as `4313f9b8`): the Goaded card's distance now reads "Line of effect", and the effect text plus the trigger prompt rule say the new target must be within your line of effect and within the distance and line of effect of the strike.

**Verify:** Play a Mastermind with Goaded, mark a monster, and have it strike an ally. Press the Goaded trigger: the picker prompt names the striker and its reach, allies beyond that reach or behind a wall are greyed out with a tooltip explaining why, and the remaining allies can be chosen as before. Exercised live on this branch's helpers against a map of twelve tokens (range 2 flagged exactly the four tokens further than two squares away); the full Goaded flow was not driven end to end.

Report `KTD5PFR3` (Discord thread 1544664010882949202). Triaged as a feature: "Mastermind 'Goaded' card: note the new target must be in the strike's distance and LoE".
