### PR TITLE
Add Hurl Grabbed Creature behavior and end-of-cast aura duration (People Bowling to Gold)

### DIFF
--- a/DMHub Compendium/ActivatedAbilityEditor.lua
+++ b/DMHub Compendium/ActivatedAbilityEditor.lua
@@ -2839,6 +2839,10 @@ function ActivatedAbilityBehavior:AuraEditor(parentPanel, list)
                     id = "none",
                     text = "Indefinite",
                 },
+                {
+                    id = "endcast",
+                    text = "Until Ability Ends",
+                },
 				{
 					id = "endturn",
 					text = "Until End of Turn",

--- a/DMHub Game Rules/Aura.lua
+++ b/DMHub Game Rules/Aura.lua
@@ -2222,6 +2222,24 @@ function ActivatedAbilityAuraBehavior:CastOnArea(ability, casterToken, targets, 
                 casterToken.properties:AddAura(auraInstance)
             end,
         }
+
+        --"Until Ability Ends": the aura only illustrates the cast (e.g. the line a
+        --thrown creature flies down), so take it away in the cast's finish
+        --handlers instead of waiting for a turn or round event.
+        if self:try_get("duration") == "endcast" then
+            options.OnFinishCastHandlers = options.OnFinishCastHandlers or {}
+            options.OnFinishCastHandlers[#options.OnFinishCastHandlers + 1] = function()
+                if not casterToken.valid then
+                    return
+                end
+                casterToken:ModifyProperties {
+                    description = "Remove Aura",
+                    execute = function()
+                        casterToken.properties:RemoveAura(guid)
+                    end,
+                }
+            end
+        end
     end
 end
 

--- a/Draw Steel Ability Behaviors/AbilityRelocateAura.lua
+++ b/Draw Steel Ability Behaviors/AbilityRelocateAura.lua
@@ -409,8 +409,11 @@ end
 --- @param chooserToken nil|CharacterToken Who makes the choice; defaults to the traveller. Only
 --- the invoker slot varies -- the cast must stay centred on the traveller, because the candidate
 --- squares cluster around the far portal and the reticle's range is measured from the caster.
+--- @param labels nil|{name: string, prompt: string} Optional pick-ability name and prompt text,
+--- so a non-portal caller (e.g. the hurl behavior below) does not talk about emerging from a portal.
 --- @return nil|Loc
-local function ChooseTransitDestination(travelToken, candidates, symbols, chooserToken)
+local function ChooseTransitDestination(travelToken, candidates, symbols, chooserToken, labels)
+    labels = labels or {}
     local capturedLoc = nil
 
     --- Resolve a picked square back onto the candidate it represents, so the FLOOR comes from
@@ -472,13 +475,13 @@ local function ChooseTransitDestination(travelToken, candidates, symbols, choose
     end
 
     local pickAbility = ActivatedAbility.Create()
-    pickAbility.name = "Portal Transit"
+    pickAbility.name = labels.name or "Portal Transit"
     pickAbility.targetType = "emptyspace"
     pickAbility.range = tostring((maxDist + 1) * dmhub.unitsPerSquare)
     pickAbility.numTargets = "1"
     pickAbility.countsAsCast = false
     pickAbility.skippable = true
-    pickAbility.promptOverride = "Choose where you emerge"
+    pickAbility.promptOverride = labels.prompt or "Choose where you emerge"
     pickAbility.behaviors = { captureBehavior }
     pickAbility._tmp_restrictLocs = candidates
 
@@ -784,5 +787,403 @@ function ActivatedAbilityPortalTransitBehavior:EditorItems(parentPanel)
             end,
         },
     }
+    return result
+end
+
+--- @class ActivatedAbilityHurlGrabbedBehavior:ActivatedAbilityBehavior
+--- Throws a creature the caster is grabbing down a line ability (Ogre Goon "People Bowling").
+--- Runs with applyto = caster on a line-targeted ability, BEFORE its power roll:
+---   1. picks the grabbed creature (prompting only if several pass hurlFilter),
+---   2. ends the grab and teleports it to the last square of the line, or to the nearest
+---      unoccupied square around that end (a prompt when there is more than one nearest square),
+---   3. appends it to the cast's target list so the power roll that follows rolls against it too.
+--- Lives in this file to reuse ChooseTransitDestination (the restrict-to-squares pick), which is
+--- file-local. It is NOT forced movement: no stability, no collision, no distance reduction.
+--- @field hurlFilter string GoblinScript on the grabbed creature; only creatures passing it can be hurled.
+--- @field searchRadius number How far (squares) around the line's end to look for a free landing square.
+--- @field addAsTarget boolean Append the hurled creature to the cast's targets for later behaviors.
+--- @field promptText string Prompt shown when the director must choose between equally near squares.
+RegisterGameType("ActivatedAbilityHurlGrabbedBehavior", "ActivatedAbilityBehavior")
+
+ActivatedAbility.RegisterType{
+    id = 'hurl_grabbed',
+    text = 'Hurl Grabbed Creature',
+    createBehavior = function()
+        return ActivatedAbilityHurlGrabbedBehavior.new{
+            applyto = "caster",
+        }
+    end,
+}
+
+ActivatedAbilityHurlGrabbedBehavior.summary = 'Hurl Grabbed Creature'
+ActivatedAbilityHurlGrabbedBehavior.hurlFilter = "Size < 5"
+ActivatedAbilityHurlGrabbedBehavior.searchRadius = 3
+ActivatedAbilityHurlGrabbedBehavior.addAsTarget = true
+ActivatedAbilityHurlGrabbedBehavior.promptText = "Choose where the hurled creature lands"
+
+--The Grabbed condition id (same constant as Creature.lua / AbilityRelocateCreature.lua).
+local g_hurlGrabbedConditionId = "70504ebe-3899-41d3-9f60-74b52ce35e39"
+
+--- @param ability ActivatedAbility
+--- @param creatureLookup table
+--- @return string
+function ActivatedAbilityHurlGrabbedBehavior:SummarizeBehavior(ability, creatureLookup)
+    return "Hurl a grabbed creature to the end of the line"
+end
+
+--- The creatures the caster is grabbing that pass hurlFilter.
+--- @param casterToken CharacterToken
+--- @return CharacterToken[]
+function ActivatedAbilityHurlGrabbedBehavior:FindGrabbedCandidates(casterToken)
+    local result = {}
+    local filter = self:try_get("hurlFilter", "")
+    casterToken.properties:VisitConditionCasterSource(function(conditionid, grabbedTok)
+        if conditionid ~= g_hurlGrabbedConditionId or grabbedTok == nil or (not grabbedTok.valid) then
+            return
+        end
+        local passes = true
+        if filter ~= "" then
+            local value = ExecuteGoblinScript(filter, grabbedTok.properties:LookupSymbol({}), 1, "Hurl grabbed filter")
+            passes = GoblinScriptTrue(value)
+        end
+        if passes then
+            result[#result+1] = grabbedTok
+        end
+    end)
+    return result
+end
+
+--- Ask the caster's controller which grabbed creature to throw when more than one qualifies.
+--- Returns nil if the prompt was cancelled.
+--- @param casterToken CharacterToken
+--- @param candidates CharacterToken[]
+--- @param symbols table
+--- @return nil|CharacterToken
+local function ChooseHurledCreature(casterToken, candidates, symbols)
+    local allowed = {}
+    for _, tok in ipairs(candidates) do
+        allowed[tok.charid] = true
+    end
+
+    local chosen = nil
+    local captureBehavior = ActivatedAbilityBehavior.new{ instant = true }
+    captureBehavior.Cast = function(behaviorSelf, captureAbility, captureCasterToken, captureTargets, captureOptions)
+        for _, t in ipairs(captureTargets or {}) do
+            if t.token ~= nil and allowed[t.token.charid] then
+                chosen = t.token
+            end
+        end
+    end
+
+    local pickAbility = ActivatedAbility.Create()
+    pickAbility.name = "Hurl Grabbed Creature"
+    pickAbility.targetType = "target"
+    pickAbility.range = "2"
+    pickAbility.numTargets = "1"
+    pickAbility.countsAsCast = false
+    pickAbility.skippable = true
+    pickAbility.objectTarget = true
+    pickAbility.targetFilter = 'ConditionCaster("Grabbed") = Caster'
+    pickAbility.promptOverride = "Choose the grabbed creature to hurl"
+    pickAbility.behaviors = { captureBehavior }
+    --Transient list the Monster AI prompt handler (MonsterAIPrompts.lua) picks from.
+    pickAbility._tmp_hurlCandidates = candidates
+
+    ActivatedAbilityInvokeAbilityBehavior.ExecuteInvoke(casterToken, pickAbility, casterToken, "prompt", symbols, {})
+    return chosen
+end
+
+--- True if `hurledToken` could come to rest at `loc`: every square of its footprint is on the
+--- map and holds no other token. Size-aware like LocIsFreeFor above (which is portal-specific).
+--- @param hurledToken CharacterToken
+--- @param loc Loc
+--- @return boolean
+local function LocIsFreeForHurl(hurledToken, loc)
+    local locs = hurledToken:LocsOccupyingWhenAt(loc)
+    if locs == nil or #locs == 0 then
+        return false
+    end
+    for _, occLoc in ipairs(locs) do
+        if not occLoc.isOnMap then
+            return false
+        end
+        for _, tok in ipairs(dmhub.GetTokensAtLoc(occLoc) or {}) do
+            if tok.id ~= hurledToken.id then
+                return false
+            end
+        end
+    end
+    return true
+end
+
+--- The last square of the line: the one furthest from the caster (matches how
+--- ActivatedAbilityRelocateCreatureBehavior finds the end of a line).
+--- @param casterToken CharacterToken
+--- @param targetArea table|nil options.targetArea of the cast.
+--- @return nil|Loc
+local function FindLineEnd(casterToken, targetArea)
+    local locs = targetArea and targetArea.locations
+    if locs == nil or #locs == 0 then
+        return nil
+    end
+    local best = locs[1]
+    for i = 2, #locs do
+        if locs[i]:DistanceInTiles(casterToken.loc) > best:DistanceInTiles(casterToken.loc) then
+            best = locs[i]
+        end
+    end
+    return best
+end
+
+--- Landing candidates: the line's end square if free, otherwise every free square nearest to it
+--- (ties are all returned so the caster can choose). The caster must be able to see a fallback
+--- square, so the throw is never resolved through a wall.
+--- @param casterToken CharacterToken
+--- @param hurledToken CharacterToken
+--- @param endLoc Loc
+--- @param searchRadius number
+--- @return Loc[]
+local function FindLandingCandidates(casterToken, hurledToken, endLoc, searchRadius)
+    if LocIsFreeForHurl(hurledToken, endLoc) then
+        return { endLoc }
+    end
+
+    local nearest = {}
+    local nearestDist = nil
+    for _, loc in ipairs(endLoc:LocsInRadius(searchRadius) or {}) do
+        local dist = loc:DistanceInTiles(endLoc)
+        if dist > 0 and (nearestDist == nil or dist <= nearestDist) and LocIsFreeForHurl(hurledToken, loc) then
+            --GetLineOfSight accepts a Loc; guard it anyway so an engine change never blocks the throw.
+            local visible = true
+            local ok, los = pcall(function() return casterToken:GetLineOfSight(loc) end)
+            if ok and type(los) == "number" then
+                visible = los > 0
+            end
+            if visible then
+                if nearestDist == nil or dist < nearestDist then
+                    nearest = { loc }
+                    nearestDist = dist
+                else
+                    nearest[#nearest+1] = loc
+                end
+            end
+        end
+    end
+    return nearest
+end
+
+--- @param ability ActivatedAbility
+--- @param casterToken CharacterToken
+--- @param targets table
+--- @param options table
+function ActivatedAbilityHurlGrabbedBehavior:Cast(ability, casterToken, targets, options)
+    local symbols = options.symbols or {}
+
+    local candidates = self:FindGrabbedCandidates(casterToken)
+    if #candidates == 0 then
+        casterToken.properties:FloatLabel("Nothing to hurl", "red")
+        return
+    end
+
+    local hurled = candidates[1]
+    if #candidates > 1 then
+        hurled = ChooseHurledCreature(casterToken, candidates, symbols)
+        if hurled == nil then
+            return
+        end
+    end
+
+    local endLoc = FindLineEnd(casterToken, options.targetArea)
+    if endLoc == nil then
+        casterToken.properties:FloatLabel("Hurl needs a line target", "red")
+        return
+    end
+
+    local landing = FindLandingCandidates(casterToken, hurled, endLoc, self:try_get("searchRadius", 3))
+    if #landing == 0 then
+        casterToken.properties:FloatLabel("No room to land", "red")
+        return
+    end
+
+    local dest = landing[1]
+    if #landing > 1 then
+        dest = ChooseTransitDestination(hurled, landing, symbols, casterToken, {
+            name = "Hurl Landing Square",
+            prompt = self:try_get("promptText", ""),
+        })
+        if dest == nil then
+            return
+        end
+    end
+
+    local origLoc = hurled.loc
+
+    --The throw ends the grab. Purge only this caster's grab so another grabber keeps theirs.
+    hurled:ModifyProperties{
+        description = "Hurled",
+        execute = function()
+            hurled.properties:InflictCondition(g_hurlGrabbedConditionId, {
+                purge = true,
+                casterInfo = { tokenid = casterToken.charid },
+            })
+        end,
+    }
+
+    --Fly the creature down the line like a push: straight-line forced moves that
+    --pass over creatures, are not its own move action, and do not provoke. The
+    --grab was ended above, so the Grabbed condition's forcemove trigger (drag
+    --the grabber along) never fires. Not a rules forced move: no
+    --forcedMovementDistance, so a blocked path just stops with no collision
+    --damage. When the landing square is off the line's end, the throw still
+    --runs the whole line to its end square and then hops (jump animation)
+    --into the square the director chose.
+    local function WaitForGameUpdate()
+        local updateAt = dmhub.ngameupdate
+        local startTime = dmhub.Time()
+        while dmhub.ngameupdate <= updateAt and dmhub.Time() < startTime + 2 do
+            coroutine.yield(0.05)
+        end
+    end
+
+    local function ThrowMove(toLoc, movementType)
+        hurled.properties._tmp_freeMovement = true
+        local path = hurled:Move(toLoc.withGroundAltitude, {
+            straightline = true,
+            ignorecreatures = true,
+            moveThroughFriends = true,
+            maxCost = 30000,
+            movementType = movementType,
+            jumpHeight = 2,
+            ignoreFalling = (movementType == "jump"),
+            freeMovement = true,
+            forced = true,
+        })
+        hurled.properties._tmp_freeMovement = false
+        return path ~= nil
+    end
+
+    --The push always runs the full line, even onto a square another creature
+    --or object already holds (creatures are ignored, so the engine lets the
+    --thrown creature pass over and stop there); only then does it hop into
+    --the square the director chose. Skip the push if it already stands there.
+    local legs = {}
+    if hurled.loc.xyfloorOnly.str ~= endLoc.xyfloorOnly.str then
+        legs[#legs+1] = { loc = endLoc, movementType = "move" }
+    end
+    if dest.xyfloorOnly.str ~= endLoc.xyfloorOnly.str then
+        legs[#legs+1] = { loc = dest, movementType = "jump" }
+    end
+
+    local moved = true
+    for i, leg in ipairs(legs) do
+        if i > 1 then
+            WaitForGameUpdate()
+        end
+        moved = ThrowMove(leg.loc, leg.movementType)
+        if not moved then
+            break
+        end
+    end
+
+    --Fall back to a silent teleport if the engine refused a leg: the creature
+    --must still land somewhere.
+    if not moved then
+        print("HurlGrabbed:: MOVE REFUSED, teleporting instead. dest =", dest.str)
+        hurled.properties._tmp_suppressTeleportEvent = true
+        hurled:Teleport(dest.withGroundAltitude)
+        hurled.properties._tmp_suppressTeleportEvent = nil
+    end
+    hurled.properties:FloatLabel("Hurled!", "white")
+
+    --Let the move land before anything rolls against the creature.
+    WaitForGameUpdate()
+    if hurled.valid then
+        hurled:TryFall()
+    end
+
+    --Commit to the cost once the throw has actually happened, so a cancelled
+    --pick above never charges the maneuver. (Ending a grab mid-cast logs one
+    --engine "already in a transaction" line; the engine's own Grabbed teleport
+    --trigger does the same, and state stays correct.)
+    ability:CommitToPaying(casterToken, options)
+
+    if self:try_get("addAsTarget", true) and options.targets ~= nil and hurled.valid then
+        local present = false
+        for _, existing in ipairs(options.targets) do
+            if existing.token ~= nil and existing.token.charid == hurled.charid then
+                present = true
+                break
+            end
+        end
+        if not present then
+            options.targets[#options.targets+1] = { token = hurled, origLoc = origLoc }
+        end
+        if symbols.cast ~= nil then
+            symbols.cast.targets = options.targets
+        end
+    end
+end
+
+--- @param parentPanel Panel
+--- @return Panel[]
+function ActivatedAbilityHurlGrabbedBehavior:EditorItems(parentPanel)
+    local result = {}
+    self:ApplyToEditor(parentPanel, result)
+    self:FilterEditor(parentPanel, result)
+
+    result[#result+1] = gui.Panel{
+        classes = { "formPanel" },
+        gui.Label{ classes = { "formLabel" }, text = "Hurl Filter:" },
+        gui.GoblinScriptInput{
+            classes = { "formInput" },
+            value = self:try_get("hurlFilter", ""),
+            change = function(element)
+                self.hurlFilter = element.value
+            end,
+            documentation = {
+                help = "Which grabbed creatures may be hurled. Evaluated on each creature the caster is grabbing.",
+                output = "boolean",
+                subject = creature.helpSymbols,
+                subjectDescription = "A creature the caster is grabbing",
+                examples = {
+                    { script = "Size < 5", text = "Only Size 1 creatures can be hurled." },
+                },
+            },
+        },
+    }
+
+    result[#result+1] = gui.Panel{
+        classes = { "formPanel" },
+        gui.Label{ classes = { "formLabel" }, text = "Landing Search Radius:" },
+        gui.Input{
+            classes = { "formInput" },
+            text = tostring(self:try_get("searchRadius", 3)),
+            change = function(element)
+                self.searchRadius = tonumber(element.text) or 3
+                element.text = tostring(self.searchRadius)
+            end,
+        },
+    }
+
+    result[#result+1] = gui.Panel{
+        classes = { "formPanel" },
+        gui.Label{ classes = { "formLabel" }, text = "Prompt Text:" },
+        gui.Input{
+            classes = { "formInput" },
+            text = self:try_get("promptText", ""),
+            change = function(element)
+                self.promptText = element.text
+            end,
+        },
+    }
+
+    result[#result+1] = gui.Check{
+        text = "Add Hurled Creature To Targets",
+        value = self:try_get("addAsTarget", true),
+        change = function(element)
+            self.addAsTarget = element.value
+        end,
+    }
+
     return result
 end

--- a/Monster AI/MonsterAIPrompts.lua
+++ b/Monster AI/MonsterAIPrompts.lua
@@ -537,6 +537,39 @@ MonsterAI:RegisterPrompt{
     end,
 }
 
+--Hurl Grabbed Creature (Ogre Goon "People Bowling", AbilityRelocateAura.lua):
+--two picks. The creature pick carries its candidates in _tmp_hurlCandidates;
+--throw the first (the goon normally grabs only one creature anyway). The
+--landing pick carries the equally-near free squares in _tmp_restrictLocs;
+--any of them satisfies the rule, so take the first.
+MonsterAI:RegisterPrompt{
+    prompts = {"Hurl Grabbed Creature"},
+
+    handler = function(ai, invokerToken, casterToken, abilityClone, symbols, options)
+        local candidates = abilityClone:try_get("_tmp_hurlCandidates")
+        if candidates == nil or #candidates == 0 then
+            return nil
+        end
+        return {
+            targets = { {token = candidates[1]} }
+        }
+    end,
+}
+
+MonsterAI:RegisterPrompt{
+    prompts = {"Hurl Landing Square"},
+
+    handler = function(ai, invokerToken, casterToken, abilityClone, symbols, options)
+        local locs = abilityClone:try_get("_tmp_restrictLocs")
+        if locs == nil or #locs == 0 then
+            return nil
+        end
+        return {
+            targets = { {loc = locs[1]} }
+        }
+    end,
+}
+
 MonsterAI:RegisterPrompt{
     prompts = {"Decrepit Skeleton:Invoked Ability"},
 


### PR DESCRIPTION
## Summary

Takes the Ogre Goon's **People Bowling** to Gold (data change pushed separately in draw-steel-data `2febbde3`).

- **New behavior `hurl_grabbed` ("Hurl Grabbed Creature")** in `Draw Steel Ability Behaviors/AbilityRelocateAura.lua`. On a line-targeted ability it finds the creature the caster is grabbing (GoblinScript `hurlFilter`, default `Size < 5`), ends the grab, runs a push-style straight-line move all the way to the line's end square (through and onto occupied squares), then jumps into the nearest unoccupied square of the director's choice when the end is taken (a prompt only when several squares tie), and appends the hurled creature to the cast's targets so the power roll that follows hits it too. Falls back to a silent teleport if the engine refuses a move.
- **Monster AI prompt handlers** (`Monster AI/MonsterAIPrompts.lua`) answer both picks so AI-run goons can use the maneuver.
- **Aura duration "Until Ability Ends"** (`endcast`) in `DMHub Game Rules/Aura.lua` + the ability editor dropdown: the aura is removed in the cast's finish handlers. Used for People Bowling's line outline so it no longer lingers to end of turn.
- `ChooseTransitDestination` (the file-local restrict-to-squares chooser) gains an optional `labels` argument so non-portal callers get their own prompt/name.

The behavior lives in `AbilityRelocateAura.lua` because the MCP bridge on the dev Mac has no Lua-file registration tool and the file owns the chooser it reuses.

## Testing

Live in the dev game with scripted casts (synthetic line) and Ricky's manual action-bar casts:
- end square free: creature lands on the last square, grab ends, 3 Malice spent, both line targets take the rolled tier;
- end square occupied by up to three creatures: creature is pushed to the occupied end square, then jumps to the chosen square; prone applied on tier 3;
- outline aura present during the cast, gone afterward.

Known, pre-existing: ending a grab mid-cast logs one engine "Tried to BeginTransaction() on a document that is already in a transaction" line; the engine's own Grabbed teleport trigger does the same and state is correct.
