### PR TITLE
Fix blank journal tree when a document has no parentFolder (report T7R52R5A)

### DIFF
--- a/DMHub Core Panels/Journal.lua
+++ b/DMHub Core Panels/Journal.lua
@@ -2398,7 +2398,7 @@ CreateJournalPanel = function(options)
                 end
 
                 for k, doc in unhidden_pairs(customDocs) do
-                    local parentFolder = doc.parentFolder
+                    local parentFolder = doc.parentFolder or "private"
                     local members = foldersToMembers[parentFolder] or {}
                     members[k] = doc
                     foldersToMembers[parentFolder] = members


### PR DESCRIPTION
**Symptom:** The journal side tree renders completely empty -- no folders, no documents -- although every document is still present in storage.

**Root cause:** In the journal panel's `refreshAssets` handler (`DMHub Core Panels/Journal.lua`), the custom-documents loop read `doc.parentFolder` with no fallback. If any entry in the `documents` table reads back with `parentFolder == nil`, the loop's last line executes `foldersToMembers[nil] = members` and raises `table index is nil` (32 occurrences in the report's log, each immediately after the PDF-fragment prints). That error aborts `refreshAssets` before it assigns `journalPanel.data.foldersToMembers` and before it fires `refreshDocuments`, so the tree keeps the panel's initial empty `foldersToMembers = {}` -- a blank journal.

**The fix:** One line -- `local parentFolder = doc.parentFolder or "private"`. This restores symmetry with the four sibling loops in the same function (pdfDocuments, images, PDF fragments, folders), which all already apply the same `or "private"` fallback.

For any well-formed `CustomDocument` the expression is unchanged: `CustomDocument.parentFolder = "private"` is the class default (`DocumentSystem/DocumentSystem.lua`), so the `or` branch is never taken. Only a malformed, type-less record (a raw table with no metatable) reaches the fallback, and it lands in the "private" bucket instead of killing the refresh. Such a member has `nodeType == nil`, so `CreateFolderContentsPanel` matches neither its document nor its folder branch and skips it silently; every real document renders again.

**Out of scope:** The type-less record itself originates engine-side and is tracked separately. This change is purely the render-side hardening.

Verified with the bundled Lua 5.4.7 `luac -p`; the file parses clean and introduces no non-ASCII bytes.

Report id: T7R52R5A. Originated from automated feedback triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)