### PR TITLE
fix(triggers): measure subjectRange from the move's origin square

### DIFF
--- a/DMHub Game Rules/TriggeredAbility.lua
+++ b/DMHub Game Rules/TriggeredAbility.lua
@@ -957,6 +957,57 @@ local function SerializeTriggerContext(symbols, targets)
 	return serializedSymbols, serializedTargets
 end
 
+--Triggers that fire as the subject STARTS to move, so subjectRange has to be
+--measured from where it set off.
+local g_departureTriggers = {
+    move = true,
+    teleport = true,
+}
+
+--Distance for a subjectRange gate. On a departure trigger the subject's token
+--may already sit at its destination -- the observer's client applies the moved
+--location before draining its triggeredEvents queue -- so measure from
+--path.steps[1], the square it left. No path, or any other trigger, uses the
+--live token.
+local function SubjectRangeDistance(triggerName, subjectToken, casterToken, symbols)
+    if not g_departureTriggers[triggerName] then
+        return subjectToken:Distance(casterToken)
+    end
+
+    --pcall: PathMoved has no default for 'path', so reading it can raise.
+    local steps = nil
+    local size = 1
+    local pathMoved = symbols and symbols.path
+    if pathMoved ~= nil then
+        pcall(function()
+            steps = pathMoved.path.steps
+            size = pathMoved.size or 1
+        end)
+    end
+
+    if steps == nil or #steps == 0 then
+        return subjectToken:Distance(casterToken)
+    end
+
+    local origin = steps[1]
+    if size <= 1 then
+        return casterToken:Distance(origin)
+    end
+
+    --A size-N token covers N x N squares from that step; take the nearest.
+    local result = nil
+    for i = 1, size do
+        for j = 1, size do
+            local distance = casterToken:Distance(origin:dir(i - 1, j - 1))
+            if result == nil or distance < result then
+                result = distance
+            end
+        end
+    end
+
+    return result
+end
+
 --auraControllerToken: token controlling an aura this is triggered from, or can be nil for a regular trigger attached to the creature it's triggering on.
 --- @param characterModifier CharacterModifier
 --- @param creature Creature
@@ -1084,7 +1135,7 @@ function TriggeredAbility:Trigger(characterModifier, creature, symbols, auraCont
         if subjectRangeFormula ~= "" then
             local range = ExecuteGoblinScript(subjectRangeFormula, creature:LookupSymbol(symbols), nil, "Calculate Subject Range")
             if range ~= nil then
-                local distance = subjectToken:Distance(casterToken)
+                local distance = SubjectRangeDistance(self:try_get("trigger", ""), subjectToken, casterToken, symbols)
                 range = tonumber(range)
                 if distance > range then
                     --out of range.


### PR DESCRIPTION
Fixes bug report `DSJ2UK26`: a censor was offered the Judgment free triggered action against a judged creature that started its shift out of reach and merely shifted *past* them.

## Cause

`TriggeredAbility:Trigger` gated `subjectRange` on `subjectToken:Distance(casterToken)` — the subject's **live** location. For triggers that fire as the subject *starts* to move, that is the wrong square.

`CharacterModifier:HasTriggeredEvent` does no range check, so the mover's machine queues the event onto the observer's `triggeredEvents` unconditionally and the gate runs later, on the observer's client. By then that client has applied the replicated `locInfo/loc`, so the gate asks "is the subject within N *now*" rather than "was it within N when it set off".

Both directions were wrong for a remote observer:

- A judged creature shifting **into** reach wrongly offered Judgment — the reported symptom.
- A creature moving **out of** reach wrongly had its reaction suppressed. Swat the Fly (deathrex, ogre), Null's Anticipating Strike and Restrained by Bowl all sit on `trigger: move` + `subjectRange: 1` and were silently failing to fire for player-controlled observers.

Single-client play never showed it, since the dispatching machine still has the mover at its origin.

## Fix

Measure from `path.steps[1]` — the square the subject left — for `move` and `teleport`. A larger token's whole `size x size` footprint is walked from that step and the nearest taken, mirroring what `PathMoved`'s "distance to creature" symbol already does; the reported Hyenaut is size 2. An event that arrives with no path, and every other trigger, still uses the live token.

`steps[1]` is the origin square rather than the first square entered — verified against the engine via `MarkMovementArrow`, where a 3-square move reports `numSteps=3` with 4 steps, `steps[1]` being the token's current location. It is the same step `ActivatedAbilityRevertLocBehavior` rewinds a cancelled shift to.

Scoped deliberately: `finishmove` / `forcemove` / `movethrough` read from the destination and are untouched.

## Effect on existing content

`trigger: move` entries carrying a `subjectRange`:

- **Corrected behaviour** (range 1, where origin vs destination decides it): censor Judgment, Null Anticipating Strike, deathrex + ogre Swat the Fly, Restrained by Bowl.
- **Marginal** (a 5-30 square threshold is rarely crossed by one move): angulotl hopper Trip of the Tongue, rival tactician Overwatch, mastermind, gloom dragon Encroaching Darkness, shambling mound Tether Down.
- **Unaffected**: vanguard, which already gates on `path.Distance to Creature(self)` in its `conditionFormula` behind a catch-all `subjectRange: 30`.

No `trigger: teleport` content uses `subjectRange`, so that half is forward-looking only.

## Testing

Syntax-checked with `load()` inside the running engine. Behavioural verification needs two clients:

1. Director-controlled judged creature starts non-adjacent, shifts past a player-controlled censor -> no prompt (previously prompted).
2. Same creature starts adjacent, shifts away -> prompt still appears, and accepting still rewinds it to the origin square.
3. Ogre/deathrex Swat the Fly with a player-controlled observer, enemy moving away -> now fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
