### PR TITLE
Macro behavior: add optional delay before executing

### DIFF
--- a/Draw Steel Ability Behaviors/AbilityMacro.lua
+++ b/Draw Steel Ability Behaviors/AbilityMacro.lua
@@ -17,9 +17,24 @@ ActivatedAbility.RegisterType
 
 ActivatedAbilityMacroBehavior.summary = 'Macro Execution'
 
+--Seconds to wait before running the macro. Lets a cosmetic command (e.g. a
+--screen shake) line up with a token animation that is still playing when the
+--behavior fires, since Cast returns as soon as the logical move completes.
+ActivatedAbilityMacroBehavior.delay = 0
+
 function ActivatedAbilityMacroBehavior:Cast(ability, casterToken, targets, options)
     local macro = StringInterpolateGoblinScript(self.macro, casterToken.properties:LookupSymbol(options.symbols))
     print("MACRO:: EXECUTE:", macro)
+
+    local delay = tonumber(self.delay) or 0
+    if delay > 0 then
+        dmhub.Schedule(delay, function()
+            if mod.unloaded then return end
+            dmhub.Execute(macro)
+        end)
+        return
+    end
+
     dmhub.Execute(macro)
 end
 
@@ -42,6 +57,27 @@ function ActivatedAbilityMacroBehavior:EditorItems(parentPanel)
             placeholderText = "Enter macro text here...",
             change = function(element)
                 self.macro = element.text
+            end,
+        },
+    }
+
+    result[#result+1] = gui.Panel{
+        classes = {"formPanel"},
+        gui.Label{
+            classes = {"formLabel"},
+            text = "Delay (s):",
+        },
+        gui.Input{
+            classes = {"formInput"},
+            width = 100,
+            text = tostring(self.delay),
+            characterLimit = 16,
+            change = function(element)
+                self.delay = tonumber(element.text) or self.delay
+                if self.delay < 0 then
+                    self.delay = 0
+                end
+                element.text = tostring(self.delay)
             end,
         },
     }


### PR DESCRIPTION
## What

Adds a `delay` field (seconds, default 0) to `ActivatedAbilityMacroBehavior`. When set, the macro is scheduled that many seconds after the behavior fires instead of running immediately. The ability editor exposes it as **Delay (s)** next to the macro text.

## Why

`Cast` returns as soon as a token's logical move completes, so a cosmetic macro such as a screen shake fires while the movement animation is still playing. A short delay lets it line up with the landing.

First consumer: the Ogre Juggernaut's Earth-Breaking Jump now broadcasts a mild screen shake one second after the jump starts (draw-steel-data 601ba839). That data commit is safe to run against a codex without this PR; the macro just fires immediately.

## Notes

- Zero delay keeps the old immediate path, so existing Macro behaviors are unaffected.
- Reminder for anyone copying journal button text into a Macro behavior: the engine only dispatches Lua chat macros when the string has **no leading slash** (`broadcast screenshake ...`, not `/broadcast ...`). The journal's `[[/broadcast ...]]` buttons strip it themselves.