### PR TITLE
Fix hover destroying the live power roll for Hidden sub-abilities (report BDJNBWXD)

### DIFF
--- a/Timeline/AbilitySidebar.lua
+++ b/Timeline/AbilitySidebar.lua
@@ -2548,7 +2548,14 @@ function CharacterPanel.DisplayAbility(token, ability, symbols, options)
         if not AbilityOwnsDisplayedCard(ability) then
             g_displayedAbilityAliases[#g_displayedAbilityAliases+1] = ability
         end
-        return true
+        --Honour options.lock here too: the caller is about to embed a live roll
+        --dialog in the parent's card, and without it a stray hover preview displaces
+        --the card and destroys the roll. Coroutine-tied only, so it always expires.
+        local lockId = nil
+        if options.lock and options.lockCoroutine ~= nil then
+            lockId = CharacterPanel.LockDisplayAbility(options.lockCoroutine)
+        end
+        return true, lockId
     end
 
     local embeddedRoll = panel:FindChildRecursive(function(p)


### PR DESCRIPTION
**Symptom:** After a tier-3 result triggered a sub-ability, hovering the trigger chip made the live power-roll timeline/dialog disappear and the ability resolved with nothing applied.

**Root cause:** `CharacterPanel.DisplayAbility` (Timeline/AbilitySidebar.lua) has an early-return branch for sub-abilities whose `categorization` is `Hidden` -- they ride on the parent ability's card instead of replacing it. That branch returned bare `true`, ignoring `options.lock`, so `AcquireAbilityRollDialog` got `lockId = nil` and no display lock was taken even though it asked for one. The function's normal exit path does take the lock; only this early return skipped it. With the card unlocked, any hover preview (action-bar ability preview or trigger-chip preview) called `DisplayAbility`, found no lock held, cleared and rebuilt the panel, and destroyed the embedded roll dialog. The roll behavior then saw an invalid dialog, cancelled, and the cast aborted. Reproduced with the Elementalist `Practical Magic - Knockback` sub-ability, which is `categorization: Hidden`.

**Fix:** honour `options.lock` on that early-return path, mirroring the function's normal path, and return the lock id as the second value. The lock is only taken when `options.lockCoroutine` is set, so it is limited to `AcquireAbilityRollDialog` (whose caller always releases it) and always self-expires with the cast coroutine. The two other `{lock = true}` callers pass no `lockCoroutine` and keep today's behaviour, so they cannot pin the card with an unreleasable lock. `DisplayLockHeld()` is already checked immediately above, so no other holder's lock is stolen.

Report BDJNBWXD (v0.0.829). Raised from automated feedback triage.
