### PR TITLE
Fix empty Bestiary tree when a monster has a fractional level (report BHFUVQX9)

### DIFF
--- a/DMHub Core Panels/CharacterPanel.lua
+++ b/DMHub Core Panels/CharacterPanel.lua
@@ -1003,8 +1003,9 @@ local function CreateMonsterEntry(nodeid, startHidden)
 
         local level = nil
         pcall(function() level = props:Level() end)
+        level = tonumber(level)
         if level ~= nil and level > 0 then
-            parts[#parts + 1] = string.format("Level %d", level)
+            parts[#parts + 1] = string.format("Level %d", round(level))
         end
 
         local role = nil


### PR DESCRIPTION
**Symptom:** The Bestiary tree renders empty -- header only, no folders, no monsters (report BHFUVQX9).

**Root cause:** `MonsterSubtitleText` in `CreateMonsterEntry` (`DMHub Core Panels/CharacterPanel.lua`) formats the row's "Level 3 Elite Brute" subtitle with `string.format("Level %d", props:Level())`. `monster:Level()` returns the legacy 5e-heritage `cr` field verbatim, and `cr` can legitimately be fractional: `monster:SetCR` accepts "1/2", "1/4", "1/8" and stores `1/denom` as a Lua float, and the AI importer stores whatever `ImportUtils.ParseCR` returns. In Lua 5.4 `string.format("%d", 0.5)` raises *"number has no integer representation"*.

The existing `pcall` wraps only the `props:Level()` call, not the `string.format`, so the throw escaped `MonsterSubtitleText`, escaped the `gui.Label{ text = MonsterSubtitleText() }`, escaped `CreateMonsterEntry`/`CreateBestiaryNode`, and aborted the enclosing folder's `RebuildChildren` loop. Because `elements = newElements` and `AssembleChildren(element)` both sit after that loop, `element.children` was never assigned and the folder rendered with only its construction-time `children = { headerPanel }` -- a visibly empty Bestiary. Integer-level monsters are unaffected, which is why this only bites some users.

The reporter's logs show this error repeated across the session:

```
Error in function call: [string "DMHub Core Panels : CharacterPanel"]:1007: bad argument #2 to 'format' (number has no integer representation)
  [C]: in function 'string.format'
  ...:1007: in local 'MonsterSubtitleText'
  ...:1472: in function <...:959>
  ...:2008: in upvalue 'RebuildChildren'
```

**The fix:** two lines in `MonsterSubtitleText` -- coerce with `tonumber` and wrap the format argument in `round`:

```lua
        pcall(function() level = props:Level() end)
        level = tonumber(level)
        if level ~= nil and level > 0 then
            parts[#parts + 1] = string.format("Level %d", round(level))
        end
```

This restores the guard every other `cr` consumer in the codex already applies -- `Draw Steel Core Rules/MCDMMonster.lua` `RoleDescription` formats the identical string as `round(tonumber(self.cr) or 0)`, and the character sheet does the same -- so a fractional-cr monster now shows the same level the rest of the UI already shows for it (e.g. "Level 1" for `cr` 0.5). It is a consistency fix, not a new display convention.

The added `tonumber` also removes a second latent throw on the very next expression: a string-valued `cr` would raise "attempt to compare string with number" on `level > 0`, likewise outside the `pcall`. A non-numeric value now yields `nil` and falls through to the existing role / `RaceOrMonsterType()` fallbacks.

Nothing else in the function or the file is changed. The nearby `SubtitleText` helper for player characters uses `CharacterLevel()`, a different path, and was deliberately left alone.

**Verification:** `luac -p "DMHub Core Panels/CharacterPanel.lua"` parses clean (this file uses no `@if` preprocessor directives), and the diff introduces no non-ASCII bytes.

**Note on data:** `data/monsters/stirge.yaml` (`cr: 0.5`) is the only non-integer level among the shipped monsters, but it is deliberately *not* touched here -- a user-created or module-overridden monster would reintroduce the same crash regardless, so the display guard is the real repair.

Report id: `BHFUVQX9`. Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
