### PR TITLE
Fix persistent abilities erroring on persistence:try_get (report ASW923MQ)

### DIFF
--- a/Draw Steel Core Rules/MCDMCreature.lua
+++ b/Draw Steel Core Rules/MCDMCreature.lua
@@ -6711,7 +6711,7 @@ function creature:PersistentAbilities()
                     local targetToken = dmhub.GetTokenById(targetid)
                     local usable = targetToken ~= nil and targetToken.valid and targetToken.properties ~= nil
                         and (not targetToken.properties:IsDead())
-                    if usable and persistence:try_get("inrange") == true and selfToken ~= nil then
+                    if usable and persistence.inrange == true and selfToken ~= nil then
                         local range = ability:GetRange(self)
                         if type(range) == "number" and selfToken:Distance(targetToken) > range then
                             usable = false
@@ -6763,7 +6763,7 @@ function creature:PersistentAbilities()
             --offering the trigger (start of turn, target alive) should not be
             --restated there.
             local promptText
-            local customPrompt = persistence:try_get("promptText")
+            local customPrompt = persistence.promptText
             if type(customPrompt) == "string" and trim(customPrompt) ~= "" then
                 promptText = string.format("%s: %s; %s", tr("Persistence"), ability.name, customPrompt)
             else


### PR DESCRIPTION
**Symptom:** Persistent abilities break -- the Persistence Control dialog shows a blank cost and its Submit button errors instead of closing, and (in `recast_target` mode) a character's active modifiers are wiped, so e.g. an Elementalist's Ward of Surprising Reactivity vanishes from the sheet and never fires.

**Root cause:** Regression from commit 5e0d497d. `creature:PersistentAbilities()` in `Draw Steel Core Rules/MCDMCreature.lua` reads two keys off `local persistence = ability:Persistence()` via `persistence:try_get(...)`. But `ActivatedAbility:Persistence()` returns `self:try_get("persistence", {})` -- the ability's authored persistence *config* table, created by the editor as a bare `{}` and stored in the data repo as a plain YAML map with no `__typeName`. It deserializes as a plain Lua table with no metatable, so `try_get` is nil and the call raises `attempt to call a nil value (method 'try_get')`. This is not the registered `Persistence` game type (that is the tracking entry in `creature.persistentAbilities`, built via `Persistence.new{...}`); the two were conflated.

The raise propagates out of `PersistentAbilities` -> `FillTemporalActiveModifiers` -> `CalculateActiveModifiers` -> `GetActiveModifiers` -> `CalculateAttribute` -> `EvalGoblinScript`, so the "Heroic Resource Gain at Start" GoblinScript fails and `startOfTurnHeroicResource` comes back nil, which is what blanks the cost label and wedges the dialog. Line 6766 runs for every persistence mode, so this affects all persistent abilities; line 6714 only fires in `recast_target` mode (observed raising 405 times in a single session).

**Fix:** Change the two reads back to plain field reads on the config table, matching the established pattern already used on this same object at lines 6651/6682/6683 and in `ActivatedAbility.lua`, `Aura.lua` and `ActivatedAbilityEditor.lua`:

- `persistence:try_get("inrange") == true` -> `persistence.inrange == true`
- `local customPrompt = persistence:try_get("promptText")` -> `local customPrompt = persistence.promptText`

Semantics are preserved: `Persistence()` defaults to `{}` so the local is never nil, and a missing key on a plain table returns nil (absent `inrange` is still not `true`; absent `promptText` is still nil, and the next line already does `type(customPrompt) == "string"`). File syntax-checked clean with the bundled `luac -p`.

Reports: ASW923MQ (corroborated by YAQS45RC).

Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
