### PR TITLE
feat(targeting): tri-state IsFriendForTargeting with a neutral ally state

### DIFF
--- a/DMHub Game Rules/AbilityInvokeAbility.lua
+++ b/DMHub Game Rules/AbilityInvokeAbility.lua
@@ -260,7 +260,8 @@ local function CollectMovementConstraintCandidates(behavior, anchorType, casterT
     for _,candidate in ipairs(dmhub.allTokens) do
         local include = MovementConstraintCandidateIsLiving(candidate, movedToken)
         if include and anchorType == "nearest_enemy" then
-            include = not IsFriendForTargeting(casterToken, candidate)
+            --strict == false: tri-state IsFriendForTargeting, nil (neutral) is not an enemy.
+            include = IsFriendForTargeting(casterToken, candidate) == false
         end
         if include and maxDistance ~= nil and movedToken:Distance(candidate) > maxDistance then
             include = false

--- a/DMHub Game Rules/ActivatedAbility.lua
+++ b/DMHub Game Rules/ActivatedAbility.lua
@@ -1544,11 +1544,13 @@ function ActivatedAbility:TargetPassesFilter(casterToken, targetToken, symbols, 
             return false
         end
 
-        if self.targetAllegiance == 'enemy' and IsFriendForTargeting(casterToken, targetToken) and (not isAnyObject) then
+        --IsFriendForTargeting is tri-state (true friend / false enemy / nil neither):
+        --a neutralized ally passes neither allegiance gate, so both compare strictly.
+        if self.targetAllegiance == 'enemy' and IsFriendForTargeting(casterToken, targetToken) ~= false and (not isAnyObject) then
             return false
         end
 
-        if self.targetAllegiance == 'ally' and (not IsFriendForTargeting(casterToken, targetToken)) and (not isAnyObject) then
+        if self.targetAllegiance == 'ally' and IsFriendForTargeting(casterToken, targetToken) ~= true and (not isAnyObject) then
             return false
         end
     end
@@ -1573,7 +1575,9 @@ function ActivatedAbility:TargetPassesFilter(casterToken, targetToken, symbols, 
     symbols = table.shallow_copy(symbols or {})
     symbols.invoker = symbols.invoker or caster
     symbols.caster = caster
-    symbols.enemy = not IsFriendForTargeting(casterToken, targetToken)
+    --strict == false: tri-state IsFriendForTargeting returns nil for a neutralized
+    --ally, which is not an enemy.
+    symbols.enemy = IsFriendForTargeting(casterToken, targetToken) == false
 	symbols.target = GenerateSymbols(targetToken.properties)
 
 	local result = filter == "" or GoblinScriptTrue(ExecuteGoblinScript(filter, targetToken.properties:LookupSymbol(symbols), 0, string.format("Target filter for %s", self.name)))
@@ -1614,7 +1618,8 @@ function ActivatedAbility:TargetPassesAuthoredFilters(casterToken, targetToken, 
 	symbols = table.shallow_copy(symbols or {})
 	symbols.invoker = symbols.invoker or caster
 	symbols.caster = caster
-	symbols.enemy = not IsFriendForTargeting(casterToken, targetToken)
+	--strict == false: tri-state IsFriendForTargeting, nil (neutral) is not an enemy.
+	symbols.enemy = IsFriendForTargeting(casterToken, targetToken) == false
 	symbols.target = GenerateSymbols(targetToken.properties)
 
 	for _,customFilter in ipairs(customFilters) do

--- a/DMHub Game Rules/Creature.lua
+++ b/DMHub Game Rules/Creature.lua
@@ -6701,7 +6701,7 @@ function creature:OnMove(path)
         -- space counts too. Deal Might damage to the first such enemy, once per turn.
         if reapingActive and not rawget(self, "_tmp_reapingScytheDealt") then
             for k,tok in pairs(adjacentTokens) do
-                if (not previousAdjacent[k]) and tok.loc ~= nil and (not IsFriendForTargeting(ourToken, tok)) then
+                if (not previousAdjacent[k]) and tok.loc ~= nil and IsFriendForTargeting(ourToken, tok) == false then
                     tok.properties:InflictDamageInstance(reapDamage, "", {}, "Reaping Scythe", { attacker = self })
                     self._tmp_reapingScytheDealt = true
                     break
@@ -7566,13 +7566,18 @@ function creature:GetCustomAttribute(attrInfo)
 	return result
 end
 
--- Returns whether casterToken treats targetToken as a friend for TARGETING purposes.
--- Mirrors casterToken:IsFriend, except a creature with the "Count Allies as Enemies"
--- attribute treats allies within N squares (N = attribute value) as enemies, and a
--- creature with the "Count As Ally To Enemies" attribute forces everyone (even actual
--- enemies) to treat it as a friend. The target-side "cannot be treated as enemy" check
--- runs first and wins over both the base relationship and the caster-side attribute,
--- since it represents an effect the target is actively using to protect itself.
+-- TRI-STATE: how casterToken views targetToken for TARGETING purposes.
+--   true  = a friend (valid ally target)
+--   false = an enemy (valid enemy target)
+--   nil   = NEITHER -- not targetable as an ally, but not an enemy either
+-- Callers must treat "enemy" as a strict == false check and "friend" as a strict
+-- == true check; `not result` wrongly reads neutral (nil) as an enemy.
+-- Mirrors casterToken:IsFriend, with three attribute-driven overrides: the target-side
+-- "Count As Ally To Enemies" (Guise) forces friend and runs first since the target is
+-- actively protecting itself; caster-side "Count Allies as Enemies" makes allies within
+-- N squares read as enemies; caster-side "Count Allies as Neutral" (Memory Thief tier 1)
+-- makes allies within N squares read as neither. Enemies wins over Neutral when a
+-- creature somehow carries both.
 function IsFriendForTargeting(casterToken, targetToken)
     if casterToken == nil or targetToken == nil then
         return false
@@ -7590,7 +7595,7 @@ function IsFriendForTargeting(casterToken, targetToken)
         return false
     end
 
-    -- Never treat self as an enemy.
+    -- Never treat self as an enemy or as neutral.
     if casterToken.properties == targetToken.properties then
         return true
     end
@@ -7604,7 +7609,35 @@ function IsFriendForTargeting(casterToken, targetToken)
         end
     end
 
+    if IsNeutralizedAlly(casterToken, targetToken) then
+        return nil -- an ally, but not treatable as one: neither friend nor enemy
+    end
+
     return true
+end
+
+-- True when casterToken's "Count Allies as Neutral" attribute (Memory Thief tier 1)
+-- covers targetToken: within N squares (N = attribute value), casterToken cannot treat
+-- targetToken as an ally -- but targetToken does not become an enemy either. Self is
+-- never neutralized. IsFriendForTargeting returns nil off this. Targeting only for
+-- now: trigger eligibility, flanking, and auras stay on raw IsFriend by design.
+function IsNeutralizedAlly(casterToken, targetToken)
+    if casterToken == nil or targetToken == nil
+            or casterToken.properties == nil or targetToken.properties == nil
+            or casterToken.properties == targetToken.properties then
+        return false
+    end
+
+    local n = casterToken.properties:CalculateNamedCustomAttribute("Count Allies as Neutral")
+    if n ~= nil and n > 0 then
+        local casterLoc = casterToken.loc
+        local targetLoc = targetToken.loc
+        if casterLoc ~= nil and targetLoc ~= nil and casterLoc:DistanceInTiles(targetLoc) <= n then
+            return true
+        end
+    end
+
+    return false
 end
 
 --Derived states like "winded" that aren't conditions, but which we still want to be
@@ -7625,12 +7658,14 @@ function creature:MatchesString(viewingToken, token, str)
     str = string.lower(tostring(str))
 
     if viewingToken ~= nil then
+        --IsFriendForTargeting is tri-state (nil = neither): a neutralized ally
+        --matches neither "enemy" nor "ally", so both use strict comparisons.
         if str == "enemy" then
-            return not IsFriendForTargeting(viewingToken, token)
+            return IsFriendForTargeting(viewingToken, token) == false
         end
 
         if str == "ally" or str == "friend" then
-            return IsFriendForTargeting(viewingToken, token)
+            return IsFriendForTargeting(viewingToken, token) == true
         end
     end
 


### PR DESCRIPTION
## Summary
Implements Deni's design for Memory Thief tier 1 ("the target can't treat their allies as allies"): `IsFriendForTargeting` becomes tri-state - `true` = friend, `false` = enemy, `nil` = neither. A new caster-side custom attribute, **Count Allies as Neutral** (data repo), makes allies within N squares read as `nil`; its only setter is the Memory Thief (Weak) ongoing effect in the Condemned adventure.

## Changes
- `Creature.lua` - `IsFriendForTargeting` returns `nil` for neutralized allies via a new `IsNeutralizedAlly` helper (self never neutralized; Count Allies as Enemies wins if both attributes are present). `MatchesString` `"ally"`/`"enemy"` and the Reaping Scythe adjacency check use strict comparisons.
- `ActivatedAbility.lua` - `targetAllegiance` gates compare strictly (`~= true` / `~= false`); both `symbols.enemy` injections are `== false`.
- `AbilityInvokeAbility.lua` - nearest-enemy movement-constraint anchor is `== false`.

All 8 call sites of the function are converted; behavior is identical to before for every `true`/`false` result - only `nil` is newly defined, and a neutral creature passes neither allegiance gate.

## Scope (deliberate)
Targeting only, per the design conversation: trigger eligibility (TriggeredAbility subject dispatch, PowerTableTriggers), flanking, and aura audiences stay on raw `IsFriend` - those files are untouched. Known consequence: reactive ally triggers (e.g. Word of Guidance) still offer on a neutralized ally until the follow-up conversation lands.

## Testing
Live-tested by James with the Memory Thief tier 1 effect: Healing Grace can't target the afflicted's allies; their strikes still can't target allies (they don't become enemies); everything is unchanged for creatures without the attribute.

## Notes for reviewer
- The diff looks large because the upstream blobs have mixed line endings and the rewrite normalizes them; the real change is ~58 lines - use "Hide whitespace changes".
- Suggestion (not included): inject `symbols.ally = (IsFriendForTargeting(...) == true)` beside `symbols.enemy` in `TargetPassesFilter`, so content formulas can say "strictly an ally" now that `not enemy` includes neutrals. Happy to add here or in a follow-up.
- While testing we found the Words of Wrath and Grace recovery step offered enemies - a pre-existing content bug (`targetFilter: enemy` on the invoked standard ability since the initial data import), fixed in the data repo, unrelated to this change.
- Requires a codex reload. Companion PRs: the attribute (data repo) and the Memory Thief tier 1 content (condemned repo) reference this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)