### PR TITLE
implement-content: document potency gating via filterTarget

### DIFF
--- a/.claude/skills/implement-content/skill.md
+++ b/.claude/skills/implement-content/skill.md
@@ -373,6 +373,7 @@ All reference docs live in the `data/` submodule under `data/docs/`.
 | File | What it contains |
 |---|---|
 | `data/docs/RULES_REFERENCE.md` | Draw Steel game rules (combat, conditions, power rolls, monster/encounter building) |
+| `data/docs/reference/IMPLEMENTATION-PATTERNS.md` | Recurring YAML shapes: potency gates, movement, triggers |
 | `data/monsters/<uuid>.yaml` | Example monster files -- study for exact YAML patterns |
 | `data/objectTables/<tablefolder>/` | Example compendium entries by type |
 
@@ -396,6 +397,8 @@ The most common errors:
 9. **Feature `tags:` are required metadata** on every CharacterFeature you author -- see
    "Feature Tags" below. An untagged feature renders as a normal visible feature row, which
    is wrong for ability-grant wrappers and plumbing carriers.
+10. **Potency gates need `filterTarget`** -- `not Cast.PassesPotency(Target, "M", "Average")`.
+    There is no `potencyAttr` field, and the `not` matters
 
 ### Modifier Name Must Match Parent Feature
 
@@ -644,6 +647,20 @@ For complex conditions, use a separate `ActivatedAbilityApplyOngoingEffectBehavi
   ongoingEffect: <effect-uuid>
   duration: save_ends
 ```
+
+### Gating a Behavior Behind a Potency Check
+
+A behavior with `tiersSelected` applies to **every** target of those tiers. If the rules
+text gates the effect on a potency check ("I<{Average}, cursed"), add the gate yourself:
+
+```yaml
+  filterTarget: not Cast.PassesPotency(Target, "I", "Average")
+```
+
+`Cast.PassesPotency` returns true when the target RESISTS, so the gate is nearly always
+negated. There is no `potencyAttr` field. Standard conditions need none of this -- the
+parser resolves `M<{Weak}, prone` from tier text natively. Details in
+`data/docs/reference/MONSTERS.md`, "Potency with ongoing effects".
 
 ## Damage Formulas
 


### PR DESCRIPTION
The `implement-content` skill never mentioned `Cast.PassesPotency`. Its potency coverage is entirely tier-string syntax (`M<{Weak}, prone`), which the power-table parser resolves natively -- so there was no guidance for the case where an effect *can't* be a tier clause (custom ongoing-effect UUID, non-standard duration, summon) and the gate has to be added by hand.

The failure mode is silent: a behavior with `tiersSelected` and no `filterTarget` applies to every target of those tiers, with no validation error. Getting the polarity backwards is equally quiet -- `Cast.PassesPotency` returns true when the target *resists*, while rules text reads from the opposite side ("if the target fails"), so the gate is nearly always negated.

Three changes:

- A "Gating a Behavior Behind a Potency Check" subsection after Separate Condition Application, where authors land when tier text runs out.
- Pitfall #10 in the Critical Pitfalls list.
- `IMPLEMENTATION-PATTERNS.md` added to the Key References table. It already documented this exact pattern ("Forced Movement with Potency Check") but nothing in the repo pointed at it -- no skill, no CLAUDE.md, no cross-link -- so it was correct and invisible.

Companion fix already on `draw-steel-data` main (`11833d93`): `docs/reference/MONSTERS.md` had been recommending a hand-rolled `Intuition Potency Resistance < N` comparison, which hardcodes a literal threshold instead of scaling with the caster's potency.

Verified against the engine: `MCDMActivatedAbilityCast.lua` for the signature and resist polarity, `MCDMCreature.lua:1718` for the Weak/Average/Strong = potency-2/-1/-0 ladder, `ActivatedAbility.lua:139` for `filterTarget` being a base field on every behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)