### PR TITLE
Roll dialog: name the ability that inflicted a condition rider's modifier

### DIFF
--- a/DMHub Game Rules/CharacterModifier.lua
+++ b/DMHub Game Rules/CharacterModifier.lua
@@ -3212,6 +3212,25 @@ function CharacterModifier:GetSummaryText()
 	return string.format("<b>%s</b>--%s", self.name, self.description)
 end
 
+--- Appends "who gave you this" to a modifier tooltip, when we know it. `modContext` is
+--- the entry from creature:GetActiveModifiers(); a modifier that arrived on a condition
+--- rider carries the inflicting condition's sourceDescription (e.g. "Inflicted by Ogre
+--- Goon 2's <b>Grabby Hand</b> ability"). Call it AFTER any GoblinScript interpolation,
+--- so a token name in the source text is never treated as a formula.
+--- Deliberately a static, not a method: a hot reload cannot add methods to modifier
+--- instances that are already deserialized.
+--- @param text string
+--- @param modContext nil|table
+--- @return string
+function CharacterModifier.AppendSourceText(text, modContext)
+	local sourceDescription = modContext ~= nil and modContext.sourceDescription or nil
+	if sourceDescription == nil or sourceDescription == "" then
+		return text
+	end
+
+	return string.format("%s\n%s", text, sourceDescription)
+end
+
 --Below here we have functions that can be called on any modifier to see
 --how it behaves in various circumstances.
 

--- a/DMHub Game Rules/CharacterModifier.lua
+++ b/DMHub Game Rules/CharacterModifier.lua
@@ -3212,13 +3212,10 @@ function CharacterModifier:GetSummaryText()
 	return string.format("<b>%s</b>--%s", self.name, self.description)
 end
 
---- Appends "who gave you this" to a modifier tooltip, when we know it. `modContext` is
---- the entry from creature:GetActiveModifiers(); a modifier that arrived on a condition
---- rider carries the inflicting condition's sourceDescription (e.g. "Inflicted by Ogre
---- Goon 2's <b>Grabby Hand</b> ability"). Call it AFTER any GoblinScript interpolation,
---- so a token name in the source text is never treated as a formula.
---- Deliberately a static, not a method: a hot reload cannot add methods to modifier
---- instances that are already deserialized.
+--- Appends the "Inflicted by X's <b>Y</b> ability" attribution to a modifier tooltip, if
+--- modContext (an entry from creature:GetActiveModifiers()) carries a sourceDescription.
+--- Call AFTER GoblinScript interpolation, so a token name is never parsed as a formula.
+--- Static, not a method: hot reload cannot add methods to already-deserialized modifiers.
 --- @param text string
 --- @param modContext nil|table
 --- @return string

--- a/DMHub Game Rules/Creature.lua
+++ b/DMHub Game Rules/Creature.lua
@@ -5683,6 +5683,10 @@ function creature:FillTemporalActiveModifiers(result)
                         for i,mod in ipairs(riderInfo.modifiers) do
                             result[#result+1] = {
                                 mod = mod,
+                                --Carried so the roll dialog can say who inflicted the
+                                --condition this rider came in on (see
+                                --CharacterModifier.AppendSourceText).
+                                sourceDescription = v.sourceDescription,
                             }
                         end
                     end

--- a/DMHub Game Rules/Creature.lua
+++ b/DMHub Game Rules/Creature.lua
@@ -5683,9 +5683,7 @@ function creature:FillTemporalActiveModifiers(result)
                         for i,mod in ipairs(riderInfo.modifiers) do
                             result[#result+1] = {
                                 mod = mod,
-                                --Carried so the roll dialog can say who inflicted the
-                                --condition this rider came in on (see
-                                --CharacterModifier.AppendSourceText).
+                                --Carried so the roll dialog can name the inflicting ability.
                                 sourceDescription = v.sourceDescription,
                             }
                         end

--- a/Draw Steel UI/DSRollDialog.lua
+++ b/Draw Steel UI/DSRollDialog.lua
@@ -1904,6 +1904,8 @@ function GameHud.CreateRollDialog(self)
                         if creature ~= nil then
                             tooltip = StringInterpolateGoblinScript(tooltip, creature)
                         end
+                        --Names the condition/ability this modifier came from, when known.
+                        tooltip = CharacterModifier.AppendSourceText(tooltip, mod.context)
                         for i, justification in ipairs(mod.hint.justification) do
                             tooltip = string.format("%s\n<color=%s>%s", tooltip, cond(ischecked, '#aaffaa', '#ffaaaa'),
                                 justification)

--- a/Draw Steel UI/DSRollDialog.lua
+++ b/Draw Steel UI/DSRollDialog.lua
@@ -1904,7 +1904,6 @@ function GameHud.CreateRollDialog(self)
                         if creature ~= nil then
                             tooltip = StringInterpolateGoblinScript(tooltip, creature)
                         end
