### PR TITLE
Fix blank Encounters panel when an encounter references a missing monster (report JUBZWAN7)

### DIFF
--- a/Draw Steel Core Rules/MCDMEncounter.lua
+++ b/Draw Steel Core Rules/MCDMEncounter.lua
@@ -281,7 +281,7 @@ function Encounter.MainMonster(encounter)
     for i, group in ipairs(encounter.groups) do
         for monsterid, value in pairs(group.monsters) do
             local monster = assets.monsters[monsterid]
-            if mainmonster == nil or monster.properties:EV() > mainmonster.properties:EV() then
+            if monster ~= nil and (mainmonster == nil or monster.properties:EV() > mainmonster.properties:EV()) then
                 mainmonster = monster
             end
         end
@@ -364,10 +364,13 @@ function Encounter.CountEDS(self)
         for monsterid, quantity in pairs(group.monsters) do
             local monster = assets.monsters[monsterid]
 
-            if monster.properties.minion then
-                EDSTotal = EDSTotal + round((assets.monsters[monsterid].properties:EV() * quantity) / 4)
-            else
-                EDSTotal = EDSTotal + (assets.monsters[monsterid].properties:EV() * quantity)
+            if monster ~= nil then
+                local entryEV = monster.properties:EV() * quantity
+                if monster.properties.minion then
+                    entryEV = round(entryEV / 4)
+                end
+
+                EDSTotal = EDSTotal + entryEV
             end
         end
     end

--- a/Draw Steel V/EncounterPanel.lua
+++ b/Draw Steel V/EncounterPanel.lua
@@ -4790,13 +4790,15 @@ CreateEncounterPanel = function()
                     for key, quantity in pairs(monstertable) do
                         local currentmonster = assets.monsters[key]
 
-                        if headmonster == nil then
-                            headmonster = currentmonster
-                        end
+                        if currentmonster ~= nil then
+                            if headmonster == nil then
+                                headmonster = currentmonster
+                            end
 
-                        if currentmonster.properties:EV() > highestev then
-                            highestev = currentmonster.properties:EV()
-                            headmonster = currentmonster
+                            if currentmonster.properties:EV() > highestev then
+                                highestev = currentmonster.properties:EV()
+                                headmonster = currentmonster
+                            end
                         end
                     end
 


### PR DESCRIPTION
**Symptom:** The Encounters panel renders completely empty -- all saved encounters look like they vanished, and newly created ones never appear in the list.

**Root cause:** One saved encounter held a monster id that no longer resolves in `assets.monsters`. `Encounter.CountEDS` (`Draw Steel Core Rules/MCDMEncounter.lua`) indexed that lookup with no nil guard, so it threw `attempt to index a nil value (local 'monster')`. That call happens while the Encounters inspector's `update` handler is building its list, so the throw aborted the handler before it ever assigned `panel.children` -- leaving the entire list blank rather than just the one bad card. The encounters themselves were never lost; saves were persisting fine (the server acked every write), the panel just could not draw them.

The same unguarded lookup exists in two more places on the same code path -- `Encounter.MainMonster` (called from the encounter card's `think` handler, so fixing only `CountEDS` would move the crash) and the head-monster loop in the inspector's `update` handler in `Draw Steel V/EncounterPanel.lua` (which survives today only because these encounters use `groups` and the legacy flat `encounter.monsters` is the empty class default).

**What this changes:** Nil-guards all three lookups, following the pattern already shipped in `DocumentSystem/RichEncounter.lua`'s `GroupEV`: a monster id that no longer resolves contributes 0 EV and is skipped instead of raising. `CountEDS` is also rewritten to reuse the `monster` local instead of re-indexing `assets.monsters` twice; the minion branch still rounds the already-multiplied value (`round((EV * quantity) / 4)`), so EV totals are byte-identical for any encounter whose monsters all resolve.

Not addressed here: the encounter builder's Create button label never flips to "Save", which is what made a successful save look like a no-op. That is a separate issue.

Report: JUBZWAN7 (v0.0.825, WindowsPlayer). Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
