### PR TITLE
Fix "Draw Steel!" button doing nothing when a creature carries a deleted ongoing effect (report RPM7DDNW)

### DIFF
--- a/DMHub Game Rules/Creature.lua
+++ b/DMHub Game Rules/Creature.lua
@@ -12413,7 +12413,7 @@ function creature:HasCondition(conditionid)
         local effectInfo = ongoingEffects[i]
 		if effectInfo.seq > seqFound then
 			local ongoingEffectInfo = ongoingEffectsTable[effectInfo.ongoingEffectid]
-            if ongoingEffectInfo.condition == conditionid then
+            if ongoingEffectInfo ~= nil and ongoingEffectInfo.condition == conditionid then
                 local casterInfo = effectInfo:try_get("casterInfo")
 				seqFound = effectInfo.seq
                 result = (casterInfo and casterInfo.tokenid) or true


### PR DESCRIPTION
**Symptom:** The "Draw Steel!" button (dropdown menu, journal, and title bar) silently does nothing -- the encounter never starts.

**Root cause:** `creature:HasCondition` in `DMHub Game Rules/Creature.lua` iterates the creature's active ongoing effects and looks each one up in the cached `characterOngoingEffects` table, then reads `.condition` off the result without a nil check. A creature can legitimately carry a `CharacterOngoingEffectInstance` whose `ongoingEffectid` no longer exists in that table -- the effect definition was deleted or re-authored. The lookup then returns nil and the read raises:

```
attempt to index a nil value (local 'ongoingEffectInfo')
  in method 'HasCondition'
  in local 'CreateGroupPanel'     (Draw Steel UI : DSInitiativeRoll)
  in upvalue 'ShowCombatSetupDialog'
```

Because the throw happens while building the combat setup dialog, every "Draw Steel!" entry point fails the same way and nothing appears on screen. The same unguarded read also takes down `SyncHiddenInvisibility` in `Draw Steel Core Rules/MCDMCreature.lua`, which is what prevents the situation from self-healing: the DS `RefreshToken` override calls `SyncHiddenInvisibility` before base `RefreshToken` reaches `ValidateAndRepair`, the routine that would otherwise prune the dangling instance.

In the reporter's log the culprit is a character carrying an old custom "Moonfall" effect that no longer exists in `characterOngoingEffects`; the *guarded* sibling site `FillTemporalActiveModifiers` names it 80 times in the same log without incident.

**The fix:** one line -- skip effect instances that do not resolve, instead of raising on them:

```lua
if ongoingEffectInfo ~= nil and ongoingEffectInfo.condition == conditionid then
```

This was the unguarded outlier; the sibling `ongoingEffectsTable[...]` lookups in this file (e.g. the `ongoingeffects` and `stacks` symbols, and the `ValidateAndRepair` paths) already nil-check the same way. Resolvable effects take the identical path they do today, so there is no behavioural change for valid data.

Report id: RPM7DDNW

Originated from automated feedback triage.