### PR TITLE
Fix empty equipment category caches when refreshTables fires early

### DIFF
--- a/DMHub Game Rules/EquipmentCategory.lua
+++ b/DMHub Game Rules/EquipmentCategory.lua
@@ -225,9 +225,16 @@ dmhub.RegisterEventHandler("refreshTables", function()
 		return
 	end
 
+	local cats = dmhub.GetTable("equipmentCategories")
+	--refreshTables can fire before the tables have downloaded. Building the
+	--category caches from an empty table would leave them empty forever,
+	--so wait for a refresh that actually has categories in it.
+	if cats == nil or next(cats) == nil then
+		return
+	end
+
 	firstTime = false
 
-	local cats = dmhub.GetTable("equipmentCategories") or {}
 	for k,cat in pairs(cats) do
 		if cat.isUnarmored then
 			g_unarmoredCategory = k


### PR DESCRIPTION
**Symptom:** After logging in, the character sheet's Light Style dropdown offers only "None" and the equipped torch shows as "(Invalid)".

**Root cause:** `DMHub Game Rules/EquipmentCategory.lua` populates its category caches from a one-shot `refreshTables` handler, but it spent the `firstTime` latch before checking that the table had any content. The first `refreshTables` fires in the lobby, before the game's data tables have downloaded, so `equipmentCategories` is empty; every cache it builds (`g_unarmoredCategory`, `martialWeaponCategories`, `meleeWeaponCategories`, `rangedWeaponCategories`, `quantityCategories`, `treasureCategories`, `lightSourceCategories`, `packsCategories`, `ammunitionOptions`) is left empty and never rebuilt for the rest of the app session. `EquipmentCategory.IsLightSource()` then returns false for every item, emptying the Light Style dropdown.

Both reporters' logs confirm it: the first Lua refresh printed empty table checks and the damage-types initializer bailed on an empty table, then a second refresh reported the real data.

**The fix:** Fetch the table before consuming the latch and return early (leaving `firstTime` set) when it is nil or empty, so population happens on the first refresh that actually carries categories. This mirrors the guard already present for the identical race in `DMHub Game Rules/DamageTypes.lua`. The handler stays one-shot, so `ammunitionOptions` (which appends) cannot gain duplicates, and `g_catsToItemsCache = {}` still resets on every refresh ahead of the guards.

Reports: GUKH4NRQ and ZMCFFKEZ (two users independently, v0.0.825).

Originated from automated feedback triage.