### PR TITLE
Retargeted strikes use the new target's modifiers

### DIFF
--- a/DMHub Game Rules/ActivatedAbilityCast.lua
+++ b/DMHub Game Rules/ActivatedAbilityCast.lua
@@ -766,6 +766,44 @@ function ActivatedAbilityCast:RecordRetarget(retarget)
     retargets[#retargets+1] = retarget
 end
 
+--- True if an identical retarget has already been recorded on this cast.
+--- @param tokenid string
+--- @param retargetid string
+--- @param retargetType string
+--- @return boolean
+function ActivatedAbilityCast:HasRetarget(tokenid, retargetid, retargetType)
+    for _, retarget in ipairs(self:try_get("retargets", {})) do
+        if retarget.tokenid == tokenid and retarget.retargetid == retargetid and retarget.retargetType == retargetType then
+            return true
+        end
+    end
+    return false
+end
+
+--- Records (or clears) an open roll's "all" retarget for tokenid, so the dialog
+--- can rebuild that row for the new creature. Pass a nil retargetid when the
+--- trigger was withdrawn. Returns true if anything changed.
+--- @param tokenid string the target the strike was originally aimed at
+--- @param casterid string the trigger's owner
+--- @param retargetid nil|string the creature the trigger redirected to
+--- @return boolean
+function ActivatedAbilityCast:SyncLiveRetarget(tokenid, casterid, retargetid)
+    local retargets = self:get_or_add("retargets", {})
+    local changed = false
+    for i = #retargets, 1, -1 do
+        local retarget = retargets[i]
+        if retarget.live and retarget.tokenid == tokenid and retarget.retargetid ~= retargetid then
+            table.remove(retargets, i)
+            changed = true
+        end
+    end
+    if type(retargetid) == "string" and not self:HasRetarget(tokenid, retargetid, "all") then
+        retargets[#retargets+1] = { casterid = casterid, tokenid = tokenid, retargetid = retargetid, retargetType = "all", live = true }
+        changed = true
+    end
+    return changed
+end
+
 function ActivatedAbilityCast:RedirectTarget(target)
     local retargets = self:try_get("retargets")
     if retargets == nil then

--- a/Draw Steel Core Rules/MCDMAbilityRollBehavior.lua
+++ b/Draw Steel Core Rules/MCDMAbilityRollBehavior.lua
@@ -1255,13 +1255,16 @@ function ActivatedAbilityPowerRollBehavior:Cast(ability, casterToken, targets, o
     local baseBoons = nil
     local baseBanes = nil
 
+    --The targets as first chosen; every recalculation re-applies redirects to these.
+    local originalTargets = table.shallow_copy(targets or {})
+
     local CalculateMultitargets = function()
         while #multitargets > 0 do
             table.remove(multitargets, #multitargets)
         end
 
         --respect any target redirecting occurring.
-        for i,target in ipairs(targets or {}) do
+        for i,target in ipairs(originalTargets) do
             targets[i] = options.symbols.cast:RedirectTarget(target)
         end
 
@@ -1505,12 +1508,21 @@ function ActivatedAbilityPowerRollBehavior:Cast(ability, casterToken, targets, o
             end
 
 
+            --A retargeted row uses the new creature's modifiers but keeps the old
+            --row's triggers, so the redirecting trigger (and any edge it grants) stays.
+            local rowTriggers = {}
+            local originalRow = target.originalid ~= nil and multitargetsByTokenId[target.originalid] or nil
+            if originalRow ~= nil then
+                rowTriggers = originalRow.triggers
+            end
+
             multitargets[#multitargets+1] = {
                 token = target.token,
+                originalid = target.originalid,
                 boons = boons - baseBoons,
                 banes = banes - baseBanes,
                 modifiers = candidateModifiers,
-                triggers = {},
+                triggers = rowTriggers,
             }
 
             multitargetsByTokenId[target.token.charid] = multitargets[#multitargets]

--- a/Draw Steel UI/DSActionBar.lua
+++ b/Draw Steel UI/DSActionBar.lua
@@ -4827,6 +4827,8 @@ function GameHud.CreateActionBar(self, dialog, tokenInfo)
                                                     execute = function()
                                                         trigger.triggered = true
                                                         trigger.retargetid = newTargetToken.charid
+                                                        --choosing the new target commits the trigger, so the card leaves the drawer.
+                                                        trigger.dismissed = true
 
                                                         token.properties:DispatchAvailableTrigger(trigger)
                                                     end,
@@ -5024,6 +5026,8 @@ function GameHud.CreateActionBar(self, dialog, tokenInfo)
 
                                                             trigger.triggered = index
                                                             trigger.retargetid = newTargetToken.charid
+                                                            --choosing the new target commits the trigger, so the card leaves the drawer.
+                                                            trigger.dismissed = true
 
                                                             token.properties:DispatchAvailableTrigger(trigger)
                                                         end,

--- a/Draw Steel UI/DSRollDialog.lua
+++ b/Draw Steel UI/DSRollDialog.lua
@@ -98,13 +98,25 @@ function GameHud.CreateRollDialog(self)
     local m_multitargets = nil
     local m_CalculateMultiTargets = nil
 
+    -- True if this row is for creature c, including a row a trigger retargeted
+    -- away from c while the dialog is open (the row then carries originalid).
+    local function MultiTargetIsFor(target, c)
+        if c == nil then
+            return false
+        end
+        if target.token.properties == c then
+            return true
+        end
+        return target.originalid ~= nil and target.originalid == dmhub.LookupTokenId(c)
+    end
+
     local GetCurrentMultiTarget = function()
         if m_multitargets == nil or targetCreature == nil then
             return nil
         end
 
         for i, target in ipairs(m_multitargets) do
-            if target.token.properties == targetCreature then
+            if MultiTargetIsFor(target, targetCreature) then
                 return i
             end
         end
@@ -113,6 +125,33 @@ function GameHud.CreateRollDialog(self)
     end
 
     local m_symbols = nil
+
+    -- Records a trigger-chosen retarget as soon as it arrives, so the next
+    -- recalculation rebuilds that row for the new creature (its own flanking,
+    -- cover and conditions). A withdrawn retarget swings the row back.
+    local function SyncLiveRetargets()
+        if m_multitargets == nil or m_symbols == nil or m_symbols.cast == nil then
+            return
+        end
+        for _, target in ipairs(m_multitargets) do
+            local hasRedirect = false
+            local retargetid = nil
+            local casterid = nil
+            for _, trigger in ipairs(target.triggers or {}) do
+                local powerMod = trigger.modifier:try_get("powerRollModifier")
+                if powerMod ~= nil and powerMod:try_get("changeTarget") and powerMod:try_get("changeTargetEffect", "all") == "all" then
+                    hasRedirect = true
+                    if retargetid == nil and trigger.triggered and type(trigger.retargetid) == "string" then
+                        retargetid = trigger.retargetid
+                        casterid = trigger.charid
+                    end
+                end
+            end
+            if hasRedirect then
+                m_symbols.cast:SyncLiveRetarget(target.originalid or target.token.charid, casterid, retargetid)
+            end
+        end
+    end
 
     --any ongoing roll as a result of this dialog.
     local m_rollInfo = nil
@@ -1055,9 +1094,11 @@ function GameHud.CreateRollDialog(self)
                         m_openedTriggers = {}
                     end
 
+                    -- Keyed by the original target so a row swapped to its redirect
+                    -- target keeps talking to the same trigger record.
                     local key = trigger.modifier.guid .. (trigger.charid or "")
                     if not targetAll then
-                        key = key .. target.token.charid
+                        key = key .. (target.originalid or target.token.charid)
                     end
 
                     -- Skip triggers that fail roll requirements
@@ -1212,7 +1253,10 @@ function GameHud.CreateRollDialog(self)
                 if token ~= nil then
                     local tokenTriggers = token.properties:GetAvailableTriggers() or {}
                     local tokenTrigger = tokenTriggers[trigger.id]
-                    if tokenTrigger ~= nil and (tokenTrigger.triggered ~= trigger.triggered or tokenTrigger.resolving ~= trigger.resolving) then
+                    --retargetid is part of the change detection: a trigger-before
+                    --flow (e.g. Devilish Charm) picks the new target after
+                    --activation without flipping triggered.
+                    if tokenTrigger ~= nil and (tokenTrigger.triggered ~= trigger.triggered or tokenTrigger.retargetid ~= trigger.retargetid or tokenTrigger.resolving ~= trigger.resolving) then
                         trigger.triggered = tokenTrigger.triggered
                         trigger.retargetid = tokenTrigger.retargetid
                         --carry resolving into our copy so the periodic re-dispatch
@@ -1246,6 +1290,7 @@ function GameHud.CreateRollDialog(self)
             end
 
             if needUpdate then
+                SyncLiveRetargets()
                 RecalculateMultiTargets()
             end
         end,
@@ -2333,16 +2378,24 @@ function GameHud.CreateRollDialog(self)
 
         rollInput:SetClass("manualEdit", false)
 
+        -- Rows keep their order when a retarget swaps one to a new creature, so
+        -- the current row's position still finds it if the old creature is gone.
+        local previousIndex = GetCurrentMultiTarget()
+
         if m_CalculateMultiTargets ~= nil then
             m_multitargets = m_CalculateMultiTargets()
         end
 
         local index = nil
         for i, target in ipairs(m_multitargets) do
-            if target.token.properties == targetCreature then
+            if MultiTargetIsFor(target, targetCreature) then
                 index = i
                 break
             end
+        end
+
+        if index == nil and previousIndex ~= nil and previousIndex <= #m_multitargets then
+            index = previousIndex
         end
 
         if index == nil then
@@ -3140,7 +3193,14 @@ function GameHud.CreateRollDialog(self)
                         for i, target in ipairs(multitargetsUsed) do
                             for j, trigger in ipairs(target.triggers or {}) do
                                 if trigger.triggered and trigger.modifier.powerRollModifier:try_get("changeTarget") and type(trigger.retargetid) == "string" and m_symbols ~= nil and m_symbols.cast ~= nil then
-                                    m_symbols.cast:RecordRetarget { casterid = trigger.charid, tokenid = target.token.charid, retargetid = trigger.retargetid, retargetType = trigger.modifier.powerRollModifier:try_get("changeTargetEffect", "all") }
+                                    --an "all" retarget is usually already recorded live
+                                    --(SyncLiveRetargets), which also swapped this row to
+                                    --the new target; record from the original target.
+                                    local fromid = target.originalid or target.token.charid
+                                    local retargetType = trigger.modifier.powerRollModifier:try_get("changeTargetEffect", "all")
+                                    if not m_symbols.cast:HasRetarget(fromid, trigger.retargetid, retargetType) then
+                                        m_symbols.cast:RecordRetarget { casterid = trigger.charid, tokenid = fromid, retargetid = trigger.retargetid, retargetType = retargetType }
+                                    end
                                 end
                             end
 

--- a/DrawSteelActionBar/DrawSteelTriggerPanel.lua
+++ b/DrawSteelActionBar/DrawSteelTriggerPanel.lua
@@ -712,6 +712,8 @@ mod.shared.CreateTriggerPanel = function()
                                                     execute = function()
                                                         trigger.triggered = true
                                                         trigger.retargetid = newTargetToken.charid
+                                                        --choosing the new target commits the trigger, so the card leaves the drawer.
+                                                        trigger.dismissed = true
 
                                                         g_token.properties:DispatchAvailableTrigger(trigger)
                                                     end,
@@ -941,6 +943,8 @@ mod.shared.CreateTriggerPanel = function()
 
                                                             trigger.triggered = index
                                                             trigger.retargetid = newTargetToken.charid
+                                                            --choosing the new target commits the trigger, so the card leaves the drawer.
+                                                            trigger.dismissed = true
 
                                                             g_token.properties:DispatchAvailableTrigger(trigger)
                                                         end,
@@ -1166,6 +1170,8 @@ mod.shared.CreateTriggerPanel = function()
                                                     execute = function()
                                                         trigger.triggered = true
                                                         trigger.retargetid = newTargetToken.charid
+                                                        --choosing the new target commits the trigger, so the card leaves the drawer.
+                                                        trigger.dismissed = true
 
                                                         g_token.properties:DispatchAvailableTrigger(trigger)
                                                     end,
@@ -1678,6 +1684,8 @@ mod.shared.CreateTriggerPanel = function()
 
                                                             trigger.triggered = index
                                                             trigger.retargetid = newTargetToken.charid
+                                                            --choosing the new target commits the trigger, so the card leaves the drawer.
+                                                            trigger.dismissed = true
 
                                                             g_token.properties:DispatchAvailableTrigger(trigger)
                                                         end,

--- a/Timeline/EmbeddedRollDialog.lua
+++ b/Timeline/EmbeddedRollDialog.lua
@@ -499,13 +499,25 @@ function GameHud.CreateEmbeddedRollDialog()
     -- them re-subscribe to the new dice and replay the animation.
     local m_rerolling = false
 
+    -- True if this row is for creature c, including a row a trigger retargeted
+    -- away from c while the dialog is open (the row then carries originalid).
+    local function MultiTargetIsFor(target, c)
+        if c == nil then
+            return false
+        end
+        if target.token.properties == c then
+            return true
+        end
+        return target.originalid ~= nil and target.originalid == dmhub.LookupTokenId(c)
+    end
+
     local GetCurrentMultiTarget = function()
         if m_multitargets == nil or targetCreature == nil then
             return nil
         end
 
         for i, target in ipairs(m_multitargets) do
-            if target.token.properties == targetCreature then
+            if MultiTargetIsFor(target, targetCreature) then
                 return i
             end
         end
@@ -514,6 +526,33 @@ function GameHud.CreateEmbeddedRollDialog()
     end
 
     local m_symbols = nil
+
+    -- Records a trigger-chosen retarget as soon as it arrives, so the next
+    -- recalculation rebuilds that row for the new creature (its own flanking,
+    -- cover and conditions). A withdrawn retarget swings the row back.
+    local function SyncLiveRetargets()
+        if m_multitargets == nil or m_symbols == nil or m_symbols.cast == nil then
+            return
+        end
+        for _, target in ipairs(m_multitargets) do
+            local hasRedirect = false
+            local retargetid = nil
+            local casterid = nil
+            for _, trigger in ipairs(target.triggers or {}) do
+                local powerMod = trigger.modifier:try_get("powerRollModifier")
+                if powerMod ~= nil and powerMod:try_get("changeTarget") and powerMod:try_get("changeTargetEffect", "all") == "all" then
+                    hasRedirect = true
+                    if retargetid == nil and trigger.triggered and type(trigger.retargetid) == "string" then
+                        retargetid = trigger.retargetid
+                        casterid = trigger.charid
+                    end
+                end
+            end
+            if hasRedirect then
+                m_symbols.cast:SyncLiveRetarget(target.originalid or target.token.charid, casterid, retargetid)
+            end
+        end
+    end
 
     --any ongoing roll as a result of this dialog.
     local m_rollInfo = nil
@@ -1049,7 +1088,10 @@ function GameHud.CreateEmbeddedRollDialog()
             return
         end
 
-        local charid = target.token.charid
+        -- A row already swapped to its redirect target still reports the
+        -- original target it came from.
+        local charid = target.originalid or target.token.charid
+        local originalToken = dmhub.GetTokenById(charid) or target.token
         local applied = m_appliedArrowRetargets[charid]
         local newid = triggerInfo.retargetid
 
@@ -1067,14 +1109,14 @@ function GameHud.CreateEmbeddedRollDialog()
 
         -- The arrow currently points at the previously applied redirect
         -- target (if any), otherwise at the original target.
-        local currentToken = target.token
+        local currentToken = originalToken
         if applied ~= nil then
-            currentToken = dmhub.GetTokenById(applied) or target.token
+            currentToken = dmhub.GetTokenById(applied) or originalToken
         end
 
         -- nil retargetid means the redirect was withdrawn: swing back to the
         -- original target.
-        local newToken = target.token
+        local newToken = originalToken
         if newid ~= nil then
             newToken = dmhub.GetTokenById(newid)
         end
@@ -1084,6 +1126,22 @@ function GameHud.CreateEmbeddedRollDialog()
 
         local marker = FindMarkerForTarget(casterToken, currentToken)
         if marker == nil then
+            return
+        end
+
+        -- A strike turned back on the attacker (e.g. Clever Trick) gets no arrow,
+        -- like any self-target; sweeping onto the caster draws a zero-length arc.
+        if newToken.charid == casterToken.charid then
+            marker:DestroyLineOfSight()
+            m_appliedArrowRetargets[charid] = newid
+            local rays = m_options.markLineOfSight
+            if rays ~= nil then
+                for k, m in pairs(rays) do
+                    if m == marker then
+                        rays[k] = nil
+                    end
+                end
+            end
             return
         end
 
@@ -1249,7 +1307,7 @@ function GameHud.CreateEmbeddedRollDialog()
 
         -- Find the current target in multitargets.
         for _, target in ipairs(m_multitargets) do
-            if target.token ~= nil and target.token.valid and target.token.properties == targetCreature then
+            if target.token ~= nil and target.token.valid and MultiTargetIsFor(target, targetCreature) then
                 UpdateArrowLabelForTarget(casterToken, target, rollProperties)
                 return
             end
@@ -2088,7 +2146,7 @@ function GameHud.CreateEmbeddedRollDialog()
                     local targetAll = (trigger.modifier:try_get("multitarget", "one") == "all")
                     local key = trigger.modifier.guid .. (trigger.charid or "")
                     if not targetAll then
-                        key = key .. target.token.charid
+                        key = key .. (target.originalid or target.token.charid)
                     end
                     if not seen[key] then
                         seen[key] = true
@@ -2152,9 +2210,11 @@ function GameHud.CreateEmbeddedRollDialog()
                         m_openedTriggers = {}
                     end
 
+                    -- Keyed by the original target so a row swapped to its redirect
+                    -- target keeps talking to the same trigger record.
                     local key = trigger.modifier.guid .. (trigger.charid or "")
                     if not targetAll then
-                        key = key .. target.token.charid
+                        key = key .. (target.originalid or target.token.charid)
                     end
 
                     -- Skip triggers that fail roll requirements
@@ -2363,6 +2423,7 @@ function GameHud.CreateEmbeddedRollDialog()
             end
 
             if needUpdate then
+                SyncLiveRetargets()
                 RecalculateMultiTargets()
             end
         end,
@@ -4382,16 +4443,24 @@ function GameHud.CreateEmbeddedRollDialog()
 
         rollInput:SetClass("manualEdit", false)
 
+        -- Rows keep their order when a retarget swaps one to a new creature, so
+        -- the current row's position still finds it if the old creature is gone.
+        local previousIndex = GetCurrentMultiTarget()
+
         if m_CalculateMultiTargets ~= nil then
             m_multitargets = m_CalculateMultiTargets()
         end
 
         local index = nil
         for i, target in ipairs(m_multitargets) do
-            if target.token.properties == targetCreature then
+            if MultiTargetIsFor(target, targetCreature) then
                 index = i
                 break
             end
+        end
+
+        if index == nil and previousIndex ~= nil and previousIndex <= #m_multitargets then
+            index = previousIndex
         end
 
         if index == nil then
@@ -6036,7 +6105,14 @@ function GameHud.CreateEmbeddedRollDialog()
                         for i, target in ipairs(multitargetsUsed) do
                             for j, trigger in ipairs(target.triggers or {}) do
                                 if trigger.triggered and trigger.modifier.powerRollModifier:try_get("changeTarget") and type(trigger.retargetid) == "string" and m_symbols ~= nil and m_symbols.cast ~= nil then
-                                    m_symbols.cast:RecordRetarget { casterid = trigger.charid, tokenid = target.token.charid, retargetid = trigger.retargetid, retargetType = trigger.modifier.powerRollModifier:try_get("changeTargetEffect", "all") }
+                                    --an "all" retarget is usually already recorded live
+                                    --(SyncLiveRetargets), which also swapped this row to
+                                    --the new target; record from the original target.
+                                    local fromid = target.originalid or target.token.charid
+                                    local retargetType = trigger.modifier.powerRollModifier:try_get("changeTargetEffect", "all")
+                                    if not m_symbols.cast:HasRetarget(fromid, trigger.retargetid, retargetType) then
+                                        m_symbols.cast:RecordRetarget { casterid = trigger.charid, tokenid = fromid, retargetid = trigger.retargetid, retargetType = retargetType }
+                                    end
                                 end
                             end
 


### PR DESCRIPTION
## Summary

When a triggered action redirects a strike while the attacker's roll dialog is open, the roll kept being worked out against the **original** target. Only the damage moved to the new target at the end. So every edge or bane that depends on the target came from the wrong creature: flanking, cover, conditions, and the target's own "strikes against me" modifiers.

This hits most of the core redirect triggers (any `changeTarget` trigger with the default `changeTargetEffect: all`):

| Ability | Source | What went wrong before |
|---|---|---|
| **Duck!** | Brawler title | The trigger needs you to be flanked, so the attacker usually has a flanking edge on you. The strike moves to the other flanker, whom the attacker isn't flanking, but the edge stayed. |
| **Clever Trick** / **So Gullible** | Shadow, College of the Harlequin Mask | The strike moves from the Shadow to another enemy, but the Shadow's cover still applied and the new target's flanking and cover were ignored. |
| **Goaded** | Tactician, Mastermind | Strike moves to you or another ally; the new target's defences were ignored. |
| **Intercede** | Paragon | You become the target; your own modifiers were ignored. |
| **Arrest**, **Word of Fate Denied** | Censor / Conduit | Same. |
| **Shield!**, **Leader Formation** | Summoner | Same. |
| **Stasis Shield** (the redirect version) | Talent, Chronopathy | Same. |
| **Sacred Bond**, **Trinity of Trickery**, **Mirror Token**, **"'Scuse Me, Boss"** | Effects, treasure, retainer | Same. |
| **Devilish Charm** (all five devils), **Clever Trick** (Bugbear Sneak), **Intercepting Shield**, **Goad**, **"No."**, **Show Them Your Might!** | Monsters | Same, for heroes' strikes redirected by monsters. |

Redirects that only move the damage (`changeTargetEffect: none`, e.g. Meat Shield) or only redirect forced movement (`forcemove`) take a different code path and are unchanged.

## Changes

- **Retarget recorded as soon as it's chosen.** `ActivatedAbilityCast:SyncLiveRetarget` records an "all" retarget on the cast the moment the trigger picks the new target, and removes it again if the trigger is withdrawn. `CalculateMultitargets` re-applies redirects from the originally chosen targets on each recalculation and rebuilds that row for the new creature. The row keeps the redirecting trigger, so anything the trigger adds (an edge, a bane, half damage) stays applied.
- **Both roll dialogs** (`EmbeddedRollDialog`, `DSRollDialog`) find the current row and key trigger bookkeeping by the original target, so the trigger isn't lost or duplicated after the row swaps. At commit they record the retarget from the original target and skip it if it's already recorded. `DSRollDialog` now also notices a `retargetid`-only change, as the sidebar dialog already did (needed for trigger-before flows such as Devilish Charm tier 1).
- **Used retarget triggers leave the drawer.** Picking the new target now dismisses the trigger card, like other used triggers. Before, the card stayed in the drawer, and clicking it again silently undid the redirect.
- **Redirecting a strike back onto the attacker** (Clever Trick allows "the enemy who targeted you") now removes that targeting arrow. Before, the arrow swept onto the attacker itself and flew off as a zero-length arc. Normal targeting never draws an arrow from a creature to itself.

## Testing

Tested live in the Codex:
- **Clever Trick:** after the redirect, the new target's edges and banes are recalculated.
- **Duck!:** the same recalculation.
- **Clever Trick onto the attacker itself:** the arrow is removed cleanly.
- **Retarget trigger cards:** they leave the drawer once the new target is chosen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
