### PR TITLE
Add Squad GoblinScript symbol (War Dog Backpacker full implementation)

### DIFF
--- a/Draw Steel Core Rules/MCDMCreature.lua
+++ b/Draw Steel Core Rules/MCDMCreature.lua
@@ -1812,6 +1812,20 @@ creature.RegisterSymbol {
 }
 
 creature.RegisterSymbol {
+    symbol = "squad",
+    lookup = function(c)
+        --Captains report their squad too; pair with Minion to exclude them.
+        return c:MinionSquad() or ""
+    end,
+    help = {
+        name = "Squad",
+        type = "text",
+        desc = "The minion squad this creature belongs to, or empty text if none.",
+        seealso = { "Minion", "Squad Captain", "Living Squad Members" },
+    }
+}
+
+creature.RegisterSymbol {
     symbol = "livingsquadmembers",
     lookup = function(c)
         --resolve the squad this creature belongs to. Minions report their squad


### PR DESCRIPTION
Gets the War Dog Backpacker (The Condemned) to full implementation.

Blackpowder Spray's tier 1 rider ("one backpacker using the ability is reduced to 0 Stamina") is a prompt invoke whose target filter needs to compare squad membership. This adds the `Squad` GoblinScript creature symbol: the creature's `MinionSquad()` name, or empty text. Captains report their squad too, so filters pair it with `Minion`.

Used by the Backpacker as `Target.Minion and Target.Squad = Caster.Squad`. Live-tested: only the casting squad is selectable, the pick books one minion band and marks that token's death skull, tiers 2 and 3 do not prompt.