### PR TITLE
Synaptic Override: compelled attacks aim at the target's allies (new Target Allegiance attribute)

### DIFF
--- a/DMHub Game Rules/ModifierModifyAbilities.lua
+++ b/DMHub Game Rules/ModifierModifyAbilities.lua
@@ -176,6 +176,25 @@ CharacterModifier.RegisterAbilityModifier
 
 CharacterModifier.RegisterAbilityModifier
 {
+	id = "targetallegiance",
+	text = "Target Allegiance",
+	operations = { "Set" },
+	--Changes only WHO the ability may target, leaving the target type, radius,
+	--and object targeting untouched. Unlike "Target Type" this works on abilities
+	--whose shape we don't know in advance -- e.g. Synaptic Override forcing an
+	--enemy's own signature ability to be aimed at that enemy's allies.
+	set = function(modifier, creature, ability, operation, value)
+		if value == "ally" or value == "enemy" then
+			ability.targetAllegiance = value
+		elseif value == "all" then
+			ability.targetAllegiance = nil
+		end
+		return true
+	end,
+}
+
+CharacterModifier.RegisterAbilityModifier
+{
 	id = "reasonfilter",
 	text = "Reasoned Filter",
 	operations = { "reasonfilter" },
@@ -1328,6 +1347,37 @@ CharacterModifier.TypeInfo.modifyability = {
 									classes = "formDropdown",
 									options = rules.damageTypesAvailable,
 									idChosen = attr.value,
+									change = function(element)
+										modifier.attributes[i].value = element.idChosen
+										Refresh()
+									end,
+								},
+							}
+						elseif attr.id == "targetallegiance" then
+							children[#children+1] = gui.Panel{
+								classes = {"formPanel"},
+								gui.Label{
+									classes = {"formLabel"},
+									text = "Affects:",
+								},
+								gui.Dropdown{
+									styles = ThemeEngine.GetStyles(),
+									classes = "formDropdown",
+									options = {
+										{
+											id = "all",
+											text = "Any Creatures",
+										},
+										{
+											id = "ally",
+											text = "Allied Creatures",
+										},
+										{
+											id = "enemy",
+											text = "Enemy Creatures",
+										},
+									},
+									idChosen = attr.value or "all",
 									change = function(element)
 										modifier.attributes[i].value = element.idChosen
 										Refresh()


### PR DESCRIPTION
## The bug

Using Synaptic Override (Talent / Telepathy), a tier 2/3 result invokes the target's signature ability -- but the only legal targets were the *heroes*. The invoked ability is cast by the compelled enemy with its normal `targetAllegiance = "enemy"`, and allegiance resolves relative to the caster (the compelled creature), so "enemies" meant the heroes instead of "any enemies of **your** choice" (the Talent's enemies = the compelled creature's own allies). Tier 1's compelled free strike had the same problem.

## The fix

**Engine (this PR):** adds a minimal **Target Allegiance** attribute to the Modify Abilities system. The existing Target Type attribute can flip allegiance but also overwrites the ability's target type and radius, which can't work when the modified ability's shape is unknown in advance (a signature ability can be a strike, burst, cube...). The new attribute changes only who may be targeted, and gets a dropdown in the ability editor.

**Data (already on draw-steel-data main, e74e83ce):** all three tiers of Synaptic Override embed the attribute with `value: ally`. Tiers 2/3 now carry a self-contained copy of the Signature Ability augment instead of referencing the shared standard ability, since that helper's other users (Tactician, Ajax, rival furies, Chronokinetic) direct an *ally* at its own enemies and must stay as-is.

## Tested

Live in a game: a Talent used Synaptic Override on an Arixx, which was correctly compelled to use Dirt Devil against its own allies. Known cosmetic quirk: the compelled ability's card says it targets "allies" -- true from the compelled creature's perspective, but potentially confusing to the player; left as-is for now.