### PR TITLE
Fix journal links corrupted by link colouring and glossary hints

### DIFF
--- a/DocumentSystem/MarkdownDocument.lua
+++ b/DocumentSystem/MarkdownDocument.lua
@@ -1210,11 +1210,15 @@ local function ColorizeLinks(content, link)
     end)
     -- bare [Label]: remaining balanced single-bracket spans. The (!?) prefix
     -- keeps image alt text ([..] right after a !) from being matched on its own.
+    -- A bare link uses the bracket text as BOTH the display and the target, so
+    -- styling it in place would corrupt the target. Emit the explicit
+    -- [display](target) form instead, keeping the untouched label as the target.
     content = content:gsub("(!?)(%b[])", function(bang, disp)
         if bang == "!" then return nil end
-        local styled = wrap(disp:sub(2, -2))
+        local label = disp:sub(2, -2)
+        local styled = wrap(label)
         if styled == nil then return nil end
-        return "[" .. styled .. "]"
+        return "[" .. styled .. "](" .. label .. ")"
     end)
     return content
 end
@@ -3022,6 +3026,30 @@ local function GlossaryMarkSegment(seg, index, washed)
     return table.concat(out)
 end
 
+--Glossary-mark one line, leaving link TARGETS alone. Markdown links are still
+--plain text at this point -- the engine turns them into <link=...> tags later --
+--so a hint injected into a target ends up inside the tag and the whole link
+--renders as literal markup. The display half of [display](target) is safe and
+--still gets hinted; a bare [Label] is its own target, so it is left whole.
+local function GlossaryMarkLine(line, index, washed)
+    local out = {}
+    local pos = 1
+    while true do
+        --Match on "](target)" rather than the whole link: the caller has already
+        --split the text on <...> tags, so a styled link arrives as the display
+        --run and the "](target)" tail in separate segments.
+        local s, e = string.find(line, "%]%b()", pos)
+        if s == nil then
+            out[#out + 1] = GlossaryMarkSegment(string.sub(line, pos), index, washed)
+            break
+        end
+        out[#out + 1] = GlossaryMarkSegment(string.sub(line, pos, s - 1), index, washed)
+        out[#out + 1] = string.sub(line, s, e)
+        pos = e + 1
+    end
+    return table.concat(out)
+end
+
 --Tag-aware pass over a label's final rich text. Skips <...> tag runs,
 --anything inside an existing <link> or <size> run (size = skinned
 --headings), and raw markdown heading lines (# ...) which the engine
@@ -3078,7 +3106,7 @@ local function ApplyGlossaryHints(text)
                     if atLineStart and string.match(line, "^#+[ \t]") ~= nil then
                         segOut[#segOut + 1] = line
                     else
-                        segOut[#segOut + 1] = GlossaryMarkSegment(line, index, washed)
+                        segOut[#segOut + 1] = GlossaryMarkLine(line, index, washed)
                     end
                     if nl ~= nil then
                         segOut[#segOut + 1] = "\n"

--- a/DocumentSystem/MarkdownDocument.lua
+++ b/DocumentSystem/MarkdownDocument.lua
@@ -3026,26 +3026,42 @@ local function GlossaryMarkSegment(seg, index, washed)
     return table.concat(out)
 end
 
---Glossary-mark one line, leaving link TARGETS alone. Markdown links are still
---plain text at this point -- the engine turns them into <link=...> tags later --
---so a hint injected into a target ends up inside the tag and the whole link
---renders as literal markup. The display half of [display](target) is safe and
---still gets hinted; a bare [Label] is its own target, so it is left whole.
-local function GlossaryMarkLine(line, index, washed)
+--Glossary-mark one chunk of text, hinting nothing inside a markdown link.
+--Links are still markdown here -- the engine turns them into <link=...> tags
+--later -- so neither half may be touched: a hint in the TARGET ends up inside
+--the tag value and the link renders as literal markup, while a hint in the
+--DISPLAY nests a glossary link inside the document link and the outer link
+--stops responding to clicks. Matches the seamless editor, which blanks whole
+--link constructs before its own glossary scan.
+--
+--`state` carries the position across calls, because the caller has split the
+--text on <...> tags: a styled link arrives as "[", the display run, and the
+--"](target)" tail in three separate segments.
+local function GlossaryMarkChunk(chunk, index, washed, state)
     local out = {}
     local pos = 1
-    while true do
-        --Match on "](target)" rather than the whole link: the caller has already
-        --split the text on <...> tags, so a styled link arrives as the display
-        --run and the "](target)" tail in separate segments.
-        local s, e = string.find(line, "%]%b()", pos)
-        if s == nil then
-            out[#out + 1] = GlossaryMarkSegment(string.sub(line, pos), index, washed)
-            break
+    local n = #chunk
+    while pos <= n do
+        if state.mode == "target" then
+            local close = string.find(chunk, ")", pos, true)
+            out[#out + 1] = string.sub(chunk, pos, close or n)
+            pos = (close or n) + 1
+            if close ~= nil then state.mode = "normal" end
+        elseif state.mode == "display" then
+            local close = string.find(chunk, "]", pos, true)
+            out[#out + 1] = string.sub(chunk, pos, close or n)
+            pos = (close or n) + 1
+            if close ~= nil then
+                state.mode = string.sub(chunk, pos, pos) == "(" and "target" or "normal"
+            end
+        else
+            local open = string.find(chunk, "[", pos, true)
+            out[#out + 1] = GlossaryMarkSegment(string.sub(chunk, pos, (open or n + 1) - 1), index, washed)
+            if open == nil then break end
+            out[#out + 1] = "["
+            pos = open + 1
+            state.mode = "display"
         end
-        out[#out + 1] = GlossaryMarkSegment(string.sub(line, pos, s - 1), index, washed)
-        out[#out + 1] = string.sub(line, s, e)
-        pos = e + 1
     end
     return table.concat(out)
 end
@@ -3070,6 +3086,9 @@ local function ApplyGlossaryHints(text)
     local n = #text
     local washed = {}
     local atLineStart = true
+    --tracks whether we are inside a markdown link's display or target; the
+    --tag-splitting below cuts one link into several segments.
+    local linkState = { mode = "normal" }
     while i <= n do
         local ch = string.sub(text, i, i)
         if ch == "<" then
@@ -3106,7 +3125,7 @@ local function ApplyGlossaryHints(text)
                     if atLineStart and string.match(line, "^#+[ \t]") ~= nil then
                         segOut[#segOut + 1] = line
                     else
-                        segOut[#segOut + 1] = GlossaryMarkLine(line, index, washed)
+                        segOut[#segOut + 1] = GlossaryMarkChunk(line, index, washed, linkState)
                     end
                     if nl ~= nil then
                         segOut[#segOut + 1] = "\n"


### PR DESCRIPTION
## Summary

Three related failures in the markdown display path, all caused by a text pass writing markup into a markdown link before the engine has turned it into a `<link=...>` tag. Symptoms range from a link rendering as visible markup to a link that looks perfect but ignores clicks.

All three only affect documents whose stylesheet sets `link.color`, which is why the default skin never showed any of them.

Found while auditing an adventure's journals: 114 links rendered as garbage, a further set broke in a way no change to the link syntax could fix, and a third set rendered correctly but were not clickable.

## Bug 1 - `ColorizeLinks` corrupts bare `[Label]` links

`ColorizeLinks` styles a link by wrapping the bracket contents in `<color=..><u>..</u></color>`. That is correct for `[display](target)`, where the target is a separate span.

It is wrong for a bare `[Label]`, because a bare link uses the bracket text as **both** the display and the link target. The injected markup therefore landed inside the target. TMP cut the `<link=` tag at the first `>`, and the result rendered as a stray `<link` followed by the label printed twice:

```
leads to the <link=<color=#8a6a2e><u>Hidden Basement</u></color>>Hidden Basement</link>
                       ^ tag cut here
```

**Fix:** emit the explicit `[styled](label)` form, keeping the untouched label as the target. The bare shorthand keeps working and now styles correctly.

## Bug 2 - glossary hints injected into link targets

`ApplyGlossaryHints` has a guard that skips anything inside an existing `<link>` run. That guard never fires for markdown links, because the pass runs *before* the engine converts `[display](target)` into `<link=...>` markup - at that point the link is still plain text.

So a glossary term appearing in a link's **target** was marked up, and the resulting `<link=glossary:...>` / `<u>` runs ended up inside the outer link's tag value, breaking it the same way as above.

Only **multi-word** glossary terms could trigger this. The existing proper-noun guard already skips a capitalised single-word term sitting next to another capitalised word, so single-word terms in a title were never marked. This is why `[Combat: Inner Sanctum]` and `[Director Reference: Gerold's Head]` render fine, while every link to a `Montage Test: ...` page broke - "Montage Test" is a two-word term.

## Bug 3 - glossary hints inside link display text swallow the click

The same pass also marked terms in a link's **display** text. That does not corrupt the tag, so the link renders perfectly - but the injected `<link=glossary:...>` is now nested inside the document link, and the nested link takes the click. The entry looks right, the hover tooltip still names the correct document, and clicking does nothing.

This is the easiest of the three to miss, and it is why the first attempt at bug 2 looked like a complete fix.

Example: a table of contents entry `[Negotiation or Combat: Record Control]`, where only the `Negotiation` span was hinted and the whole entry stopped responding.

## Fix for bugs 2 and 3

`GlossaryMarkChunk` skips both halves of a markdown link.

It carries its position in a `state` table across calls rather than parsing a whole link in one pass, because the caller has already split the text on `<...>` tags: a styled link arrives as `[`, the display run, and the `](target)` tail in **three separate segments**, so no single call can see the whole construct. An earlier attempt that matched `%b[]` within one segment silently did nothing for this reason.

This matches the seamless editor, which blanks whole link constructs before its own glossary scan and documents that link labels never hint. Glossary hinting in body prose is unchanged.

## Reproduction

In a document using a stylesheet that sets `link.color`:

| Markdown | Before | After |
|---|---|---|
| `[Hidden Basement]` | stray `<link` + label twice | renders as a link |
| `[Combat: Inner Sanctum]` | renders as a link | unchanged |
| `[Montage Test: Flying the Cruiser]` | stray `<link` + target leaked | renders as a link |
| `[Flying the Cruiser](Montage Test: Flying the Cruiser)` | stray `<link` + target leaked | renders as a link |
| `[Montage Test: Flying the Cruiser](Chapel)` | renders as a link | unchanged |
| `[Negotiation or Combat: Record Control]` | renders, but not clickable | clickable |

Bug 2 was isolated by probe: a term in the *display* is harmless to rendering, the same term in the *target* breaks the link regardless of which link syntax is used, and setting `glossaryhints` to `off` makes all cases render. Bug 3 surfaced only when the resulting links were actually clicked.

## Testing

- Verified on screen in a themed journal: 114 previously-broken links across 75 documents now render, including a table of contents with 66 of them.
- Verified the previously unclickable entries now open their documents.
- Confirmed glossary underlines still appear in body prose on the same pages ("montage test", "negotiation", "objective", "test").
- Unit-checked `MarkdownDocument.__ColorizeLinks` for the bare, two-arg and image (`![alt](url)`) cases.
- Default-skin documents are unaffected - `ColorizeLinks` returns early when the skin sets no `link.color`.

## Known issue, not addressed here

A link target beginning with `...` still fails to render (e.g. a document literally named `... Into the Fire`). It is unrelated to all three bugs above - it survives every fix here and involves no glossary term. It can be worked around in content with the `document:` link prefix.
