### PR TITLE
Add Hurl Grabbed Creature behavior and end-of-cast aura duration (rebase of #322)

### DIFF
--- a/DMHub Compendium/ActivatedAbilityEditor.lua
+++ b/DMHub Compendium/ActivatedAbilityEditor.lua
@@ -2839,6 +2839,10 @@ function ActivatedAbilityBehavior:AuraEditor(parentPanel, list)
                     id = "none",
                     text = "Indefinite",
                 },
+                {
+                    id = "endcast",
+                    text = "Until Ability Ends",
+                },
 				{
 					id = "endturn",
 					text = "Until End of Turn",

--- a/DMHub Game Rules/Aura.lua
+++ b/DMHub Game Rules/Aura.lua
@@ -2253,6 +2253,24 @@ function ActivatedAbilityAuraBehavior:CastOnArea(ability, casterToken, targets, 
                 casterToken.properties:AddAura(auraInstance)
             end,
         }
+
+        --"Until Ability Ends": the aura only illustrates the cast (e.g. the line a
+        --thrown creature flies down), so take it away in the cast's finish
+        --handlers instead of waiting for a turn or round event.
+        if self:try_get("duration") == "endcast" then
+            options.OnFinishCastHandlers = options.OnFinishCastHandlers or {}
+            options.OnFinishCastHandlers[#options.OnFinishCastHandlers + 1] = function()
+                if not casterToken.valid then
+                    return
+                end
+                casterToken:ModifyProperties {
+                    description = "Remove Aura",
+                    execute = function()
+                        casterToken.properties:RemoveAura(guid)
+                    end,
+                }
+            end
+        end
     end
 end
 

--- a/Draw Steel Ability Behaviors/AbilityRelocateAura.lua
+++ b/Draw Steel Ability Behaviors/AbilityRelocateAura.lua
@@ -409,8 +409,11 @@ end
 --- @param chooserToken nil|CharacterToken Who makes the choice; defaults to the traveller. Only
 --- the invoker slot varies -- the cast must stay centred on the traveller, because the candidate
 --- squares cluster around the far portal and the reticle's range is measured from the caster.
+--- @param labels nil|{name: string, prompt: string} Optional pick-ability name and prompt text,
+--- so a non-portal caller (e.g. the hurl behavior below) does not talk about emerging from a portal.
 --- @return nil|Loc
-local function ChooseTransitDestination(travelToken, candidates, symbols, chooserToken)
+local function ChooseTransitDestination(travelToken, candidates, symbols, chooserToken, labels)
+    labels = labels or {}
     local capturedLoc = nil
 
     --- Resolve a picked square back onto the candidate it represents, so the FLOOR comes from
@@ -472,13 +475,13 @@ local function ChooseTransitDestination(travelToken, candidates, symbols, choose
     end
 
     local pickAbility = ActivatedAbility.Create()
-    pickAbility.name = "Portal Transit"
+    pickAbility.name = labels.name or "Portal Transit"
     pickAbility.targetType = "emptyspace"
     pickAbility.range = tostring((maxDist + 1) * dmhub.unitsPerSquare)
     pickAbility.numTargets = "1"
     pickAbility.countsAsCast = false
     pickAbility.skippable = true
-    pickAbility.promptOverride = "Choose where you emerge"
+    pickAbility.promptOverride = labels.prompt or "Choose where you emerge"
     pickAbility.behaviors = { captureBehavior }
     pickAbility._tmp_restrictLocs = candidates
 
@@ -1294,6 +1297,381 @@ function ActivatedAbilityDisplaceOverlappingBehavior:EditorItems(parentPanel)
                 self.growDuration = element.text
             end,
         },
+    }
+
+    return result
+end
+
+--- @class ActivatedAbilityHurlGrabbedBehavior:ActivatedAbilityBehavior
+--- Throws a creature the caster is grabbing down a line ability (Ogre Goon "People Bowling").
+--- Runs with applyto = caster on a line-targeted ability, BEFORE its power roll:
+---   1. picks the grabbed creature (prompting only if several pass hurlFilter),
+---   2. ends the grab and teleports it to the last square of the line, or to the nearest
+---      unoccupied square around that end (a prompt when there is more than one nearest square),
+---   3. appends it to the cast's target list so the power roll that follows rolls against it too.
+--- Lives in this file to reuse ChooseTransitDestination (the restrict-to-squares pick), which is
+--- file-local. It is NOT forced movement: no stability, no collision, no distance reduction.
+--- @field hurlFilter string GoblinScript on the grabbed creature; only creatures passing it can be hurled.
+--- @field searchRadius number How far (squares) around the line's end to look for a free landing square.
+--- @field addAsTarget boolean Append the hurled creature to the cast's targets for later behaviors.
+--- @field promptText string Prompt shown when the director must choose between equally near squares.
+RegisterGameType("ActivatedAbilityHurlGrabbedBehavior", "ActivatedAbilityBehavior")
+
+ActivatedAbility.RegisterType{
+    id = 'hurl_grabbed',
+    text = 'Hurl Grabbed Creature',
+    createBehavior = function()
+        return ActivatedAbilityHurlGrabbedBehavior.new{
+            applyto = "caster",
+        }
+    end,
+}
+
+ActivatedAbilityHurlGrabbedBehavior.summary = 'Hurl Grabbed Creature'
+ActivatedAbilityHurlGrabbedBehavior.hurlFilter = "Size < 5"
+ActivatedAbilityHurlGrabbedBehavior.searchRadius = 3
+ActivatedAbilityHurlGrabbedBehavior.addAsTarget = true
+ActivatedAbilityHurlGrabbedBehavior.promptText = "Choose where the hurled creature lands"
+
+--The Grabbed condition id (same constant as Creature.lua / AbilityRelocateCreature.lua).
+local g_hurlGrabbedConditionId = "70504ebe-3899-41d3-9f60-74b52ce35e39"
+
+--- @param ability ActivatedAbility
+--- @param creatureLookup table
+--- @return string
+function ActivatedAbilityHurlGrabbedBehavior:SummarizeBehavior(ability, creatureLookup)
+    return "Hurl a grabbed creature to the end of the line"
+end
+
+--- The creatures the caster is grabbing that pass hurlFilter.
+--- @param casterToken CharacterToken
+--- @return CharacterToken[]
+function ActivatedAbilityHurlGrabbedBehavior:FindGrabbedCandidates(casterToken)
+    local result = {}
+    local filter = self:try_get("hurlFilter", "")
+    casterToken.properties:VisitConditionCasterSource(function(conditionid, grabbedTok)
+        if conditionid ~= g_hurlGrabbedConditionId or grabbedTok == nil or (not grabbedTok.valid) then
+            return
+        end
+        local passes = true
+        if filter ~= "" then
+            local value = ExecuteGoblinScript(filter, grabbedTok.properties:LookupSymbol({}), 1, "Hurl grabbed filter")
+            passes = GoblinScriptTrue(value)
+        end
+        if passes then
+            result[#result+1] = grabbedTok
+        end
+    end)
+    return result
+end
+
+--- Ask the caster's controller which grabbed creature to throw when more than one qualifies.
+--- Returns nil if the prompt was cancelled.
+--- @param casterToken CharacterToken
+--- @param candidates CharacterToken[]
+--- @param symbols table
+--- @return nil|CharacterToken
+local function ChooseHurledCreature(casterToken, candidates, symbols)
+    local allowed = {}
+    for _, tok in ipairs(candidates) do
+        allowed[tok.charid] = true
+    end
+
+    local chosen = nil
+    local captureBehavior = ActivatedAbilityBehavior.new{ instant = true }
+    captureBehavior.Cast = function(behaviorSelf, captureAbility, captureCasterToken, captureTargets, captureOptions)
+        for _, t in ipairs(captureTargets or {}) do
+            if t.token ~= nil and allowed[t.token.charid] then
+                chosen = t.token
+            end
+        end
+    end
+
+    local pickAbility = ActivatedAbility.Create()
+    pickAbility.name = "Hurl Grabbed Creature"
+    pickAbility.targetType = "target"
+    pickAbility.range = "2"
+    pickAbility.numTargets = "1"
+    pickAbility.countsAsCast = false
+    pickAbility.skippable = true
+    pickAbility.objectTarget = true
+    pickAbility.targetFilter = 'ConditionCaster("Grabbed") = Caster'
+    pickAbility.promptOverride = "Choose the grabbed creature to hurl"
+    pickAbility.behaviors = { captureBehavior }
+    --Transient list the Monster AI prompt handler (MonsterAIPrompts.lua) picks from.
+    pickAbility._tmp_hurlCandidates = candidates
+
+    ActivatedAbilityInvokeAbilityBehavior.ExecuteInvoke(casterToken, pickAbility, casterToken, "prompt", symbols, {})
+    return chosen
+end
+
+--- The last square of the line: the one furthest from the caster (matches how
+--- ActivatedAbilityRelocateCreatureBehavior finds the end of a line).
+--- @param casterToken CharacterToken
+--- @param targetArea table|nil options.targetArea of the cast.
+--- @return nil|Loc
+local function FindLineEnd(casterToken, targetArea)
+    local locs = targetArea and targetArea.locations
+    if locs == nil or #locs == 0 then
+        return nil
+    end
+    local best = locs[1]
+    for i = 2, #locs do
+        if locs[i]:DistanceInTiles(casterToken.loc) > best:DistanceInTiles(casterToken.loc) then
+            best = locs[i]
+        end
+    end
+    return best
+end
+
+--- Landing candidates: the line's end square if free, otherwise every free square nearest to it
+--- (ties are all returned so the caster can choose). The caster must be able to see a fallback
+--- square, so the throw is never resolved through a wall.
+--- @param casterToken CharacterToken
+--- @param hurledToken CharacterToken
+--- @param endLoc Loc
+--- @param searchRadius number
+--- @return Loc[]
+local function FindLandingCandidates(casterToken, hurledToken, endLoc, searchRadius)
+    if LocIsFreeForToken(hurledToken, endLoc) then
+        return { endLoc }
+    end
+
+    local nearest = {}
+    local nearestDist = nil
+    for _, loc in ipairs(endLoc:LocsInRadius(searchRadius) or {}) do
+        local dist = loc:DistanceInTiles(endLoc)
+        if dist > 0 and (nearestDist == nil or dist <= nearestDist) and LocIsFreeForToken(hurledToken, loc) then
+            --GetLineOfSight accepts a Loc; guard it anyway so an engine change never blocks the throw.
+            local visible = true
+            local ok, los = pcall(function() return casterToken:GetLineOfSight(loc) end)
+            if ok and type(los) == "number" then
+                visible = los > 0
+            end
+            if visible then
+                if nearestDist == nil or dist < nearestDist then
+                    nearest = { loc }
+                    nearestDist = dist
+                else
+                    nearest[#nearest+1] = loc
+                end
+            end
+        end
+    end
+    return nearest
+end
+
+--- @param ability ActivatedAbility
+--- @param casterToken CharacterToken
+--- @param targets table
+--- @param options table
+function ActivatedAbilityHurlGrabbedBehavior:Cast(ability, casterToken, targets, options)
+    local symbols = options.symbols or {}
+
+    local candidates = self:FindGrabbedCandidates(casterToken)
+    if #candidates == 0 then
+        casterToken.properties:FloatLabel("Nothing to hurl", "red")
+        return
+    end
+
+    local hurled = candidates[1]
+    if #candidates > 1 then
+        hurled = ChooseHurledCreature(casterToken, candidates, symbols)
+        if hurled == nil then
+            return
+        end
+    end
+
+    local endLoc = FindLineEnd(casterToken, options.targetArea)
+    if endLoc == nil then
+        casterToken.properties:FloatLabel("Hurl needs a line target", "red")
+        return
+    end
+
+    local landing = FindLandingCandidates(casterToken, hurled, endLoc, self:try_get("searchRadius", 3))
+    if #landing == 0 then
+        casterToken.properties:FloatLabel("No room to land", "red")
+        return
+    end
+
+    local dest = landing[1]
+    if #landing > 1 then
+        dest = ChooseTransitDestination(hurled, landing, symbols, casterToken, {
+            name = "Hurl Landing Square",
+            prompt = self:try_get("promptText", ""),
+        })
+        if dest == nil then
+            return
+        end
+    end
+
+    local origLoc = hurled.loc
+
+    --The throw ends the grab. Purge only this caster's grab so another grabber keeps theirs.
+    hurled:ModifyProperties{
+        description = "Hurled",
+        execute = function()
+            hurled.properties:InflictCondition(g_hurlGrabbedConditionId, {
+                purge = true,
+                casterInfo = { tokenid = casterToken.charid },
+            })
+        end,
+    }
+
+    --Fly the creature down the line like a push: straight-line forced moves that
+    --pass over creatures, are not its own move action, and do not provoke. The
+    --grab was ended above, so the Grabbed condition's forcemove trigger (drag
+    --the grabber along) never fires. Not a rules forced move: no
+    --forcedMovementDistance, so a blocked path just stops with no collision
+    --damage. When the landing square is off the line's end, the throw still
+    --runs the whole line to its end square and then hops (jump animation)
+    --into the square the director chose.
+    local function WaitForGameUpdate()
+        local updateAt = dmhub.ngameupdate
+        local startTime = dmhub.Time()
+        while dmhub.ngameupdate <= updateAt and dmhub.Time() < startTime + 2 do
+            coroutine.yield(0.05)
+        end
+    end
+
+    local function ThrowMove(toLoc, movementType)
+        hurled.properties._tmp_freeMovement = true
+        local path = hurled:Move(toLoc.withGroundAltitude, {
+            straightline = true,
+            ignorecreatures = true,
+            moveThroughFriends = true,
+            maxCost = 30000,
+            movementType = movementType,
+            jumpHeight = 2,
+            ignoreFalling = (movementType == "jump"),
+            freeMovement = true,
+            forced = true,
+        })
+        hurled.properties._tmp_freeMovement = false
+        return path ~= nil
+    end
+
+    --The push always runs the full line, even onto a square another creature
+    --or object already holds (creatures are ignored, so the engine lets the
+    --thrown creature pass over and stop there); only then does it hop into
+    --the square the director chose. Skip the push if it already stands there.
+    local legs = {}
+    if hurled.loc.xyfloorOnly.str ~= endLoc.xyfloorOnly.str then
+        legs[#legs+1] = { loc = endLoc, movementType = "move" }
+    end
+    if dest.xyfloorOnly.str ~= endLoc.xyfloorOnly.str then
+        legs[#legs+1] = { loc = dest, movementType = "jump" }
+    end
+
+    local moved = true
+    for i, leg in ipairs(legs) do
+        if i > 1 then
+            WaitForGameUpdate()
+        end
+        moved = ThrowMove(leg.loc, leg.movementType)
+        if not moved then
+            break
+        end
+    end
+
+    --Fall back to a silent teleport if the engine refused a leg: the creature
+    --must still land somewhere.
+    if not moved then
+        print("HurlGrabbed:: MOVE REFUSED, teleporting instead. dest =", dest.str)
+        hurled.properties._tmp_suppressTeleportEvent = true
+        hurled:Teleport(dest.withGroundAltitude)
+        hurled.properties._tmp_suppressTeleportEvent = nil
+    end
+    hurled.properties:FloatLabel("Hurled!", "white")
+
+    --Let the move land before anything rolls against the creature.
+    WaitForGameUpdate()
+    if hurled.valid then
+        hurled:TryFall()
+    end
+
+    --Commit to the cost once the throw has actually happened, so a cancelled
+    --pick above never charges the maneuver. (Ending a grab mid-cast logs one
+    --engine "already in a transaction" line; the engine's own Grabbed teleport
+    --trigger does the same, and state stays correct.)
+    ability:CommitToPaying(casterToken, options)
+
+    if self:try_get("addAsTarget", true) and options.targets ~= nil and hurled.valid then
+        local present = false
+        for _, existing in ipairs(options.targets) do
+            if existing.token ~= nil and existing.token.charid == hurled.charid then
+                present = true
+                break
+            end
+        end
+        if not present then
+            options.targets[#options.targets+1] = { token = hurled, origLoc = origLoc }
+        end
+        if symbols.cast ~= nil then
+            symbols.cast.targets = options.targets
+        end
+    end
+end
+
+--- @param parentPanel Panel
+--- @return Panel[]
+function ActivatedAbilityHurlGrabbedBehavior:EditorItems(parentPanel)
+    local result = {}
+    self:ApplyToEditor(parentPanel, result)
+    self:FilterEditor(parentPanel, result)
+
+    result[#result+1] = gui.Panel{
+        classes = { "formPanel" },
+        gui.Label{ classes = { "formLabel" }, text = "Hurl Filter:" },
+        gui.GoblinScriptInput{
+            classes = { "formInput" },
+            value = self:try_get("hurlFilter", ""),
+            change = function(element)
+                self.hurlFilter = element.value
+            end,
+            documentation = {
+                help = "Which grabbed creatures may be hurled. Evaluated on each creature the caster is grabbing.",
+                output = "boolean",
+                subject = creature.helpSymbols,
+                subjectDescription = "A creature the caster is grabbing",
+                examples = {
+                    { script = "Size < 5", text = "Only Size 1 creatures can be hurled." },
+                },
+            },
+        },
+    }
+
+    result[#result+1] = gui.Panel{
+        classes = { "formPanel" },
+        gui.Label{ classes = { "formLabel" }, text = "Landing Search Radius:" },
+        gui.Input{
+            classes = { "formInput" },
+            text = tostring(self:try_get("searchRadius", 3)),
+            change = function(element)
+                self.searchRadius = tonumber(element.text) or 3
+                element.text = tostring(self.searchRadius)
+            end,
+        },
+    }
+
+    result[#result+1] = gui.Panel{
+        classes = { "formPanel" },
+        gui.Label{ classes = { "formLabel" }, text = "Prompt Text:" },
+        gui.Input{
+            classes = { "formInput" },
+            text = self:try_get("promptText", ""),
+            change = function(element)
+                self.promptText = element.text
+            end,
+        },
+    }
+
+    result[#result+1] = gui.Check{
+        text = "Add Hurled Creature To Targets",
+        value = self:try_get("addAsTarget", true),
+        change = function(element)
+            self.addAsTarget = element.value
+        end,
     }
 
     return result

--- a/Monster AI/MonsterAIPrompts.lua
+++ b/Monster AI/MonsterAIPrompts.lua
@@ -579,6 +579,39 @@ MonsterAI:RegisterPrompt{
     end,
 }
 
+--Hurl Grabbed Creature (Ogre Goon "People Bowling", AbilityRelocateAura.lua):
+--two picks. The creature pick carries its candidates in _tmp_hurlCandidates;
+--throw the first (the goon normally grabs only one creature anyway). The
+--landing pick carries the equally-near free squares in _tmp_restrictLocs;
+--any of them satisfies the rule, so take the first.
+MonsterAI:RegisterPrompt{
+    prompts = {"Hurl Grabbed Creature"},
+
+    handler = function(ai, invokerToken, casterToken, abilityClone, symbols, options)
+        local candidates = abilityClone:try_get("_tmp_hurlCandidates")
+        if candidates == nil or #candidates == 0 then
+            return nil
+        end
+        return {
+            targets = { {token = candidates[1]} }
+        }
+    end,
+}
+
+MonsterAI:RegisterPrompt{
+    prompts = {"Hurl Landing Square"},
+
+    handler = function(ai, invokerToken, casterToken, abilityClone, symbols, options)
+        local locs = abilityClone:try_get("_tmp_restrictLocs")
+        if locs == nil or #locs == 0 then
+            return nil
+        end
+        return {
+            targets = { {loc = locs[1]} }
+        }
+    end,
+}
+
 MonsterAI:RegisterPrompt{
     prompts = {"Decrepit Skeleton:Invoked Ability"},
 


### PR DESCRIPTION
Rebase of #322 by @rickdog4031 onto current `main`. The commit is unchanged in authorship and intent; this PR exists only because #322 had gone stale against `main` and could not be merged.

## Why this needs to land

The data half is **already merged**. `draw-steel-data` `2febbde3` ("Ogre Goon: People Bowling to Gold") is on `main`, so `monsters/ogre-goon.yaml` currently references:

- `__typeName: ActivatedAbilityHurlGrabbedBehavior` — registered only by this change
- `duration: endcast` on the outline aura — added only by this change

That commit also removed the old invoke chain it replaced, so until this merges People Bowling has no working implementation on either side.

## What #322 contained (unchanged here)

- **New behavior `hurl_grabbed` ("Hurl Grabbed Creature")** in `Draw Steel Ability Behaviors/AbilityRelocateAura.lua`: on a line-targeted ability it finds the creature the caster is grabbing (GoblinScript `hurlFilter`, default `Size < 5`), ends the grab, runs a push-style straight-line move to the line's end square, jumps to the nearest unoccupied square of the director's choice when the end is taken, and appends the hurled creature to the cast's targets so the following power roll hits it too.
- **Monster AI prompt handlers** (`Monster AI/MonsterAIPrompts.lua`) so AI-run goons can use the maneuver.
- **Aura duration "Until Ability Ends"** (`endcast`) in `DMHub Game Rules/Aura.lua` + the ability editor dropdown.
- **`ChooseTransitDestination` gains an optional `labels` argument** so non-portal callers get their own prompt and name.

## The rebase

Against the merge base both branches *appended* to the end of `AbilityRelocateAura.lua` — #322 added 398 lines, and `c014a104` ("Add Pull Into Caster Space and Displace Overlapping behaviors") added 512. Git reported 8 conflict hunks, but they are positional rather than semantic: the two feature blocks do not contradict each other. Resolved as shared prefix (carrying the `labels` edits) → `c014a104`'s block verbatim → this change's block.

The diff against `main` is purely additive apart from three intended lines in `ChooseTransitDestination` (its signature and the two hardcoded label strings). No line of `c014a104`'s code is modified or removed.

### One deduplication

#322's `LocIsFreeForHurl` and `main`'s `LocIsFreeForToken` are the same footprint-occupancy check written independently by both branches — identical modulo parameter names. The duplicate is dropped and its two callers repointed at `LocIsFreeForToken`, which is why the appended block is 375 lines rather than 398.

`FindLandingCandidates` and `NearestFreeLocs` are deliberately **not** merged despite looking similar: the former short-circuits when the line's end square is free and filters by line of sight from the thrower, the latter filters by pathability. Different rules.

## Side effect worth noting

`c014a104`'s `DisplaceOverlapping` already calls `ChooseTransitDestination` with a 5th `labels` table, but `main`'s signature only takes 4 parameters, so Lua silently drops it. On `main` today a displaced creature is therefore prompted `"Choose where you emerge"` under the heading `"Portal Transit"`. This change adds the parameter that call site was written against, so those labels start working.

## Verification

- `luac -p` clean on all four files (bundled Lua 5.4.7).
- Diff vs `main` confirmed additive; the appended block differs from #322's original by exactly the removed helper and its two call-site renames.
- Behavioural testing is inherited from #322 and was performed by @rickdog4031 in the dev game (end square free; end square occupied by up to three creatures; outline aura present during the cast and cleared afterwards). **Not re-run here** — this PR changes no logic beyond the deduplication above, but a re-test before merge would be sensible given the file moved underneath it.

Known and pre-existing, from #322: ending a grab mid-cast logs one engine `Tried to BeginTransaction() on a document that is already in a transaction` line; the engine's own Grabbed teleport trigger does the same and state is correct.

## Minor, not changed here

Both `DisplaceOverlapping` and the new hurl behavior pass `self:try_get("promptText", "")` into `labels.prompt`, and the fallback is written `labels.prompt or "..."`. Empty string is truthy in Lua, so a director who explicitly blanks `promptText` in the editor gets an empty prompt rather than the default. Class-level defaults mean this does not occur otherwise. Left alone as a UX call rather than a rebase decision.

Closes #322.
