### PR TITLE
Add a Caster's Mount apply-to mapping for ability behaviors

### DIFF
--- a/DMHub Compendium/ActivatedAbilityEditor.lua
+++ b/DMHub Compendium/ActivatedAbilityEditor.lua
@@ -1913,6 +1913,10 @@ function ActivatedAbilityBehavior:ApplyToEditor(parentPanel, list)
 			text = "Caster's Riders",
 		},
 		{
+			id = "caster_mount",
+			text = "Caster's Mount",
+		},
+		{
 			id = "caster_summoner",
 			text = "Caster's Summoner",
 		},

--- a/DMHub Game Rules/ActivatedAbility.lua
+++ b/DMHub Game Rules/ActivatedAbility.lua
@@ -3888,6 +3888,14 @@ function ActivatedAbilityBehavior:ApplyToTargets(ability, casterToken, targets, 
                 result[#result+1] = { token = tok }
             end
         end
+    elseif self.applyto == 'caster_mount' then
+        --The creature the caster is riding or climbing; empty when not mounted.
+        result = {}
+
+        local mountToken = casterToken.mount
+        if mountToken ~= nil and mountToken.valid then
+            result[#result+1] = { token = mountToken }
+        end
     elseif self.applyto == 'caster_summoner' then
         result = {}
 

--- a/Draw Steel Core Rules/MCDMAbilityBehavior.lua
+++ b/Draw Steel Core Rules/MCDMAbilityBehavior.lua
@@ -67,6 +67,7 @@ function ActivatedAbilityDrawSteelCommandBehavior:Cast(ability, casterToken, tar
         caster_companion = true,
         caster_summoner = true,
         caster_riders = true,
+        caster_mount = true,
         caster_mentor = true,
         caster_including_squad = true,
     }


### PR DESCRIPTION
Adds `applyto = caster_mount` for ability behaviors: the creature the caster is riding or climbing, empty when not mounted. Exposed in the ability editor as "Caster's Mount".

Needed for the Memorial Ivy's Creeper: invoked abilities are cast by the outer target, so with this mapping plus self targeting the climbed creature casts Move Speed itself instead of the ivy relocating off its mount.

Tested live: ivy on a Ghoul resolves to the Ghoul and the Ghoul moves; unmounted ivy resolves to nothing.