### PR TITLE
Shambling Mound: restore engine behaviors + Engulf/Leech fixes

### DIFF
--- a/DMHub Game Hud/GameHud.lua
+++ b/DMHub Game Hud/GameHud.lua
@@ -754,6 +754,16 @@ function GameHud.LootContainer(self, token, object)
 		return
 	end
 
+	--Harvest-gated loot (e.g. the Shambling Mound's Alchemical Ingredients):
+	--the first attempt to loot prompts the looter with a characteristic test;
+	--the tier rolled decides what the container holds. Later loots go straight
+	--to the container.
+	local harvest = lootobj.properties:try_get("harvestTest")
+	if harvest ~= nil and not harvest.resolved then
+		self:RunHarvestTest(token, lootobj, object)
+		return
+	end
+
 	if lootobj.instantLoot then
 		GameHud.LootAll(lootobj, token)
 		if lootobj.destroyOnEmpty then
@@ -764,7 +774,120 @@ function GameHud.LootContainer(self, token, object)
 
 	self.inventoryDialog.data.open(token, {})
 	self.tradeInventoryDialog.data.open(lootobj, { isobject = true, isshop = lootobj.shop, title = cond(lootobj.shop, 'Shop', lootobj.objectInstance.description), tradewith = token })
-	
+
+end
+
+--Prompt the looting player with the harvest test stored on a loot container,
+--then stock the container based on the tier rolled and open it. Runs on the
+--looting player's client (LootContainer is invoked there by the engine).
+function GameHud.RunHarvestTest(self, token, lootobj, object)
+	local harvest = lootobj.properties:try_get("harvestTest")
+	if harvest == nil then
+		return
+	end
+
+	--Capture the object's id up front. The roll below yields for several
+	--seconds while the dice resolve, and across those yields the loot component
+	--(and its live object) can re-sync from the cloud, leaving our captured
+	--`lootobj` a stale reference whose mutations never upload. After the roll we
+	--re-fetch the live object by id and stock THAT. See GetObject below.
+	local objid = object ~= nil and object.id or nil
+	local floorid = token.floorid
+
+	dmhub.Coroutine(function()
+		--Wrap each tier outcome in a {#...} spoiler. The power-table roll dialog
+		--hides spoiler content from players before the dice land and reveals the
+		--achieved tier when the roll finishes (see finishRoll's {#->{! swap in
+		--MCDMAbilityRollBehavior), so the looter can't see the yield in advance.
+		local tierDescriptions = {}
+		for i,text in ipairs(harvest.tiers or {}) do
+			if harvest.spoilers ~= false and trim(text) ~= "" then
+				tierDescriptions[i] = string.format("{#%s}", text)
+			else
+				tierDescriptions[i] = text
+			end
+		end
+
+		--include the characteristic in the check text so the dialog heading
+		--reads e.g. "Alchemical Ingredients Reason test for Talent".
+		local attrid = harvest.attrid or "rea"
+		local attrInfo = creature.attributesInfo[attrid]
+		local attrName = (attrInfo ~= nil and attrInfo.description) or attrid
+
+		local check = RollCheck.new{
+			type = "test_power_roll",
+			id = attrid,
+			text = string.format("%s %s", harvest.title or "Harvest", attrName),
+			options = {
+				tiers = tierDescriptions,
+			},
+		}
+
+		--forceuserid: prompt the user who clicked the container, on this client.
+		--Without it the roll listener defers player-controlled tokens to their
+		--owning player's client, which never prompts when the DM (or another
+		--controller) is the one looting.
+		local actionid = dmhub.SendActionRequest(RollRequest.new{
+			title = harvest.title or "Harvest",
+			checks = { check },
+			tokens = { [token.charid] = { forceuserid = dmhub.loginUserid } },
+		})
+
+		local rollResult = {}
+		AwaitRequestedActionCoroutine(actionid, rollResult)
+		while rollResult.result == nil do
+			coroutine.yield(0.1)
+		end
+
+		if rollResult.result == false then
+			--the roll was declined or canceled; the container stays unharvested.
+			return
+		end
+
+		local tokenInfo = rollResult.action.info.tokens[token.charid]
+		local total = tokenInfo ~= nil and tokenInfo.result or nil
+		if total == nil then
+			return
+		end
+
+		local tier = RollUtils.DiceResultToTier{ total = total }
+
+		--Re-fetch the live loot component now that the roll is done -- the
+		--reference captured before the yields may be stale.
+		local liveLoot = lootobj
+		if objid ~= nil then
+			local floor = game.GetFloor(floorid)
+			if floor ~= nil then
+				local liveObj = floor:GetObject(objid)
+				if liveObj ~= nil then
+					local c = liveObj:GetComponent("Loot")
+					if c ~= nil then
+						liveLoot = c
+					end
+				end
+			end
+		end
+
+		local liveHarvest = liveLoot.properties:try_get("harvestTest") or harvest
+
+		liveLoot:BeginChanges()
+		for _,entry in ipairs(liveHarvest.items or harvest.items or {}) do
+			local quantities = entry.quantities or {}
+			local quantity = quantities[tier] or 0
+			if quantity > 0 then
+				liveLoot.properties:SetItemQuantity(entry.itemid, quantity)
+			end
+		end
+		if liveLoot.properties:try_get("harvestTest") ~= nil then
+			liveLoot.properties.harvestTest.resolved = true
+			liveLoot.properties.harvestTest.tier = tier
+		end
+		liveLoot:CompleteChanges("Harvest")
+
+		--open the container so the looter sees what they extracted (possibly nothing).
+		self.inventoryDialog.data.open(token, {})
+		self.tradeInventoryDialog.data.open(liveLoot, { isobject = true, title = harvest.title or liveLoot.objectInstance.description, tradewith = token })
+	end)
 end
 
 setting{

--- a/DMHub Game Rules/AbilityRelocateCreature.lua
+++ b/DMHub Game Rules/AbilityRelocateCreature.lua
@@ -391,6 +391,27 @@ function ActivatedAbilityRelocateCreatureBehavior:Cast(ability, casterToken, tar
             movementType = "move"
         end
 
+        --Object tokens are synthetic wrappers around map LevelObjects and are not
+        --in the engine's token movement dictionary: Move()/Teleport() cannot
+        --relocate them (Teleport throws, Move returns no path). Move the
+        --underlying object directly instead, preserving its intra-tile offset.
+        --This is what lets forced movement of Targetable objects (e.g. the
+        --Ghost's Paranormal Activity vertical slide) actually move the object.
+        if casterToken.isObject then
+            local inst = casterToken.objectInstance
+            local destLoc = targets[#targets].loc or targets[1].loc
+            if inst ~= nil and destLoc ~= nil then
+                local curLoc = casterToken.loc
+                local dist = casterToken:Distance(destLoc)
+                inst:SetAndUploadPos(inst.x + (destLoc.x - curLoc.x), inst.y + (destLoc.y - curLoc.y))
+                if dist > 0 then
+                    options.symbols.cast.spacesMoved = options.symbols.cast.spacesMoved + dist
+                end
+            end
+            casterToken.properties._tmp_freeMovement = false
+            return
+        end
+
         -- Charge-jump override (e.g., Panther's Mighty Spring): a creature with
         -- the "Charge Uses Jump" custom attribute leaps instead of running when
         -- the Charge action's relocate runs. We identify Charge by ability name
@@ -762,8 +783,14 @@ function ActivatedAbilityRelocateCreatureBehavior:Cast(ability, casterToken, tar
 				options.symbols.cast.spacesMoved = options.symbols.cast.spacesMoved + path.numSteps
 			end
 
+			--noCollisionDamage: set on forced-movement clones built from a
+			--"without damage" rule (e.g. Engulf dragging a creature into the
+			--Shambling Mound's sack). The movement itself plays normally but no
+			--collide events fire for the moved creature, bystanders, or objects.
+			local noCollisionDamage = ability:try_get("noCollisionDamage", false)
+
 			--when moving through creatures, trigger collision on each creature in the path.
-			if throughCreatures and path ~= nil and path.steps ~= nil then
+			if throughCreatures and path ~= nil and path.steps ~= nil and (not noCollisionDamage) then
 				local forcedMovementType = ability:try_get("forcedMovement", "slide")
 				local hitCreatures = {}
 				for _,step in ipairs(path.steps) do
@@ -825,7 +852,11 @@ function ActivatedAbilityRelocateCreatureBehavior:Cast(ability, casterToken, tar
                 -- Keep the terminal post-passthrough creature collision on the
                 -- cast so later behaviors can identify every participant.
                 options.symbols.cast:RecordForcedMovementCreatureCollision(casterToken, collisionInfo.collideWith)
+        end
 
+        --noCollisionDamage: no collide events or collision damage for anyone
+        --involved (a "without damage" forced-movement rule, e.g. Engulf).
+		if collisionInfo ~= nil and (not noCollisionDamage) then
                 local forcedMovementType = ability:try_get("forcedMovement", "slide")
                 local withobject = #(collisionInfo.collideWith or {}) == 0
 
@@ -918,7 +949,7 @@ function ActivatedAbilityRelocateCreatureBehavior:Cast(ability, casterToken, tar
 			end
 
 			--handle collisions from rebound bounces.
-			if path ~= nil and path.bounceCollisions ~= nil then
+			if path ~= nil and path.bounceCollisions ~= nil and (not noCollisionDamage) then
 				local forcedMovementType = ability:try_get("forcedMovement", "slide")
 				for _,collision in ipairs(path.bounceCollisions) do
 					local collideWith = collision.collideWith or {}

--- a/DMHub Game Rules/AbilityRemoveCreature.lua
+++ b/DMHub Game Rules/AbilityRemoveCreature.lua
@@ -565,3 +565,97 @@ function CorpseComponent:DeadCreatureToken()
     print("Dead::", self.charid, result)
     return result
 end
+
+--- @class ActivatedAbilityHarvestCorpseBehavior:ActivatedAbilityBehavior
+--- Spawns a lootable corpse object at the caster's position whose loot is
+--- gated behind a characteristic test ("harvest"). The corpse's LOOT component
+--- carries a harvestTest record; when a player tries to loot it, the loot flow
+--- (GameHud.LootContainer) prompts them with the test and stocks the container
+--- according to the tier rolled. Built for traits like the Shambling Mound's
+--- Alchemical Ingredients: "After a shambling mound dies, a creature can make
+--- a Reason test to extract toxins from the remains."
+ActivatedAbilityHarvestCorpseBehavior = RegisterGameType("ActivatedAbilityHarvestCorpseBehavior", "ActivatedAbilityBehavior")
+
+ActivatedAbilityHarvestCorpseBehavior.summary = 'Harvest Corpse'
+ActivatedAbilityHarvestCorpseBehavior.title = "Harvest"
+ActivatedAbilityHarvestCorpseBehavior.attrid = "rea"
+--display text for the three tiers of the test, shown in the roll prompt.
+ActivatedAbilityHarvestCorpseBehavior.tiers = {"", "", ""}
+--items granted per tier: list of { itemid = string, quantities = {tier1, tier2, tier3} }
+ActivatedAbilityHarvestCorpseBehavior.items = {}
+
+ActivatedAbility.RegisterType
+{
+	id = 'harvest_corpse',
+	text = 'Harvest Corpse',
+	createBehavior = function()
+		return ActivatedAbilityHarvestCorpseBehavior.new{
+		}
+	end
+}
+
+function ActivatedAbilityHarvestCorpseBehavior:SummarizeBehavior(ability, creatureLookup)
+	return string.format("Leave a corpse harvestable with a %s test", string.upper(self.attrid))
+end
+
+function ActivatedAbilityHarvestCorpseBehavior:Cast(ability, casterToken, targets, options)
+	if casterToken == nil or not casterToken.valid or casterToken.properties == nil then
+		return
+	end
+
+	--only ever leave one harvest corpse per creature.
+	if casterToken.properties:try_get("harvestCorpseSpawned") then
+		return
+	end
+
+	local objects = assets:GetObjectsWithKeyword("corpse")
+	if #objects == 0 then
+		return
+	end
+
+	local floor = game.GetFloor(casterToken.floorid)
+	if floor == nil then
+		return
+	end
+
+	local newObj = floor:CreateLocalObjectFromBlueprint{
+		assetid = objects[1].id,
+	}
+	if newObj == nil then
+		return
+	end
+
+	newObj.scale = newObj.scale * casterToken.radiusInTiles * 2
+	newObj.x = casterToken.pos.x
+	newObj.y = casterToken.pos.y
+
+	newObj:AddComponentFromJson("LOOT", {
+		["@class"] = "ObjectComponentLoot",
+		destroyOnEmpty = false,
+		instantLoot = false,
+		locked = false,
+		properties = {
+			__typeName = "loot",
+			inventory = {},
+			harvestTest = {
+				title = self.title,
+				attrid = self.attrid,
+				tiers = DeepCopy(self.tiers),
+				items = DeepCopy(self.items),
+			},
+		},
+	})
+
+	newObj:AddComponentFromJson("MESSAGE", {
+		["@class"] = "ObjectComponentHoverText",
+		text = string.format("%s: the remains of %s can be harvested", self.title, creature.GetTokenDescription(casterToken)),
+	})
+
+	casterToken:ModifyProperties{
+		description = "Harvest corpse spawned",
+		undoable = false,
+		execute = function()
+			casterToken.properties.harvestCorpseSpawned = true
+		end,
+	}
+end

--- a/DMHub Game Rules/Creature.lua
+++ b/DMHub Game Rules/Creature.lua
@@ -1916,6 +1916,11 @@ function creature.SetTemporaryHitpoints(self, amount, note, options)
 	end
 
 	if amount <= 0 and self:has_key("temporary_hitpoints_effect") and self:try_get("tempHitpointsEndEffect", true) then
+		--Announce the depletion BEFORE removing the tied effect so trigger
+		--modifiers riding that effect can still react (e.g. the Shambling
+		--Mound's Engulfed effect prompting the freed creature to relocate
+		--out of the mound's space when the sack is destroyed).
+		self:DispatchEvent("tempstaminadepleted", { ongoingeffectid = self.temporary_hitpoints_effect })
 		self:RemoveOngoingEffect(self.temporary_hitpoints_effect)
 		options.temporary_hitpoints_effect = nil
 	end

--- a/DMHub Game Rules/OngoingEffect.lua
+++ b/DMHub Game Rules/OngoingEffect.lua
@@ -14,6 +14,10 @@ CharacterOngoingEffect.endingEffectSavingThrowDC = 10
 CharacterOngoingEffect.sustainFormula = '' --a formula used to see if this effect keeps going.
 CharacterOngoingEffect.emoji = 'none'
 CharacterOngoingEffect.condition = 'none' --the underlying condition for this effect.
+--when true, an effect with an underlying condition still shows its OWN name/icon
+--on tokens and status displays instead of the condition's (e.g. "Engulfed" rather
+--than "Restrained"). The condition's mechanics are unaffected.
+CharacterOngoingEffect.displayOwnIdentity = false
 CharacterOngoingEffect.statusEffect = true --is this a standard status condition?
 CharacterOngoingEffect.hiddenOnToken = false
 CharacterOngoingEffect.hiddenFromEnemies = false --is this hidden from enemies?
@@ -149,7 +153,7 @@ function CharacterOngoingEffect:GetCondition()
 end
 
 function CharacterOngoingEffect:GetDisplayIcon()
-	if self.condition ~= "none" then
+	if self.condition ~= "none" and not self.displayOwnIdentity then
 		local cond = self:GetCondition()
 		if cond ~= nil then
 			return cond.iconid
@@ -159,7 +163,7 @@ function CharacterOngoingEffect:GetDisplayIcon()
 end
 
 function CharacterOngoingEffect:GetDisplayDisplay()
-	if self.condition ~= "none" then
+	if self.condition ~= "none" and not self.displayOwnIdentity then
 		local cond = self:GetCondition()
 		if cond ~= nil then
 			return cond.display

--- a/DMHub Token UI/TokenUI.lua
+++ b/DMHub Token UI/TokenUI.lua
@@ -326,6 +326,12 @@ local CalculateStatusIcons = function(token)
 				if ongoingEffectInfo ~= nil and ongoingEffectInfo.statusEffect and (not ongoingEffectInfo.hiddenOnToken) and ((not ongoingEffectInfo.hiddenFromEnemies) or token.isFriendOfPlayer or token.canControl or (dmhub.isDM and dmhub.tokenVision == nil and dmhub.tokensLoggedInAs == nil)) then
 					local casterInfo = cond:try_get("casterInfo")
 					local condInfo = conditionsTable[ongoingEffectInfo.condition]
+					if ongoingEffectInfo.displayOwnIdentity then
+						--effects flagged displayOwnIdentity present as themselves on the
+						--token (name/icon/hover) even though the underlying condition's
+						--mechanics still apply (e.g. "Engulfed" rather than "Restrained").
+						condInfo = nil
+					end
                     if condInfo ~= nil then
                         statusText = condInfo.name
                     end

--- a/Draw Steel Ability Behaviors/AbilityDamage.lua
+++ b/Draw Steel Ability Behaviors/AbilityDamage.lua
@@ -494,3 +494,235 @@ function ActivatedAbilityDamageChatMessage:GetTargetTokens()
     end
     return result
 end
+
+
+--- @class ActivatedAbilityLeechDamageBehavior:ActivatedAbilityBehavior
+--- Deals automatic (no power roll, no save) damage to its targets and then
+--- restores that same amount of Stamina to the aura's caster. Built for effects
+--- like the Shambling Mound's Leeching Wilds: "any enemy who starts their turn
+--- in the area takes N damage, and the shambling mound regains an equal amount
+--- of Stamina." The Stamina regained equals the damage actually taken after the
+--- target's damage immunities and weaknesses are applied, since it is read from
+--- the value InflictDamageInstance reports back.
+ActivatedAbilityLeechDamageBehavior = RegisterGameType("ActivatedAbilityLeechDamageBehavior", "ActivatedAbilityBehavior")
+
+ActivatedAbilityLeechDamageBehavior.summary = 'Leech Damage'
+ActivatedAbilityLeechDamageBehavior.roll = "4"
+ActivatedAbilityLeechDamageBehavior.damageType = "acid"
+
+ActivatedAbility.RegisterType
+{
+	id = 'leech_damage',
+	text = 'Leech Damage',
+	createBehavior = function()
+		return ActivatedAbilityLeechDamageBehavior.new{
+			roll = "4",
+			damageType = "acid",
+		}
+	end
+}
+
+function ActivatedAbilityLeechDamageBehavior:SummarizeBehavior(ability, creatureLookup)
+	return string.format("%s %s Damage; aura caster regains that Stamina",
+		dmhub.NormalizeRoll(dmhub.EvalGoblinScript(self.roll, creatureLookup, string.format("Leech damage for %s", ability.name))),
+		self.damageType)
+end
+
+--Resolve the creature that should regain Stamina: the aura's caster (the
+--creature the aura belongs to). On aura-modifier triggers the aura installs a
+--"caster" symbol pointing at its owner and an "aura" symbol holding the
+--AuraInstance (which carries its casterid). Prefer the symbol, fall back to the
+--aura's casterid, and return nil outside of an aura context so the behavior
+--simply deals damage with no heal.
+function ActivatedAbilityLeechDamageBehavior:ResolveLeechToken(options)
+	local symbols = options.symbols or {}
+
+	local casterSym = symbols.caster
+	if type(casterSym) == "function" then
+		casterSym = casterSym("self")
+	end
+	if casterSym ~= nil then
+		local tok = dmhub.LookupToken(casterSym)
+		if tok ~= nil and tok.valid then
+			return tok
+		end
+	end
+
+	local aura = symbols.aura
+	if aura ~= nil then
+		local casterid = nil
+		pcall(function() casterid = aura.casterid end)
+		if casterid ~= nil then
+			local tok = dmhub.GetTokenById(casterid)
+			if tok ~= nil and tok.valid then
+				return tok
+			end
+		end
+	end
+
+	return nil
+end
+
+function ActivatedAbilityLeechDamageBehavior:Cast(ability, casterToken, targets, options)
+	if #targets == 0 then
+		return
+	end
+
+	ability:CommitToPaying(casterToken, options)
+
+	local leechToken = self:ResolveLeechToken(options)
+
+	local damageType = self.damageType
+	local sourceDescription = ability.name
+
+	local totalDealt = 0
+
+	for _,target in ipairs(targets) do
+		if target.token ~= nil and target.token.valid and target.token.properties ~= nil then
+			local targetCreature = target.token.properties
+			local amount = dmhub.EvalGoblinScript(self.roll, casterToken.properties:LookupSymbol(options.symbols or {}), string.format("Leech damage for %s", ability.name))
+			amount = tonumber(amount) or 0
+			if amount > 0 then
+				target.token:ModifyProperties{
+					description = sourceDescription,
+					execute = function()
+						--No attacker is passed: this is automatic aura damage, mirroring
+						--creature:AuraDamage. damageDealt is the amount that landed after
+						--the target's immunities and weaknesses.
+						local res = targetCreature:InflictDamageInstance(amount, damageType, {}, sourceDescription, { damagesound = "Attack.Enviro" })
+						if type(res) == "table" and type(res.damageDealt) == "number" then
+							totalDealt = totalDealt + res.damageDealt
+						end
+					end,
+				}
+			end
+		end
+	end
+
+	if leechToken ~= nil and totalDealt > 0 then
+		local canHeal = (leechToken.properties:CalculateNamedCustomAttribute("Cannot Regain Stamina") == 0)
+		leechToken:ModifyProperties{
+			description = string.format("%s: Regain Stamina", ability.name),
+			execute = function()
+				leechToken.properties:Heal(totalDealt, sourceDescription)
+			end,
+		}
+		if canHeal then
+			leechToken.properties:FloatLabel(string.format("+%d Stamina", totalDealt), "#66ff66")
+		end
+	end
+end
+
+function ActivatedAbilityLeechDamageBehavior:EditorItems(parentPanel)
+	local result = {}
+	self:ApplyToEditor(parentPanel, result)
+	self:FilterEditor(parentPanel, result)
+	self:RollEditor(parentPanel, result)
+	self:DamageTypeEditor(parentPanel, result)
+	return result
+end
+
+--- @class ActivatedAbilityLeechTempStaminaBehavior:ActivatedAbilityBehavior
+--- Deals automatic damage to its targets and grants the caster a fixed amount
+--- of temporary Stamina for each target who actually took damage. Built for
+--- effects like the Shambling Mound's Leech maneuver: "Each creature engulfed
+--- by the shambling mound takes 5 poison damage. The shambling mound gains 5
+--- temporary Stamina for each creature who takes damage this way."
+--- The damage defaults to cannotBeReduced + bypassTempStamina because such
+--- effects usually originate "inside" a temporary-Stamina shield (the sack) and
+--- must hit the creature's real Stamina rather than the shield.
+ActivatedAbilityLeechTempStaminaBehavior = RegisterGameType("ActivatedAbilityLeechTempStaminaBehavior", "ActivatedAbilityBehavior")
+
+ActivatedAbilityLeechTempStaminaBehavior.summary = 'Leech Temporary Stamina'
+ActivatedAbilityLeechTempStaminaBehavior.roll = "5"
+ActivatedAbilityLeechTempStaminaBehavior.damageType = "poison"
+ActivatedAbilityLeechTempStaminaBehavior.tempPerTarget = "5"
+ActivatedAbilityLeechTempStaminaBehavior.cannotBeReduced = true
+ActivatedAbilityLeechTempStaminaBehavior.bypassTempStamina = true
+
+ActivatedAbility.RegisterType
+{
+	id = 'leech_temp_stamina',
+	text = 'Leech Temporary Stamina',
+	createBehavior = function()
+		return ActivatedAbilityLeechTempStaminaBehavior.new{
+			roll = "5",
+			damageType = "poison",
+			tempPerTarget = "5",
+		}
+	end
+}
+
+function ActivatedAbilityLeechTempStaminaBehavior:SummarizeBehavior(ability, creatureLookup)
+	return string.format("%s %s Damage; caster gains %s temporary Stamina per damaged target",
+		dmhub.NormalizeRoll(dmhub.EvalGoblinScript(self.roll, creatureLookup, string.format("Leech damage for %s", ability.name))),
+		self.damageType,
+		tostring(self.tempPerTarget))
+end
+
+function ActivatedAbilityLeechTempStaminaBehavior:Cast(ability, casterToken, targets, options)
+	if #targets == 0 then
+		return
+	end
+
+	ability:CommitToPaying(casterToken, options)
+
+	local damageType = self.damageType
+	local sourceDescription = ability.name
+	local cannotBeReduced = self:try_get("cannotBeReduced", true)
+	local bypassTempStamina = self:try_get("bypassTempStamina", true)
+
+	local numDamaged = 0
+
+	for _,target in ipairs(targets) do
+		if target.token ~= nil and target.token.valid and target.token.properties ~= nil then
+			local targetCreature = target.token.properties
+			local amount = dmhub.EvalGoblinScript(self.roll, casterToken.properties:LookupSymbol(options.symbols or {}), string.format("Leech damage for %s", ability.name))
+			amount = tonumber(amount) or 0
+			if amount > 0 then
+				ability.RecordTokenMessage(target.token, options, string.format("%d %s damage", amount, damageType))
+				target.token:ModifyProperties{
+					description = sourceDescription,
+					execute = function()
+						local res = targetCreature:InflictDamageInstance(amount, damageType, {}, sourceDescription, {
+							attacker = casterToken.properties,
+							ability = ability,
+							hasability = true,
+							cannotBeReduced = cannotBeReduced,
+							bypassTempStamina = bypassTempStamina,
+						})
+						if type(res) == "table" and type(res.damageDealt) == "number" and res.damageDealt > 0 then
+							numDamaged = numDamaged + 1
+						end
+					end,
+				}
+			end
+		end
+	end
+
+	if numDamaged > 0 then
+		local perTarget = tonumber(dmhub.EvalGoblinScript(self.tempPerTarget, casterToken.properties:LookupSymbol(options.symbols or {}), string.format("Temp stamina for %s", ability.name))) or 0
+		--Draw Steel temporary Stamina does not stack: the higher of the current
+		--and new values wins. SetTemporaryHitpoints overwrites, so clamp here.
+		local grant = perTarget * numDamaged
+		if grant > 0 and grant > casterToken.properties:TemporaryHitpoints() then
+			casterToken:ModifyProperties{
+				description = string.format("%s: Gain Temporary Stamina", ability.name),
+				execute = function()
+					casterToken.properties:SetTemporaryHitpoints(grant, sourceDescription)
+					casterToken.properties:DispatchEvent("gaintempstamina", {})
+				end,
+			}
+			casterToken.properties:FloatLabel(string.format("+%d Temp Stamina", grant), "#66ff66")
+		end
+	end
+end
+
+function ActivatedAbilityLeechTempStaminaBehavior:EditorItems(parentPanel)
+	local result = {}
+	self:ApplyToEditor(parentPanel, result)
+	self:FilterEditor(parentPanel, result)
+	self:RollEditor(parentPanel, result)
+	self:DamageTypeEditor(parentPanel, result)
+	return result
+end

--- a/Draw Steel Ability Behaviors/AbilityDamage.lua
+++ b/Draw Steel Ability Behaviors/AbilityDamage.lua
@@ -673,6 +673,9 @@ function ActivatedAbilityLeechTempStaminaBehavior:Cast(ability, casterToken, tar
 	local bypassTempStamina = self:try_get("bypassTempStamina", true)
 
 	local numDamaged = 0
+	--charids of the creatures actually damaged, for the action-log card below.
+	local damagedTokenIds = {}
+	local lastAmount = 0
 
 	for _,target in ipairs(targets) do
 		if target.token ~= nil and target.token.valid and target.token.properties ~= nil then
@@ -680,6 +683,7 @@ function ActivatedAbilityLeechTempStaminaBehavior:Cast(ability, casterToken, tar
 			local amount = dmhub.EvalGoblinScript(self.roll, casterToken.properties:LookupSymbol(options.symbols or {}), string.format("Leech damage for %s", ability.name))
 			amount = tonumber(amount) or 0
 			if amount > 0 then
+				lastAmount = amount
 				ability.RecordTokenMessage(target.token, options, string.format("%d %s damage", amount, damageType))
 				target.token:ModifyProperties{
 					description = sourceDescription,
@@ -696,16 +700,19 @@ function ActivatedAbilityLeechTempStaminaBehavior:Cast(ability, casterToken, tar
 						end
 					end,
 				}
+				damagedTokenIds[#damagedTokenIds+1] = target.token.charid
 			end
 		end
 	end
 
+	local grantedTemp = 0
 	if numDamaged > 0 then
 		local perTarget = tonumber(dmhub.EvalGoblinScript(self.tempPerTarget, casterToken.properties:LookupSymbol(options.symbols or {}), string.format("Temp stamina for %s", ability.name))) or 0
 		--Draw Steel temporary Stamina does not stack: the higher of the current
 		--and new values wins. SetTemporaryHitpoints overwrites, so clamp here.
 		local grant = perTarget * numDamaged
 		if grant > 0 and grant > casterToken.properties:TemporaryHitpoints() then
+			grantedTemp = grant
 			casterToken:ModifyProperties{
 				description = string.format("%s: Gain Temporary Stamina", ability.name),
 				execute = function()
@@ -715,6 +722,24 @@ function ActivatedAbilityLeechTempStaminaBehavior:Cast(ability, casterToken, tar
 			}
 			casterToken.properties:FloatLabel(string.format("+%d Temp Stamina", grant), "#66ff66")
 		end
+	end
+
+	--Action-log card: the base RecordTokenMessage notes are easy to miss, so post
+	--an explicit damage card (reusing the standard damage card) showing the poison
+	--dealt to each target, with the Stamina the caster leeched folded into the
+	--caption. Only when something actually happened.
+	if #damagedTokenIds > 0 then
+		local caption = ability.name
+		if grantedTemp > 0 then
+			caption = string.format("%s (+%d temporary Stamina)", ability.name, grantedTemp)
+		end
+		chat.SendCustom(ActivatedAbilityDamageChatMessage.new{
+			amount = lastAmount,
+			damageType = damageType,
+			chatMessage = caption,
+			casterid = casterToken.charid,
+			targetids = damagedTokenIds,
+		})
 	end
 end
 

--- a/Draw Steel Core Rules/MCDMAbilityBehavior.lua
+++ b/Draw Steel Core Rules/MCDMAbilityBehavior.lua
@@ -551,21 +551,28 @@ local g_rulePatterns = {
                 grabbedByCaster = (targetGrabbed == casterToken.charid)
             end
 
-            --Check the grabbed-by-another case FIRST: a grabbed target usually also
-            --has "Cannot Be Force Moved" granted by the grab itself, so testing the
-            --generic immunity first would mask the more specific (and actionable)
-            --reason -- the director should see that the grab is what blocks the move.
-            if targetGrabbed and targetGrabbed ~= casterToken.charid then
-                print("Target is grabbed, and cannot be force moved.")
-                ShowFailMessage("Grabbed: Cannot be Force Moved")
-                return
-            end
+            --An "into your space" pull (e.g. Engulf) is the caster asserting control
+            --over the target -- pulling it into its own body -- so like a grab it
+            --overrides the target's forced-movement immunity. Without this, engulfing
+            --a creature that is already Restrained/Engulfed/grabbed (which all grant
+            --"Cannot Be Force Moved") silently refused the pull.
+            if not match.intospace then
+                --Check the grabbed-by-another case FIRST: a grabbed target usually
+                --also has "Cannot Be Force Moved" granted by the grab itself, so
+                --testing the generic immunity first would mask the more specific
+                --(and actionable) reason -- the director should see the grab.
+                if targetGrabbed and targetGrabbed ~= casterToken.charid then
+                    print("Target is grabbed, and cannot be force moved.")
+                    ShowFailMessage("Grabbed: Cannot be Force Moved")
+                    return
+                end
 
-            local targetImmune = targetToken.properties:CalculateNamedCustomAttribute("Cannot Be Force Moved")
-            if targetImmune > 0 and (not grabbedByCaster) then
-                print("Target is immune to forced movement, not executing")
-                ShowFailMessage("Immune to Forced Movement")
-                return
+                local targetImmune = targetToken.properties:CalculateNamedCustomAttribute("Cannot Be Force Moved")
+                if targetImmune > 0 and (not grabbedByCaster) then
+                    print("Target is immune to forced movement, not executing")
+                    ShowFailMessage("Immune to Forced Movement")
+                    return
+                end
             end
 
 
@@ -3754,24 +3761,19 @@ function ActivatedAbilityRelocateCreatureBehavior:Cast(ability, casterToken, tar
     --Deliberately NOT `ability.forcedMovement`, which "Forced Movement: Slide" never declares.
     local isForcedMove = movementType == "move" and (ability.targeting == "straightline" or ability.targetType == "line")
 
-    --"into your space" pulls (e.g. the Shambling Mound's Engulf): the pull
-    --always ends in the puller's own footprint -- clicking beyond the puller
-    --must not drag the target past it, the same way a wall would stop the
-    --movement. A click on a specific square INSIDE the footprint is honored
-    --as-is so the director controls where in the space the captive ends up.
+    --"into your space" pulls (e.g. the Shambling Mound's Engulf): always land the
+    --target on the square of the puller's footprint nearest to it -- the entry
+    --point. That square is straight-line reachable from the victim, so the forced
+    --Move never refuses (a specific interior click could be off-line and get
+    --refused). Which interior tile they end on does not matter: the mound occupies
+    --the whole footprint, so the captive shares space with it either way.
     local intoCharid = ability:try_get("pullIntoSpaceOfCharid")
     if intoCharid ~= nil and casterToken ~= nil and casterToken.valid then
         local ownerTok = dmhub.GetTokenById(intoCharid)
         if ownerTok ~= nil and ownerTok.valid then
-            local chosenLoc = nil
-            if targets ~= nil and targets[1] ~= nil then
-                chosenLoc = targets[1].loc
-            end
-            if not MCDMUtils.IsLocInsideFootprint(ownerTok, chosenLoc) then
-                local dest = MCDMUtils.NearestFootprintLoc(ownerTok, casterToken)
-                if dest ~= nil then
-                    targets = { { loc = dest } }
-                end
+            local dest = MCDMUtils.NearestFootprintLoc(ownerTok, casterToken)
+            if dest ~= nil then
+                targets = { { loc = dest } }
             end
         end
     end
@@ -4062,8 +4064,11 @@ function ActivatedAbilityRepositionIntoEngulferBehavior:Cast(ability, casterToke
     end
 end
 
---Teleport captiveToken to the nearest free square of engulferToken's
---footprint, unless it is already inside or the engulfer is dead.
+--Move captiveToken into the nearest square of engulferToken's footprint, unless
+--it is already inside or the engulfer is dead. Uses an animated forced Move with
+--ignorecreatures (so it can end on the mound's own occupied square, and captives
+--can share squares) rather than a Teleport, so the drag reads as movement. Falls
+--back to a Teleport only if the engine refuses the move (nil path).
 function ActivatedAbilityRepositionIntoEngulferBehavior.SnapIntoFootprint(engulferTok, captiveToken)
     local engulferDead = false
     pcall(function() engulferDead = engulferTok.properties:IsDead() end)
@@ -4076,8 +4081,24 @@ function ActivatedAbilityRepositionIntoEngulferBehavior.SnapIntoFootprint(engulf
     end
 
     local dest = MCDMUtils.NearestFootprintLoc(engulferTok, captiveToken)
-    if dest ~= nil then
-        captiveToken:Teleport(dest)
+    if dest == nil then
+        return
+    end
+
+    captiveToken.properties._tmp_freeMovement = true
+    local path = captiveToken:Move(dest.withGroundAltitude, {
+        straightline = false,
+        ignorecreatures = true,
+        moveThroughFriends = true,
+        maxCost = 30000,
+        movementType = "move",
+        freeMovement = true,
+        forced = true,
+    })
+    captiveToken.properties._tmp_freeMovement = false
+
+    if path == nil then
+        captiveToken:Teleport(dest.withGroundAltitude)
     end
 end
 

--- a/Draw Steel Core Rules/MCDMAbilityBehavior.lua
+++ b/Draw Steel Core Rules/MCDMAbilityBehavior.lua
@@ -515,7 +515,7 @@ local g_rulePatterns = {
     },
 
     {
-        pattern = "^(?<vertical>vertical )?(?<movement>pull|push|slide) +(?<straightup>straight up +)?(?<distance>[0-9]+)(?<ignorestabilityifcompanion>[,;]? ignoring stability if (your )?companion is adjacent( to the target)?)?(?<ignorestabilityifally>[,;]? (allies ignore stability|ignoring stability if the target is (an|your) ally|ignoring (the )?stability of allies))?(?<ignorestability>[,;]? (ignoring stability|this (push|pull|slide) ignores the target.s stability))?",
+        pattern = "^(?<vertical>vertical )?(?<movement>pull|push|slide) +(?<straightup>straight up +)?(?<distance>[0-9]+)(?<ignorestabilityifcompanion>[,;]? ignoring stability if (your )?companion is adjacent( to the target)?)?(?<ignorestabilityifally>[,;]? (allies ignore stability|ignoring stability if the target is (an|your) ally|ignoring (the )?stability of allies))?(?<ignorestability>[,;]? (ignoring stability|this (push|pull|slide) ignores the target.s stability))?(?<nodamage>[,;]? without damage)?(?<intospace>[,;]? into (your|their|the creature.s) space)?",
         execute = function(behavior, ability, casterToken, targetToken, options, match)
 
             print("INVOKE:: EXECUTE FORCE MOVE", match.movement, match.distance)
@@ -538,21 +538,34 @@ local g_rulePatterns = {
                 end
             end
 
-            local targetImmune = targetToken.properties:CalculateNamedCustomAttribute("Cannot Be Force Moved")
-            if targetImmune > 0 then
-                print("Target is immune to forced movement, not executing")
-                ShowFailMessage("Immune to Forced Movement")
+            --A creature force-moving a target IT has grabbed overrides forced
+            --movement immunity: the grab itself (and conditions riding on it, e.g.
+            --the Shambling Mound engulfing a grabbed victim) grants "Cannot Be
+            --Force Moved", which would otherwise block the grabber from dragging
+            --their own captive.
+            local grabbedByCaster = false
+            local targetGrabbed = nil
+            local grabbedCondition = CharacterCondition.conditionsByName["grabbed"]
+            if grabbedCondition ~= nil then
+                targetGrabbed = targetToken.properties:HasCondition(grabbedCondition.id)
+                grabbedByCaster = (targetGrabbed == casterToken.charid)
+            end
+
+            --Check the grabbed-by-another case FIRST: a grabbed target usually also
+            --has "Cannot Be Force Moved" granted by the grab itself, so testing the
+            --generic immunity first would mask the more specific (and actionable)
+            --reason -- the director should see that the grab is what blocks the move.
+            if targetGrabbed and targetGrabbed ~= casterToken.charid then
+                print("Target is grabbed, and cannot be force moved.")
+                ShowFailMessage("Grabbed: Cannot be Force Moved")
                 return
             end
 
-            local grabbedCondition = CharacterCondition.conditionsByName["grabbed"]
-            if grabbedCondition ~= nil then
-                local targetGrabbed = targetToken.properties:HasCondition(grabbedCondition.id)
-                if targetGrabbed and targetGrabbed ~= casterToken.charid then
-                    print("Target is grabbed, and cannot be force moved.")
-                    ShowFailMessage("Grabbed: Cannot be Force Moved")
-                    return
-                end
+            local targetImmune = targetToken.properties:CalculateNamedCustomAttribute("Cannot Be Force Moved")
+            if targetImmune > 0 and (not grabbedByCaster) then
+                print("Target is immune to forced movement, not executing")
+                ShowFailMessage("Immune to Forced Movement")
+                return
             end
 
 
@@ -649,7 +662,9 @@ local g_rulePatterns = {
             -- forced movement resolved vertically. Reuse the existing vertical
             -- pathway by selecting the "Vertical" standard-ability variant.
             local convertToVertical = false
-            if not match.vertical then
+            --"into your space" pulls have a fixed horizontal destination inside the
+            --caster's footprint, so never convert them to vertical movement.
+            if (not match.vertical) and (not match.intospace) then
                 if targetToken.properties:IsFlying() then
                     convertToVertical = true
                 else
@@ -697,11 +712,34 @@ local g_rulePatterns = {
                 disableSquadCoordination = true,
             }
 
+            --"pull 6, without damage" variant: the movement plays normally but no
+            --collision damage or collide triggers fire for anyone involved (e.g.
+            --the Shambling Mound dragging an engulfed creature into its sack).
+            if match.nodamage then
+                abilityAttr.noCollisionDamage = true
+            end
+
+            --"pull 6 ... into your space" variant (e.g. Engulf): the destination is
+            --computed -- the nearest square of the caster's own footprint -- rather
+            --than chosen by the director, so the pull resolves as a single confirm.
+            --Dragging a creature inside the caster's space requires moving through
+            --the caster's occupied squares and can never deal collision damage.
+            if match.intospace then
+                abilityAttr.forcedMovementThroughCreatures = true
+                abilityAttr.noCollisionDamage = true
+                --The relocate clamps any chosen destination to the puller's own
+                --footprint (see ActivatedAbilityRelocateCreatureBehavior:Cast).
+                abilityAttr.pullIntoSpaceOfCharid = casterToken.charid
+                local casterName = creature.GetTokenDescription(casterToken)
+                local targetName = creature.GetTokenDescription(targetToken)
+                abilityAttr.promptOverride = string.format("Pull %s into %s's space", targetName, casterName)
+            end
+
             if stability > 0 then
                 adjustments[#adjustments+1] = string.format("Stability: -%d", stability)
             end
 
-            if #adjustments > 0 then
+            if #adjustments > 0 and (not match.intospace) then
                 abilityAttr.promptOverride = abilityAttr.promptOverride .. " (" .. table.concat(adjustments, ", ") .. ")"
             end
 
@@ -721,8 +759,13 @@ local g_rulePatterns = {
                             loc = targetToken.loc:WithAltitude(targetToken.loc.altitude + range),
                         }
                     }
+                elseif match.intospace then
+                    local chosen = MCDMUtils.NearestFootprintLoc(casterToken, targetToken)
+                    if chosen ~= nil then
+                        options.targetArgs = { { loc = chosen } }
+                    end
                 end
-                
+
                 InvokeAbility(ability, abilityClone, targetToken, casterToken, options)
                 options.targetArgs = nil
             end
@@ -3710,6 +3753,28 @@ function ActivatedAbilityRelocateCreatureBehavior:Cast(ability, casterToken, tar
     --The engine's own definition of forced movement: straightline/line targeting plus a "move".
     --Deliberately NOT `ability.forcedMovement`, which "Forced Movement: Slide" never declares.
     local isForcedMove = movementType == "move" and (ability.targeting == "straightline" or ability.targetType == "line")
+
+    --"into your space" pulls (e.g. the Shambling Mound's Engulf): the pull
+    --always ends in the puller's own footprint -- clicking beyond the puller
+    --must not drag the target past it, the same way a wall would stop the
+    --movement. A click on a specific square INSIDE the footprint is honored
+    --as-is so the director controls where in the space the captive ends up.
+    local intoCharid = ability:try_get("pullIntoSpaceOfCharid")
+    if intoCharid ~= nil and casterToken ~= nil and casterToken.valid then
+        local ownerTok = dmhub.GetTokenById(intoCharid)
+        if ownerTok ~= nil and ownerTok.valid then
+            local chosenLoc = nil
+            if targets ~= nil and targets[1] ~= nil then
+                chosenLoc = targets[1].loc
+            end
+            if not MCDMUtils.IsLocInsideFootprint(ownerTok, chosenLoc) then
+                local dest = MCDMUtils.NearestFootprintLoc(ownerTok, casterToken)
+                if dest ~= nil then
+                    targets = { { loc = dest } }
+                end
+            end
+        end
+    end
 
     g_baseRelocateCreatureCast(self, ability, casterToken, targets, options)
 

--- a/Draw Steel Core Rules/MCDMAbilityBehavior.lua
+++ b/Draw Steel Core Rules/MCDMAbilityBehavior.lua
@@ -3897,3 +3897,151 @@ function ActivatedAbility:Cast(casterToken, targets, options)
 
     return g_baseActivatedAbilityCast(self, casterToken, targets, options)
 end
+
+--- @class ActivatedAbilityRepositionIntoEngulferBehavior:ActivatedAbilityBehavior
+--- Snaps the casting creature back inside the footprint of the creature whose
+--- ongoing effect (e.g. the Shambling Mound's Engulfed) it carries. Designed to
+--- ride a mandatory, silent "move" trigger on the effect itself: the engine's
+--- grab-follow drags a captive along when its grabber moves but places it
+--- ADJACENT to the grabber; this behavior then teleports the captive to the
+--- nearest free square of the grabber's own space, keeping "the engulfed
+--- creature occupies the mound's space" true. No-op when the captive is
+--- already inside, when the engulfer is dead or gone, or when the effect is
+--- not present.
+ActivatedAbilityRepositionIntoEngulferBehavior = RegisterGameType("ActivatedAbilityRepositionIntoEngulferBehavior", "ActivatedAbilityBehavior")
+
+ActivatedAbilityRepositionIntoEngulferBehavior.summary = 'Reposition Into Engulfer Space'
+ActivatedAbilityRepositionIntoEngulferBehavior.ongoingEffectid = "none"
+
+ActivatedAbility.RegisterType
+{
+    id = 'reposition_into_engulfer',
+    text = 'Reposition Into Engulfer Space',
+    createBehavior = function()
+        return ActivatedAbilityRepositionIntoEngulferBehavior.new{}
+    end
+}
+
+function ActivatedAbilityRepositionIntoEngulferBehavior:SummarizeBehavior(ability, creatureLookup)
+    return "Reposition into the engulfing creature's space"
+end
+
+--Find the token of the creature that applied the given ongoing effect to us.
+function ActivatedAbilityRepositionIntoEngulferBehavior:FindEngulferToken(creatureProps)
+    for _, entry in ipairs(creatureProps:ActiveOngoingEffects()) do
+        if entry.ongoingEffectid == self.ongoingEffectid then
+            local casterInfo = nil
+            pcall(function() casterInfo = entry.casterInfo end)
+            if casterInfo ~= nil and casterInfo.tokenid ~= nil then
+                local tok = dmhub.GetTokenById(casterInfo.tokenid)
+                if tok ~= nil and tok.valid and tok.properties ~= nil then
+                    return tok
+                end
+            end
+        end
+    end
+    return nil
+end
+
+function ActivatedAbilityRepositionIntoEngulferBehavior:Cast(ability, casterToken, targets, options)
+    if self.ongoingEffectid == "none" then
+        return
+    end
+
+    --The move trigger dispatches from INSIDE the engine's Move call (OnMove
+    --fires mid-move), so an immediate Teleport here would be overwritten when
+    --the move finalizes its destination. Yield until the mover's location has
+    --been stable for a few ticks before deciding whether a snap is needed.
+    local lastLoc = casterToken.loc
+    local stable = 0
+    for i = 1, 40 do
+        coroutine.yield(0.1)
+        if not casterToken.valid then
+            return
+        end
+        local cur = casterToken.loc
+        if cur.x == lastLoc.x and cur.y == lastLoc.y then
+            stable = stable + 1
+            if stable >= 3 then
+                break
+            end
+        else
+            stable = 0
+            lastLoc = cur
+        end
+    end
+
+    local engulferTok = self:FindEngulferToken(casterToken.properties)
+    if engulferTok ~= nil then
+        --Captive side: the caster carries the effect; snap them into their
+        --engulfer's footprint.
+        self.SnapIntoFootprint(engulferTok, casterToken)
+        return
+    end
+
+    --Engulfer side: the caster is the creature whose movement dragged its
+    --captives along (or left them behind); snap every creature carrying this
+    --effect FROM the caster into the caster's footprint.
+    for _, tok in ipairs(dmhub.allTokens) do
+        if tok.charid ~= casterToken.charid and tok.valid and tok.properties ~= nil then
+            for _, entry in ipairs(tok.properties:ActiveOngoingEffects()) do
+                if entry.ongoingEffectid == self.ongoingEffectid then
+                    local casterInfo = nil
+                    pcall(function() casterInfo = entry.casterInfo end)
+                    if casterInfo ~= nil and casterInfo.tokenid == casterToken.id then
+                        self.SnapIntoFootprint(casterToken, tok)
+                    end
+                end
+            end
+        end
+    end
+end
+
+--Teleport captiveToken to the nearest free square of engulferToken's
+--footprint, unless it is already inside or the engulfer is dead.
+function ActivatedAbilityRepositionIntoEngulferBehavior.SnapIntoFootprint(engulferTok, captiveToken)
+    local engulferDead = false
+    pcall(function() engulferDead = engulferTok.properties:IsDead() end)
+    if engulferDead then
+        return
+    end
+
+    if MCDMUtils.IsInsideFootprint(engulferTok, captiveToken) then
+        return
+    end
+
+    local dest = MCDMUtils.NearestFootprintLoc(engulferTok, captiveToken)
+    if dest ~= nil then
+        captiveToken:Teleport(dest)
+    end
+end
+
+function ActivatedAbilityRepositionIntoEngulferBehavior:EditorItems(parentPanel)
+    local result = {}
+
+    local effectOptions = {
+        { id = "none", text = "Choose Effect..." },
+    }
+    for k, eff in unhidden_pairs(dmhub.GetTable("characterOngoingEffects") or {}) do
+        effectOptions[#effectOptions+1] = { id = k, text = eff.name }
+    end
+
+    result[#result+1] = gui.Panel{
+        classes = {"formPanel"},
+        gui.Label{
+            classes = {"formLabel"},
+            text = "Effect:",
+        },
+        gui.Dropdown{
+            sort = true,
+            hasSearch = true,
+            idChosen = self.ongoingEffectid,
+            options = effectOptions,
+            change = function(element)
+                self.ongoingEffectid = element.idChosen
+            end,
+        },
+    }
+
+    return result
+end

--- a/Draw Steel Core Rules/MCDMRules.lua
+++ b/Draw Steel Core Rules/MCDMRules.lua
@@ -1214,6 +1214,12 @@ TriggeredAbility.RegisterTrigger{
 }
 
 TriggeredAbility.RegisterTrigger{
+    id = "tempstaminadepleted",
+    text = "Temporary Stamina Depleted",
+    symbols = {},
+}
+
+TriggeredAbility.RegisterTrigger{
     id = "castsignature",
     text = "Use Signature Attack or Area",
     symbols = g_abilitySymbols,

--- a/Draw Steel Core Rules/MCDMUtils.lua
+++ b/Draw Steel Core Rules/MCDMUtils.lua
@@ -37,3 +37,92 @@ MCDMUtils.DeepReplace = function(node, from, to)
         end
     end
 end
+--Nearest square of a token's footprint to another token's location. Token loc
+--is the footprint's min corner, extending +x/+y by the creature's dimensions.
+--Prefers squares not already holding another creature (e.g. a previously
+--engulfed victim); the owner itself always occupies its own footprint, which
+--is expected. Returns a Loc, or nil if the owner token is invalid.
+--Used by the "pull ... into your space" forced-movement rule and by the
+--engulfed-creature reposition behavior.
+MCDMUtils.NearestFootprintLoc = function(ownerToken, targetToken)
+    if ownerToken == nil or not ownerToken.valid then
+        return nil
+    end
+
+    local dim = 1
+    if ownerToken.creatureDimensions ~= nil and ownerToken.creatureDimensions.x ~= nil then
+        dim = math.max(1, math.floor(ownerToken.creatureDimensions.x))
+    end
+
+    local ownerLoc = ownerToken.loc
+    local targetLoc = targetToken.loc
+    local best = nil
+    local bestFree = nil
+
+    local function chebyshev(loc)
+        local dx = math.abs(loc.x - targetLoc.x)
+        local dy = math.abs(loc.y - targetLoc.y)
+        if dx > dy then return dx else return dy end
+    end
+
+    for dx = 0, dim - 1 do
+        for dy = 0, dim - 1 do
+            local candidate = ownerLoc:dir(dx, dy)
+            local dist = chebyshev(candidate)
+            if best == nil or dist < best.dist then
+                best = { loc = candidate, dist = dist }
+            end
+
+            local occupiedByOther = false
+            for _, tokAt in ipairs(game.GetTokensAtLoc(candidate) or {}) do
+                if tokAt.charid ~= ownerToken.charid and tokAt.charid ~= targetToken.charid then
+                    occupiedByOther = true
+                end
+            end
+            if not occupiedByOther then
+                if bestFree == nil or dist < bestFree.dist then
+                    bestFree = { loc = candidate, dist = dist }
+                end
+            end
+        end
+    end
+
+    local chosen = bestFree or best
+    if chosen ~= nil then
+        return chosen.loc
+    end
+    return nil
+end
+
+--True if targetToken currently stands inside ownerToken's footprint.
+MCDMUtils.IsInsideFootprint = function(ownerToken, targetToken)
+    if ownerToken == nil or not ownerToken.valid or targetToken == nil or not targetToken.valid then
+        return false
+    end
+
+    local dim = 1
+    if ownerToken.creatureDimensions ~= nil and ownerToken.creatureDimensions.x ~= nil then
+        dim = math.max(1, math.floor(ownerToken.creatureDimensions.x))
+    end
+
+    local ownerLoc = ownerToken.loc
+    local loc = targetToken.loc
+    return loc.x >= ownerLoc.x and loc.x <= ownerLoc.x + dim - 1
+       and loc.y >= ownerLoc.y and loc.y <= ownerLoc.y + dim - 1
+end
+
+--True if the given loc is inside ownerToken's footprint.
+MCDMUtils.IsLocInsideFootprint = function(ownerToken, loc)
+    if ownerToken == nil or not ownerToken.valid or loc == nil then
+        return false
+    end
+
+    local dim = 1
+    if ownerToken.creatureDimensions ~= nil and ownerToken.creatureDimensions.x ~= nil then
+        dim = math.max(1, math.floor(ownerToken.creatureDimensions.x))
+    end
+
+    local ownerLoc = ownerToken.loc
+    return loc.x >= ownerLoc.x and loc.x <= ownerLoc.x + dim - 1
+       and loc.y >= ownerLoc.y and loc.y <= ownerLoc.y + dim - 1
+end

--- a/DrawSteelActionBar/DrawSteelActionBar.lua
+++ b/DrawSteelActionBar/DrawSteelActionBar.lua
@@ -11989,6 +11989,13 @@ CreateAbilityController = function()
                                 end
                             end
 
+                            --forced movement built from a "without damage" rule (e.g. the
+                            --Shambling Mound's Engulf pull) deals no collision damage at
+                            --all, so never promise any in the preview.
+                            if g_currentAbility:try_get("noCollisionDamage", false) then
+                                suppressDamage = true
+                            end
+
                             if not suppressDamage then
                                 diagramCollisionDamage = collideDamage
                             end
@@ -12133,8 +12140,11 @@ CreateAbilityController = function()
                             end
                         end
 
-                        --show damage indicators on creatures passed through.
-                        if throughCreatures and path.steps ~= nil then
+                        --show damage indicators on creatures passed through. Forced
+                        --movement built from a "without damage" rule (e.g. Engulf's
+                        --pull into the mound's own space) deals no pass-through
+                        --damage, so promise none.
+                        if throughCreatures and path.steps ~= nil and (not g_currentAbility:try_get("noCollisionDamage", false)) then
                             local throughTextLabels = {}
                             local throughShapes = {}
                             local hitIds = {}


### PR DESCRIPTION
## Shambling Mound: restore engine behaviors + Engulf/Leech playtest fixes

The Shambling Mound's `data/` content shipped upstream referencing custom ability
behaviors that were never committed to the codex repo, so the engine registered each
type as a bare shell with no `Cast` -- the Leech maneuver, Harvest, Engulf's pull, and
the Ashen Hoarder's Impaled all did nothing in play. This restores that engine Lua and
lands the playtest fixes made on top of it.

### Restored behaviors
- `ActivatedAbilityLeechDamageBehavior` (Leeching Wilds aura drain)
- `ActivatedAbilityLeechTempStaminaBehavior` (Engulf's Leech maneuver)
- `ActivatedAbilityHarvestCorpseBehavior` + `GameHud.RunHarvestTest` (Alchemical Ingredients harvest-gated loot)
- `ActivatedAbilityRepositionIntoEngulferBehavior` (keeps engulfed creatures in the mound's space)
- `MCDMUtils` footprint helpers, the `tempstaminadepleted` trigger event, `displayOwnIdentity`
  effect labeling ("Engulfed", not "Restrained"), and the `without damage` / `into your space`
  forced-movement rule grammar.

### Engulf "into your space" pull (playtest fixes)
- Auto-place the target on the nearest square of the mound's footprint (the entry point),
  which is always straight-line reachable, so the pull never silently refuses.
- Bypass forced-movement immunity for these pulls: Engulf is not described as forced movement,
  so an already-Restrained/Engulfed/grabbed target must still be pullable into the sack.
- Drag captives with an animated forced Move (ignorecreatures) instead of a Teleport, so it
  reads as movement and multiple captives can co-habit the mound's space.
- Suppress the collision-damage preview (`-1` / red) for these no-damage pulls.

### Leech
- Post an action-log card showing the poison dealt to each engulfed target, with the temporary
  Stamina the mound leeched folded into the caption.

### Notes
- Depends on the already-upstream `draw-steel-data` Shambling Mound content (re-landed Engulf
  rule + `channelDescription` committed separately in the data repo).
- `GameHud.lua` was applied as a patch on top of newer upstream, not copied wholesale.
- Verified live in the dev game (build 10): all four behaviors report `Cast=function`; Leech
  deals 5 poison + grants temp Stamina; Engulf pulls immune/restrained targets into the sack and
  animates; multiple captives co-habit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