-                        --Names the condition/ability this modifier came from, when known.
                         tooltip = CharacterModifier.AppendSourceText(tooltip, mod.context)
                         for i, justification in ipairs(mod.hint.justification) do
                             tooltip = string.format("%s\n<color=%s>%s", tooltip, cond(ischecked, '#aaffaa', '#ffaaaa'),

--- a/Timeline/EmbeddedRollDialog.lua
+++ b/Timeline/EmbeddedRollDialog.lua
@@ -3358,7 +3358,6 @@ function GameHud.CreateEmbeddedRollDialog()
                         if creature ~= nil then
                             tooltip = StringInterpolateGoblinScript(tooltip, creature)
                         end
-                        --Names the condition/ability this modifier came from, when known.
                         tooltip = CharacterModifier.AppendSourceText(tooltip, mod.context)
                         for i, justification in ipairs(mod.hint.justification) do
                             tooltip = string.format("%s\n<color=%s>%s", tooltip, cond(ischecked, '#aaffaa', '#ffaaaa'),
@@ -3729,7 +3728,6 @@ function GameHud.CreateEmbeddedRollDialog()
                         if creature ~= nil then
                             tooltip = StringInterpolateGoblinScript(tooltip, creature)
                         end
-                        --Names the condition/ability this modifier came from, when known.
                         tooltip = CharacterModifier.AppendSourceText(tooltip, mod.context)
                         for i, justification in ipairs(mod.hint.justification) do
                             tooltip = string.format("%s\n<color=%s>%s", tooltip, cond(ischecked, '#aaffaa', '#ffaaaa'),

--- a/Timeline/EmbeddedRollDialog.lua
+++ b/Timeline/EmbeddedRollDialog.lua
@@ -3358,6 +3358,8 @@ function GameHud.CreateEmbeddedRollDialog()
                         if creature ~= nil then
                             tooltip = StringInterpolateGoblinScript(tooltip, creature)
                         end
+                        --Names the condition/ability this modifier came from, when known.
+                        tooltip = CharacterModifier.AppendSourceText(tooltip, mod.context)
                         for i, justification in ipairs(mod.hint.justification) do
                             tooltip = string.format("%s\n<color=%s>%s", tooltip, cond(ischecked, '#aaffaa', '#ffaaaa'),
                                 justification)
@@ -3727,6 +3729,8 @@ function GameHud.CreateEmbeddedRollDialog()
                         if creature ~= nil then
                             tooltip = StringInterpolateGoblinScript(tooltip, creature)
                         end
+                        --Names the condition/ability this modifier came from, when known.
+                        tooltip = CharacterModifier.AppendSourceText(tooltip, mod.context)
                         for i, justification in ipairs(mod.hint.justification) do
                             tooltip = string.format("%s\n<color=%s>%s", tooltip, cond(ischecked, '#aaffaa', '#ffaaaa'),
                                 justification)


### PR DESCRIPTION
## Problem

When a condition rider contributes a power-roll modifier, the roll dialog showed only the modifier's own name and description. A player looking at a bane on their Escape Grab roll had no way to tell which enemy ability put it there.

Found live: the Ogre Goon's **Grabby Hand** applies the `Bane on Escape Grab` rider, the bane correctly appears on the roll, but the hover text names nothing.

## Cause

The attribution was already being recorded and simply never travelled with the rider.

`InflictCondition` stores a `sourceDescription` on the inflicted condition (`"Inflicted by Ogre Goon 2's <b>Grabby Hand</b> ability"`), and the token's condition hover already displays it. But when `FillTemporalActiveModifiers` walks an inflicted condition's riders, it appended each rider modifier as a bare `{mod = mod}` — dropping the entry it came from — so by the time the roll dialog built its tooltip there was nothing left to attribute.

## Fix

- `Creature.lua` — rider modifiers now carry the inflicting condition's `sourceDescription` on the active-modifier entry, which reaches the dialog as `mod.context`.
- `CharacterModifier.lua` — new `CharacterModifier.AppendSourceText(text, modContext)`.
- `DSRollDialog.lua` and `EmbeddedRollDialog.lua` (two sites) — append it below the modifier summary.

Two deliberate choices:

- `AppendSourceText` is a **static, not a method**, so a hot reload cannot raise on modifier instances that are already deserialized.
- It is called **after** `StringInterpolateGoblinScript`, so a token name inside the source text is never parsed as a formula.

## Scope

Applies to every condition rider, not just this one — Many Maws, the double-bane variant, and anything added later inherit it with no per-rider work.

Modifiers from a condition *itself* are untouched. Those are aggregated across every source that applied the condition, so there is no single ability to name.

A rider whose infliction recorded no `sourceDescription` just renders the old tooltip; nothing errors.

## Verification

Live against a grabbed hero, after a Lua reload:

```
<b>Bane on Escape Grab</b>--This creature has a bane on the Escape Grab maneuver.
Inflicted by Ogre Goon 2's <b>Grabby Hand</b> ability
```

All four files pass `luac -p`; the reload logged no new errors.